### PR TITLE
episode: annotate to_arrow() as pyarrow.Table

### DIFF
--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from mcap.records import Attachment, Schema
@@ -35,6 +35,9 @@ from hflow.format import (
     METADATA_RECORD_PROVENANCE,
 )
 from hflow.reader import EpisodeReader, TopicInfo, open_reader
+
+if TYPE_CHECKING:
+    import pyarrow
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +207,7 @@ class ChannelData:
             )
         return array
 
-    def to_arrow(self) -> Any:
+    def to_arrow(self) -> "pyarrow.Table":
         """The channel as a ``pyarrow.Table``: ``log_time_ns`` plus one column
         per primitive field (numeric/string/bool scalars and numeric lists;
         nested fields are skipped). Requires the ``arrow`` extra."""


### PR DESCRIPTION
## Summary

`ChannelData.to_arrow()` is annotated as returning `pyarrow.Table` instead of
`Any`, matching what its docstring already promised. `pyarrow` is imported under
`TYPE_CHECKING` only, so it stays an optional runtime dependency.

## Why

Closes #32. The `Any` return gave callers no completion or checking on the
result. The forward-reference annotation follows the idiom already used in
`steps.py`, `resample.py`, `app.py`, and `ffmpeg/_contact_sheet.py`; the
`ImportError` guard inside the method is untouched.

One caveat worth flagging: `pyarrow` 25.0.1 ships no `py.typed` marker and no
stubs, so `ty` resolves the annotation to `Unknown` today. With `pyarrow-stubs`
installed, `reveal_type` gives `Table`. The annotation is the prerequisite for
that resolution either way — happy to add `pyarrow-stubs` to the typing
dependencies in a follow-up if you want it, but that seemed like your call
rather than something to slip into this PR.

## Validation

- `uv run pytest -q` — 293 passed, 3 skipped
- `uv run ruff check --fix`, `uv run ruff format`, `uv run ty check` — clean
- `import hflow.episode` does not pull in `pyarrow` (`sys.modules` check)

## Checklist

- [ ] Tests — no runtime behavior change; annotation only
- [x] Docs — the docstring already documented the return type
- [x] `ruff check --fix`, `ruff format`, `ty check`
- [x] Relevant pytest suite
- [x] No recordings, media, credentials, private URLs, or runtime artifacts
- [x] Stored-data compatibility preserved