### PR TITLE
refactor(cli): centralize catalog default

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -16,6 +16,7 @@ from hflow.runtime._deploy import DEFAULT_DEPLOY_VENV_PYTHON
 from hflow.steps import RUN_PROFILES
 
 DEFAULT_DATA_ROOT = Path("./data")
+DEFAULT_CATALOG_DIR = "./data/catalog"
 DEFAULT_BUNDLE_DIR = DEFAULT_DATA_ROOT / "runtime"
 DEFAULT_DEPLOY_OUTPUT_DIR = Path("./deploy")
 
@@ -47,8 +48,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     curate_parser.add_argument(
         "--catalog",
-        default="./data/catalog",
-        help="catalog directory or object-store prefix (default: ./data/catalog)",
+        default=DEFAULT_CATALOG_DIR,
+        help=f"catalog directory or object-store prefix (default: {DEFAULT_CATALOG_DIR})",
     )
     curate_parser.add_argument(
         "--output",
@@ -69,8 +70,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     stale_parser.add_argument(
         "--catalog",
-        default="./data/catalog",
-        help="catalog directory or object-store prefix (default: ./data/catalog)",
+        default=DEFAULT_CATALOG_DIR,
+        help=f"catalog directory or object-store prefix (default: {DEFAULT_CATALOG_DIR})",
     )
     stale_group = stale_parser.add_mutually_exclusive_group(required=True)
     stale_group.add_argument(


### PR DESCRIPTION
## Summary

Centralize the catalog CLI default in `DEFAULT_CATALOG_DIR` and reuse it for both the `curate` and `stale` defaults and help text.

## Why

The catalog path was repeated four times, so future changes could leave command defaults and help text out of sync. The constant remains the string `./data/catalog` rather than a `Path` expression so this refactor preserves both argparse's default value type and the exact user-visible help text.

Closes #31

## Validation

- `uv run pytest tests/test_catalog_curation.py -q` — 16 passed
- CLI parser check for both defaults and help strings — passed
- `uv run ruff check --fix` — passed
- `uv run ruff format` — 84 files unchanged
- `uv run ty check` — passed
- `uv run pytest -q` — 285 passed, 6 skipped, 5 unrelated local-platform failures: one test assumes `/usr/bin/ffmpeg`, and four require an ffmpeg build with the `drawtext` filter (the installed Homebrew ffmpeg lacks it)

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic. (No business logic changed; existing CLI coverage passes.)
- [x] I updated documentation for changed behavior, flags, formats, or requirements. (No user-visible behavior or documentation contract changed.)
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
