### PR TITLE
CI: add least-privilege permissions and concurrency cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,4 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,3 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: ci
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Closes #13

Adds a top-level `permissions: contents: read` block so jobs run with least-privilege token scope, and a `concurrency` block so pushing a new commit to a PR cancels the previous in-progress run instead of letting both matrices finish.

`cancel-in-progress` is scoped to `pull_request` events only, so pushes to `main` are never cancelled mid-run — each merge to main gets a complete, uncancelled CI validation.