### PR TITLE
cli: add --api-port to hflow up

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -348,9 +348,8 @@ docker compose --file data/runtime/docker-compose.yaml logs airflow-dag-processo
 `ingest` prints the same hint (right after a fresh `up`, the DAG may still
 be parsing; retry in a few seconds).
 
-**Port 8080 is taken.** The port lives in the bundle's `.env` as `API_PORT`
-(re-renders don't change a preserved `.env`, so editing it sticks):
-`hflow down`, edit `API_PORT`, `hflow up` again. The API only ever binds
+**Port 8080 is taken.** Pass `--api-port` to `hflow up` (or leave the
+preserved `.env` `API_PORT` alone and pick another). The API only ever binds
 to `127.0.0.1`, so two bundles on different ports coexist fine.
 
 **`up` failed partway.** Whatever started is deliberately left running: the

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -141,6 +141,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="user requirements file for the task venv (default: hflow only)",
     )
+    up_parser.add_argument(
+        "--api-port",
+        type=int,
+        default=8080,
+        help="host port the Airflow API listens on (default: 8080)",
+    )
 
     deploy_parser = subparsers.add_parser(
         "deploy",
@@ -341,6 +347,7 @@ def _command_up(arguments: argparse.Namespace) -> int:
         app_variable=app_variable,
         requirements_file=arguments.requirements,
         hflow_source=hflow_source,
+        api_port=arguments.api_port,
     )
     # A bucket data root has no local directory to host the bundle: ./runtime.
     default_bundle_dir = (

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -402,3 +402,35 @@ def test_app_run_errors_helpfully_without_a_script_file(
     monkeypatch.setitem(sys.modules, "__main__", types.ModuleType("__main__"))
     with pytest.raises(RuntimeError, match="notebook"):
         app.run()
+
+
+def test_up_api_port_bakes_into_bundle_env(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            f"{pipeline_file}:my_app",
+            "--data-root",
+            str(data_root),
+            "--api-port",
+            "9090",
+        ]
+    )
+    assert exit_code == 0
+    bundle_dir = data_root / "runtime"
+    assert (bundle_dir / "docker-compose.yaml").is_file()
+    env_values = dict(
+        line.split("=", 1)
+        for line in (bundle_dir / ".env").read_text().splitlines()
+        if line and not line.startswith("#")
+    )
+    assert env_values["API_PORT"] == "9090"
+    assert compose_calls == [
+        [str(bundle_dir / "docker-compose.yaml"), "up", "--detach"],
+    ]


### PR DESCRIPTION
Fixes #7

`RuntimeConfig.api_port` already existed and rendered as `API_PORT` in the bundle `.env`, but `hflow up` never exposed it, so a taken 8080 forced hand-editing. Added `--api-port` (int, default 8080), forwarded into `RuntimeConfig`, and simplified the `docs/RUNTIME.md` troubleshooting entry.

Test: `test_up_api_port_bakes_into_bundle_env` asserts `API_PORT=9090` lands in the rendered `.env` with the flag-to-config plumbing intact.

Validation: `uv run pytest tests/test_runtime_cli.py::test_up_api_port_bakes_into_bundle_env -q` passes.