### PR TITLE
feat: add action_rate check and Cohort statistics docs

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -159,6 +159,22 @@ FROM measurements WHERE key = 'content_digest'
 GROUP BY digest HAVING count(*) > 1
 ```
 
+### Cohort statistics
+
+Per-episode checks record evidence; cohort math (z-score, percentile) is a query over the catalog.
+
+```sql
+SELECT episode_id,
+       action_rate_hz,
+       (action_rate_hz - AVG(action_rate_hz) OVER ())
+         / STDDEV(action_rate_hz) OVER () AS action_rate_hz_z,
+       PERCENT_RANK() OVER (ORDER BY action_rate_hz) AS action_rate_hz_pct
+FROM episodes
+WHERE task = 'fold_napkin'
+```
+
+Cohort statistics are corpus-relative. The z-score depends on which rows the query runs over, including any WHERE clause applied before the window, so compute the window over the same filtered cohort you intend to cut. Also note that STDDEV over a single-row cohort is NULL, which is the correct answer: one episode has no cohort to compare against.
+
 ### Finding stale episodes to reprocess
 
 The corpus is assumed permanently mixed-version, so "reprocess everything" is

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -332,6 +332,39 @@ def episode_duration(episode: Episode, *, topics: Sequence[str] | None = None) -
     )
 
 
+def action_rate(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
+    """Mean message rate of the given action topics, in hertz.
+
+    Speed-vs-skill is a corpus-relative judgment, so it cannot be decided
+    inside a per-episode check; this check records the evidence and the cut
+    is a curation query, e.g.::
+
+        SELECT episode_id FROM episodes WHERE action_rate_hz_z > 1.645
+
+    (the window function producing action_rate_hz_z is documented in the
+    Cohort statistics section of docs/CATALOG.md).
+    """
+    start_candidates_ns: list[int] = []
+    end_candidates_ns: list[int] = []
+    message_count_total = 0
+    streams_with_messages = 0
+    for topic in topics:
+        stamps_ns = episode.channel(topic).timestamps
+        if len(stamps_ns) == 0:
+            continue
+        message_count_total += len(stamps_ns)
+        streams_with_messages += 1
+        start_candidates_ns.append(int(stamps_ns[0]))
+        end_candidates_ns.append(int(stamps_ns[-1]))
+    span_s = (
+        (max(end_candidates_ns) - min(start_candidates_ns)) / 1e9 if start_candidates_ns else 0.0
+    )
+    # n timestamps on a stream define n - 1 intervals
+    interval_count = message_count_total - streams_with_messages
+    action_rate_hz = interval_count / span_s if span_s > 0 else 0.0
+    return CheckResult(measurements={"action_rate_hz": action_rate_hz})
+
+
 def content_digest(episode: Episode) -> CheckResult:
     """A stable digest of the episode's message content, for duplicate hunts.
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -6,6 +6,7 @@ import pytest
 
 import hflow
 from hflow.checks import (
+    action_rate,
     camera_frame_stats,
     content_digest,
     episode_duration,
@@ -119,6 +120,14 @@ def test_episode_duration_matches_the_synthesized_span(jittery_episode: hflow.Ep
     assert duration_s == pytest.approx(4.0, abs=0.1)
     message_count_total = result.measurements["message_count_total"]
     assert isinstance(message_count_total, int) and message_count_total > 0
+
+
+def test_action_rate_matches_the_synthesized_rate(jittery_episode: hflow.Episode) -> None:
+    result = action_rate(jittery_episode, topics=["/joint_states"])
+    action_rate_hz = result.measurements["action_rate_hz"]
+    assert isinstance(action_rate_hz, float)
+    # the synthetic joint stream runs at 100 Hz by SyntheticEpisodeSpec default
+    assert action_rate_hz == pytest.approx(100.0, abs=0.5)
 
 
 def test_content_digest_identifies_duplicate_content(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds the `action_rate` built-in check and a "Cohort statistics" section in docs/CATALOG.md, per the design agreed in Discussion #24. That discussion is the design doc.

The check records the raw per-episode message rate of the given action topics as `action_rate_hz`. Evidence only, no verdict: n timestamps define n - 1 intervals, so the rate is intervals divided by the span across the selected topics.

The docs section records the DuckDB window-function pattern for cohort math (z-score via `(value - AVG(value) OVER ()) / STDDEV(value) OVER ()`, plus `PERCENT_RANK()`), with the corpus-relative caveat: compute the window over the same filtered cohort you intend to cut.

## Validation
- uv run ruff check --fix && uv run ruff format
- uv run ty check (only pre-existing Windows platform diagnostics in runtime/_bundle.py, storage.py, and test_runtime_bundle.py; none in the new code)
- uv run pytest -q tests/test_checks.py (11 passed)

## Checklist
- [x] Outcome-focused test added: synthetic episode rate matches the spec's 100 Hz joint stream
- [x] Docs updated for the new behavior
- [x] ruff, ty, and pytest run
- [x] git status contains no recordings, generated artifacts, credentials, or runtime bundles
