### PR TITLE
episode: expose ChannelData.publish_times

### DIFF
--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -113,6 +113,15 @@ class ChannelData:
         return self._log_times
 
     @property
+    def publish_times(self) -> np.ndarray:
+        """Publish times in nanoseconds, shape (n,). Does not decode.
+
+        Unlike :attr:`timestamps`, publish times are not guaranteed ascending
+        (they reflect when the application handed each message to the channel).
+        """
+        return self._publish_times
+
+    @property
     def raw(self) -> list[bytes]:
         """Raw encoded message payloads. Does not decode."""
         return self._raw

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -129,8 +129,8 @@ def test_episode_exposes_publish_times(dual_channel_source: Path) -> None:
         publish_times = json_channel.publish_times
         assert isinstance(publish_times, np.ndarray)
         assert publish_times.shape == (len(json_channel),)
-        # publish_times are not guaranteed ascending, unlike log timestamps
-        assert not np.all(np.diff(publish_times) >= 0) or len(publish_times) <= 1
+        # Values match the message count and are non-negative nanos.
+        assert np.all(publish_times >= 0)
 
 
 def test_episode_unknown_keys_raise_helpfully(dual_channel_source: Path) -> None:

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -129,7 +129,6 @@ def test_episode_exposes_publish_times(dual_channel_source: Path) -> None:
         publish_times = json_channel.publish_times
         assert isinstance(publish_times, np.ndarray)
         assert publish_times.shape == (len(json_channel),)
-        # Values match the message count and are non-negative nanos.
         assert np.all(publish_times >= 0)
 
 

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -9,6 +9,7 @@ represent both channels; only the topic-keyed convenience views refuse.
 import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 from mcap.reader import make_reader
 from mcap.writer import Writer as StockWriter
@@ -119,6 +120,17 @@ def test_episode_addresses_channels_by_id(dual_channel_source: Path) -> None:
         assert [message.data for message in cdr_channel.messages] == [
             bool(payload[-1]) for payload in CDR_PAYLOADS
         ]
+
+
+def test_episode_exposes_publish_times(dual_channel_source: Path) -> None:
+    with Episode(dual_channel_source) as episode:
+        by_encoding = {info.message_encoding: info for info in episode.channels.values()}
+        json_channel = episode.channel(by_encoding["json"].channel_id)
+        publish_times = json_channel.publish_times
+        assert isinstance(publish_times, np.ndarray)
+        assert publish_times.shape == (len(json_channel),)
+        # publish_times are not guaranteed ascending, unlike log timestamps
+        assert not np.all(np.diff(publish_times) >= 0) or len(publish_times) <= 1
 
 
 def test_episode_unknown_keys_raise_helpfully(dual_channel_source: Path) -> None:


### PR DESCRIPTION
Fixes #4

`ChannelData` already accepted and stored per-message publish times, and `Episode.channel()` concatenated them from the reader, but no property exposed them. Added a `publish_times` property mirroring `timestamps`, documented as non-ascending.

Test: `test_episode_exposes_publish_times` checks the ndarray shape matches `len(channel)` and values are non-negative.

Validation: `uv run pytest tests/test_multichannel.py -q` passes.