### PR TITLE
storage: format missing-file errors with errno context

### DIFF
--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -32,6 +32,7 @@ rather than a consistency problem:
   episode uploaded by another.
 """
 
+import errno
 import fcntl
 import hashlib
 import os
@@ -630,5 +631,5 @@ def fetch_uri(uri: "str | Path") -> Path:
         return BucketStorageRoot(parent_url).fetch(name)
     local_file = Path(uri)
     if not local_file.is_file():
-        raise FileNotFoundError(local_file)
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
     return local_file

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -90,6 +90,7 @@ def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[s
     assert cli_main(["doctor", missing]) == 2
     captured = capsys.readouterr()
     assert "doctor:" in captured.err
+    assert "No such file or directory" in captured.err
     assert "Traceback" not in captured.err
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -184,6 +184,14 @@ class TestBucketStorageRoot:
         with pytest.raises(FileNotFoundError):
             root.fetch("landing/missing.mcap")
 
+    def test_fetch_local_missing_has_oserror_filename(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope.mcap"
+        with pytest.raises(FileNotFoundError) as excinfo:
+            fetch_uri(missing)
+        assert excinfo.value.errno == 2
+        assert "No such file or directory" in str(excinfo.value)
+        assert str(missing) in str(excinfo.value)
+
     def test_publish_uploads_and_warms_mirror(self, tmp_path: Path) -> None:
         root, remote_dir = bucket_over_tmp(tmp_path)
         produced_file = tmp_path / "out.mcap"


### PR DESCRIPTION
Fixes #26

`fetch_uri` raised `FileNotFoundError(local_file)` with the path as the single argument, so `str()` of the exception was just the bare path, and the CLI printed `doctor: /tmp/nope.mcap` with no 'no such file' hint after #18 turned tracebacks into one-line messages.

Per maintainer's adjustment, the path is passed only as the third (filename) argument:

```python
raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
```

so it formats as `[Errno 2] No such file or directory: '/tmp/nope.mcap'` without the path printed twice.

Tests:
- `test_fetch_local_missing_has_oserror_filename` (storage): errno == 2, message contains 'No such file or directory', path present
- `test_cli_doctor_missing_file_prints_one_line`: asserts the enhanced message on stderr

Validation: `uv run pytest tests/test_storage.py tests/test_doctor.py -q` (44 passed, 1 skipped), `uv run ruff check` + `uv run ty check` clean.