### PR TITLE
cli: one-line messages for expected errors (curate/doctor/stale)

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -470,22 +470,38 @@ def _command_status(arguments: argparse.Namespace) -> int:
     return 0
 
 
+def _command_curate(arguments: argparse.Namespace) -> int:
+    if (arguments.sql is None) == (arguments.sql_file is None):
+        print("curate: pass exactly one of a SQL string or --sql-file", file=sys.stderr)
+        return 2
+    try:
+        sql = arguments.sql if arguments.sql is not None else arguments.sql_file.read_text()
+        report = curate(arguments.catalog, sql, output=arguments.output)
+    except (ValueError, FileNotFoundError) as error:
+        print(f"curate: {error}", file=sys.stderr)
+        return 2
+    print(report.summary())
+    return 0
+
+
+def _command_doctor(arguments: argparse.Namespace) -> int:
+    try:
+        doctor_report = diagnose(arguments.file)
+    except (ValueError, FileNotFoundError) as error:
+        print(f"doctor: {error}", file=sys.stderr)
+        return 2
+    print(doctor_report.summary())
+    return 0 if doctor_report.conforming else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     arguments = _build_parser().parse_args(argv)
     if arguments.command == "curate":
-        if (arguments.sql is None) == (arguments.sql_file is None):
-            print("curate: pass exactly one of a SQL string or --sql-file", file=sys.stderr)
-            return 2
-        sql = arguments.sql if arguments.sql is not None else arguments.sql_file.read_text()
-        report = curate(arguments.catalog, sql, output=arguments.output)
-        print(report.summary())
-        return 0
+        return _command_curate(arguments)
     if arguments.command == "stale":
         return _command_stale(arguments)
     if arguments.command == "doctor":
-        doctor_report = diagnose(arguments.file)
-        print(doctor_report.summary())
-        return 0 if doctor_report.conforming else 1
+        return _command_doctor(arguments)
     if arguments.command == "up":
         return _command_up(arguments)
     if arguments.command == "deploy":

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -299,11 +299,15 @@ def _command_stale(arguments: argparse.Namespace) -> int:
     else:
         pipeline_version = arguments.pipeline_version
 
-    stale = stale_episodes(
-        arguments.catalog,
-        pipeline_version=pipeline_version,
-        schema_version=schema_version,
-    )
+    try:
+        stale = stale_episodes(
+            arguments.catalog,
+            pipeline_version=pipeline_version,
+            schema_version=schema_version,
+        )
+    except (ValueError, FileNotFoundError) as error:
+        print(f"stale: {error}", file=sys.stderr)
+        return 2
     for episode in stale:
         print(episode.source_uri if episode.source_uri is not None else episode.uri)
     print(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -100,7 +100,14 @@ def test_cli_curate_bad_catalog_prints_one_line(
     bad_catalog.mkdir()
     assert (
         cli_main(
-            ["curate", "SELECT 1", "--catalog", str(bad_catalog), "--output", str(tmp_path / "m.parquet")]
+            [
+                "curate",
+                "SELECT 1",
+                "--catalog",
+                str(bad_catalog),
+                "--output",
+                str(tmp_path / "m.parquet"),
+            ]
         )
         == 2
     )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -89,7 +89,6 @@ def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[s
     missing = "C:/definitely/not/here.mcap"
     assert cli_main(["doctor", missing]) == 2
     captured = capsys.readouterr()
-    # One-line message on stderr, no traceback.
     assert "doctor:" in captured.err
     assert "Traceback" not in captured.err
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -83,3 +83,28 @@ def test_cli_doctor_exit_codes(
     bogus.write_bytes(b"nope")
     assert cli_main(["doctor", str(bogus)]) == 1
     assert "NOT CONFORMING" in capsys.readouterr().out
+
+
+def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[str]) -> None:
+    missing = "C:/definitely/not/here.mcap"
+    assert cli_main(["doctor", missing]) == 2
+    captured = capsys.readouterr()
+    # One-line message on stderr, no traceback.
+    assert "doctor:" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_curate_bad_catalog_prints_one_line(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad_catalog = tmp_path / "not-a-catalog"
+    bad_catalog.mkdir()
+    assert (
+        cli_main(
+            ["curate", "SELECT 1", "--catalog", str(bad_catalog), "--output", str(tmp_path / "m.parquet")]
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert "curate:" in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
Fixes #3

Expected, user-recoverable errors in `curate`, `doctor`, and `stale` now print a one-line `<command>: <message>` on stderr and return exit code 2, instead of leaking a full Python traceback.

- Extracts `_command_curate` and `_command_doctor` so `main()` is pure dispatch (per the issue's companion cleanup)
- Applies the same `except (ValueError, FileNotFoundError)` pattern `_command_deploy` already used
- `_command_stale` now wraps the `stale_episodes` call the same way

Tests:
- `test_cli_doctor_missing_file_prints_one_line`: exit 2, `doctor:` on stderr, no traceback
- `test_cli_curate_bad_catalog_prints_one_line`: exit 2, `curate:` on stderr, no traceback

Validation: `uv run pytest tests/test_doctor.py tests/test_catalog_curation.py tests/test_runtime_cli.py -q` (37 passed).