### PR TITLE
test: cover joint sine parameter contract

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -19,8 +19,11 @@ from mcap_ros2.decoder import DecoderFactory
 
 from hflow.ffmpeg import ffmpeg_path
 from hflow.testing import (
+    JOINT_SINE_MAX_FREQUENCY_HZ,
+    JOINT_SINE_MIN_FREQUENCY_HZ,
     SyntheticEpisodeSpec,
     VideoEpisodeSpec,
+    joint_sine_parameters,
     synthesize_episode,
     write_video_episode,
 )
@@ -60,6 +63,36 @@ def expected_joint_position(joint_index: int, phase_rad: float, time_s: float) -
     if time_s >= DEFAULT_SPEC.joint_jump_at_s:
         position_rad += DEFAULT_SPEC.joint_jump_rad
     return position_rad
+
+
+def test_joint_sine_parameters_are_deterministic_and_span_frequencies() -> None:
+    joint_count = 5
+    first_parameters = joint_sine_parameters(SyntheticEpisodeSpec(seed=42, joint_count=joint_count))
+    second_parameters = joint_sine_parameters(
+        SyntheticEpisodeSpec(seed=42, joint_count=joint_count, duration_s=1.0, cameras=())
+    )
+
+    assert first_parameters == second_parameters
+
+    frequencies_hz = [frequency_hz for frequency_hz, _phase_rad in first_parameters]
+    expected_frequency_step_hz = (JOINT_SINE_MAX_FREQUENCY_HZ - JOINT_SINE_MIN_FREQUENCY_HZ) / (
+        joint_count - 1
+    )
+    assert frequencies_hz[0] == JOINT_SINE_MIN_FREQUENCY_HZ
+    assert frequencies_hz[-1] == JOINT_SINE_MAX_FREQUENCY_HZ
+    assert [
+        frequencies_hz[index + 1] - frequencies_hz[index] for index in range(joint_count - 1)
+    ] == pytest.approx([expected_frequency_step_hz] * (joint_count - 1))
+    assert all(0.0 <= phase_rad < 2.0 * math.pi for _frequency_hz, phase_rad in first_parameters)
+
+
+def test_joint_sine_parameters_single_joint_uses_minimum_frequency() -> None:
+    parameters = joint_sine_parameters(SyntheticEpisodeSpec(seed=42, joint_count=1))
+
+    assert len(parameters) == 1
+    frequency_hz, phase_rad = parameters[0]
+    assert frequency_hz == JOINT_SINE_MIN_FREQUENCY_HZ
+    assert 0.0 <= phase_rad < 2.0 * math.pi
 
 
 def test_joint_states_round_trip(decoded_messages_by_topic: DecodedMessagesByTopic) -> None:


### PR DESCRIPTION
## Summary

Add focused behavioral tests for `hflow.testing.joint_sine_parameters` that verify:

- specs sharing the same seed and joint count produce identical parameters;
- frequencies include the configured minimum and maximum and are evenly spaced;
- a single joint uses the minimum frequency;
- every phase lies in `[0, 2*pi)`.

## Why

Synthetic episode reproducibility depends on this public helper, but its determinism and boundary behavior previously had no direct coverage. This change pins the observable contract without changing the implementation.

Closes #34

## Validation

- `uv run pytest tests/test_testing.py -q -k joint_sine_parameters` — 2 passed, 6 deselected on Python 3.11
- `uv run --python 3.14 --locked --all-extras pytest tests/test_testing.py -q -k joint_sine_parameters` — 2 passed, 6 deselected
- `uv run pytest tests/test_testing.py -q` — 8 passed
- `uv run ruff check --fix` — passed
- `uv run ruff format` — passed
- `uv run ty check` — passed
- `uv run pytest -q` — 287 passed, 6 skipped, 5 environment-specific failures:
  - one existing test assumes `/usr/bin/ffmpeg`, which is absent on macOS;
  - four existing contact-sheet/media tests require the `drawtext` filter, which is absent from the installed Homebrew FFmpeg 9.0.1.
- Full suite with those five environment-specific cases deselected — 287 passed, 6 skipped, 5 deselected

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] Documentation is unchanged because this PR adds test coverage without changing behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged.
