### PR TITLE
feat: add Episode.attachments accessor for preserved attachments

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -186,6 +186,7 @@ def labels(ep: hflow.Episode) -> hflow.CheckResult:
 ```
 
 `ep.metadata` is a flat `dict[str, str]`: the episode semantics record (task, operator, success, embodiment, robot_software_version, plus whatever your rig recorded) merged with the version stamps (schema_version, pipeline_version, ffmpeg_version). Values are strings: `success` is `"true"`/`"false"`. `ep.metadata_records` exposes every MCAP Metadata record in the file, keyed by record name, when you need more than the merged view.
+* Use `ep.attachments` to access episode-scoped files (like URDFs and calibration data) preserved by the format.
 
 ## Dialect 5: the escape hatch
 

--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from mcap.records import Schema
+from mcap.records import Attachment, Schema
 
 from hflow import video as video_module
 from hflow.ffmpeg import ffmpeg_path
@@ -309,6 +309,11 @@ class Episode:
     def metadata_records(self) -> dict[str, dict[str, str]]:
         """All MCAP Metadata records, keyed by record name."""
         return self._reader.metadata()
+
+    @cached_property
+    def attachments(self) -> list[Attachment]:
+        """All MCAP Attachment records (e.g., calibration files, URDFs). Does not decode message data."""
+        return list(self._reader.attachments())
 
     @cached_property
     def metadata(self) -> dict[str, str]:

--- a/tests/test_episode_attachments.py
+++ b/tests/test_episode_attachments.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from hflow.episode import Episode
+from hflow.mcap_writer import CanonicalMcapWriter
+
+
+def test_episode_attachments_round_trip(tmp_path: Path) -> None:
+    mcap_path = tmp_path / "test_attachments.mcap"
+    attachment_name = "calibration.txt"
+    attachment_data = b"calibration data"
+    media_type = "text/plain"
+
+    # 1. Write it to a temporary MCAP file using CanonicalMcapWriter
+    with CanonicalMcapWriter(mcap_path) as writer:
+        writer.add_attachment(
+            attachment_name,
+            media_type,
+            attachment_data,
+        )
+
+    # 2. Read the MCAP file back into an Episode object
+    ep = Episode(mcap_path)
+
+    # 3. Assert that the attachment's name and content survived the round-trip
+    assert len(ep.attachments) == 1
+    attachment = ep.attachments[0]
+
+    assert attachment.name == attachment_name
+    assert attachment.data == attachment_data
+    assert attachment.media_type == media_type


### PR DESCRIPTION
## Summary
Adds an `Episode.attachments` accessor that allows users to read MCAP attachment records (like URDFs, calibration data, and text files) without having to bypass the `Episode` abstraction or decode message data.

## Why
This solves Issue #5. Currently, `hflow` abstracts away raw MCAP files, but it doesn't expose file attachments. By mirroring the existing `metadata_records` pattern exactly, this PR allows users to easily extract episode-scoped files preserved by the format.

## Usage Example
```python
from hflow import Episode

ep = Episode("path/to/episode.mcap")

for attachment in ep.attachments:
    print(attachment.name)       # "calibration.txt"
    print(attachment.media_type) # "text/plain"
    print(len(attachment.data))  # bytes of file content
```

## Validation
* Modified `docs/PORTING.md` to explain the new accessor.
* Added a new round-trip test (`test_episode_attachments_round_trip`) in `tests/test_episode_attachments.py` that verifies an attachment can be written via `CanonicalMcapWriter` and successfully retrieved via `Episode.attachments`.
* Verified with:
  * `uv run ruff check --fix`
  * `uv run ruff format`
  * `uv run ty check`
  * `$env:PYTHONPATH="."; uv run pytest -q tests/test_episode_attachments.py` (Passes 100%)

*Note: The full CI suite (`uv run pytest -q`) shows pre-existing failures on Windows due to platform-specific issues (e.g., `os.getuid()`), but no new failures were introduced by this change.*

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
