### PR TITLE
cli: add --version flag

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from hflow import __version__
 from hflow.curation import curate, stale_episodes
 from hflow.doctor import diagnose
 from hflow.runtime._deploy import DEFAULT_DEPLOY_VENV_PYTHON
@@ -24,6 +25,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hflow",
         description="Open-source robotics data pipeline.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"hflow {__version__}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -402,3 +402,12 @@ def test_app_run_errors_helpfully_without_a_script_file(
     monkeypatch.setitem(sys.modules, "__main__", types.ModuleType("__main__"))
     with pytest.raises(RuntimeError, match="notebook"):
         app.run()
+
+
+def test_version_flag_prints_version_and_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--version"])
+    assert excinfo.value.code == 0
+    output, _ = capsys.readouterr()
+    assert output.strip() == f"hflow {hflow.__version__}"
+    assert hflow.__version__ in output


### PR DESCRIPTION
Fixes #2

Adds a standard `--version` flag to the CLI, sourced from `hflow.__version__`.

```
$ uv run hflow --version
hflow 0.0.0
```

- `argparse`'s `version` action prints `hflow <version>` and exits 0
- Test added in `tests/test_runtime_cli.py` asserting the exit code and output

Validation: `uv run pytest tests/test_runtime_cli.py::test_version_flag_prints_version_and_exits_zero -q` passes.