### PR TITLE
checks: add required_topics built-in check

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -332,6 +332,40 @@ def episode_duration(episode: Episode, *, topics: Sequence[str] | None = None) -
     )
 
 
+def required_topics(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
+    """Presence and message volume of every topic the rig was supposed to record.
+
+    The cheapest corpus-level QC question is whether a recording captured all
+    of its expected streams -- a missing wrist camera or an absent
+    ``/joint_states`` should be one catalog query away. Per the evidence-not-
+    verdicts rule this records, for each requested topic:
+
+    - ``{topic}/present`` -- bool, whether any channel carries the topic
+    - ``{topic}/message_count`` -- int, total messages across its channels
+
+    plus a summary ``missing_topic_count``. Presence derives from
+    :attr:`Episode.channels`, so a topic mapped to multiple channels counts
+    once. Pass/fail policy is a curation query on the recorded measurements,
+    e.g.::
+
+        SELECT episode_id, value_text FROM measurements
+        WHERE key = 'missing_topic_count' AND value_text != '0'
+    """
+    required = list(topics)
+    present: dict[str, int] = {}
+    for info in episode.channels.values():
+        if info.topic in required:
+            present[info.topic] = present.get(info.topic, 0) + info.message_count
+    measurements: dict[str, MeasurementValue] = {
+        "missing_topic_count": len(required) - len(present),
+    }
+    for topic in required:
+        message_count = present.get(topic, 0)
+        measurements[f"{topic}/present"] = message_count > 0
+        measurements[f"{topic}/message_count"] = message_count
+    return CheckResult(measurements=measurements)
+
+
 def content_digest(episode: Episode) -> CheckResult:
     """A stable digest of the episode's message content, for duplicate hunts.
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -11,6 +11,7 @@ from hflow.checks import (
     episode_duration,
     idle_fraction,
     joint_discontinuity,
+    required_topics,
     timestamp_regularity,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
@@ -160,3 +161,21 @@ def test_camera_frame_stats_sees_the_injected_black_segment(tmp_path: Path) -> N
     # No dropped frames were injected: the stored count matches the rate.
     assert result.measurements[f"{camera_topic}/frame_deficit_pct"] == pytest.approx(0.0)
     assert result.measurements[f"{camera_topic}/expected_frame_count"] == message_count
+
+
+def test_required_topics_marks_present_missing_and_unknown(jittery_episode: hflow.Episode) -> None:
+    present_topic = "/joint_states"
+    missing_topic = "/never_recorded"
+    result = required_topics(jittery_episode, topics=[present_topic, missing_topic])
+
+    assert result.measurements[f"{present_topic}/present"] is True
+    assert result.measurements[f"{present_topic}/message_count"] > 0
+    assert result.measurements[f"{missing_topic}/present"] is False
+    assert result.measurements[f"{missing_topic}/message_count"] == 0
+    assert result.measurements["missing_topic_count"] == 1
+
+
+def test_required_topics_all_present(jittery_episode: hflow.Episode) -> None:
+    result = required_topics(jittery_episode, topics=["/joint_states"])
+    assert result.measurements["missing_topic_count"] == 0
+    assert result.measurements["/joint_states/present"] is True


### PR DESCRIPTION
Fixes #6

Adds `required_topics(episode, *, topics)`, the cheapest corpus-level QC question: did the rig record every topic it was supposed to?

For each requested topic it records:
- `{topic}/present` (bool) and `{topic}/message_count` (int), derived from `Episode.channels` so a topic mapped to multiple channels counts once
- a summary `missing_topic_count`

Evidence only, following the `episode_duration` pattern. Pass/fail policy stays in the user's curation SQL.

Tests: all present, one missing, and a topic name not in the file.

Validation: `uv run pytest tests/test_checks.py -q` (12 passed).