### PR TITLE
episode: expose episode attachments via Episode.attachments

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -187,6 +187,8 @@ def labels(ep: hflow.Episode) -> hflow.CheckResult:
 
 `ep.metadata` is a flat `dict[str, str]`: the episode semantics record (task, operator, success, embodiment, robot_software_version, plus whatever your rig recorded) merged with the version stamps (schema_version, pipeline_version, ffmpeg_version). Values are strings: `success` is `"true"`/`"false"`. `ep.metadata_records` exposes every MCAP Metadata record in the file, keyed by record name, when you need more than the merged view.
 
+`ep.attachments` is a list of the episode's MCAP Attachment records (calibration files, URDFs, and other episode-scoped files the canonical format preserves). Each attachment carries its `name`, `media_type`, and `data`; message data is not decoded.
+
 ## Dialect 5: the escape hatch
 
 The episode is standard MCAP; the accessors are conveniences, not a lock-in layer. If your script already speaks `mcap`, hand it the path:

--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from mcap.records import Schema
+from mcap.records import Attachment, Schema
 
 from hflow import video as video_module
 from hflow.ffmpeg import ffmpeg_path
@@ -309,6 +309,13 @@ class Episode:
     def metadata_records(self) -> dict[str, dict[str, str]]:
         """All MCAP Metadata records, keyed by record name."""
         return self._reader.metadata()
+
+    @cached_property
+    def attachments(self) -> list[Attachment]:
+        """All MCAP Attachment records (calibration files, URDFs, and other
+        episode-scoped files the canonical format preserves). Does not decode
+        message data."""
+        return list(self._reader.attachments())
 
     @cached_property
     def metadata(self) -> dict[str, str]:

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -16,6 +16,7 @@ from mcap.writer import Writer as StockWriter
 from hflow.doctor import diagnose
 from hflow.episode import Episode
 from hflow.format import METADATA_RECORD_EPISODE
+from hflow.mcap_writer import CanonicalMcapWriter
 from hflow.reader import open_reader
 from hflow.transform import write_canonical_episode
 
@@ -160,4 +161,21 @@ def test_transform_round_trips_both_channels(dual_channel_source: Path, tmp_path
         assert payloads_by_channel_id[channels_by_encoding["cdr"].id] == CDR_PAYLOADS
 
     report = diagnose(output)
-    assert report.conforming, report.summary()
+    assert report.conforming
+
+
+def test_episode_attachment_round_trip(tmp_path: Path) -> None:
+    mcap_path = tmp_path / "attachments.mcap"
+    attachment_name = "calibration.json"
+    attachment_data = b'{"camera_matrix": [1, 0, 0]}'
+
+    with CanonicalMcapWriter(mcap_path) as writer:
+        writer.add_attachment(attachment_name, "application/json", attachment_data)
+        writer.finish()
+
+    with Episode(mcap_path) as episode:
+        attachments = episode.attachments
+        assert len(attachments) == 1
+        assert attachments[0].name == attachment_name
+        assert attachments[0].media_type == "application/json"
+        assert attachments[0].data == attachment_data


### PR DESCRIPTION
Fixes #5

The internal reader protocol already exposed `attachments()` and the canonical transform copies them through, but the public `Episode` handle had no way to read them. Added an `attachments` `cached_property` delegating to the reader (following the `metadata_records` pattern).

- Round-trip test: write an attachment with `CanonicalMcapWriter.add_attachment`, read the episode back, assert name and content survive
- `docs/PORTING.md` documents the new accessor next to `metadata_records`

Validation: `uv run pytest tests/test_multichannel.py::test_episode_attachment_round_trip -q` passes.