### PR TITLE
feat: add overexposed_frame_pct to frame stats

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -195,6 +195,7 @@ def camera_frame_stats(
     black_pixel_threshold: int = 32,
     freeze_noise_db: float = -60.0,
     freeze_min_duration_s: float = 2.0,
+    bright_luma_threshold: float = 235.0,
 ) -> CheckResult:
     """Camera blackout, freeze, exposure, and frame-count evidence per camera.
 
@@ -207,8 +208,8 @@ def camera_frame_stats(
     ``freeze:<topic>`` intervals in log time. Requires a canonical episode
     (``Episode.video`` remuxes in-band H.264 only).
 
-    Evidence only, as always: blackout/exposure thresholds and any verdict
-    stay user-owned.
+    Evidence only, as always: blackout/exposure thresholds (including
+    ``bright_luma_threshold``) and any verdict stay user-owned.
     """
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
@@ -234,9 +235,11 @@ def camera_frame_stats(
             black_pixel_threshold=black_pixel_threshold,
             freeze_noise_db=freeze_noise_db,
             freeze_min_duration_s=freeze_min_duration_s,
+            bright_luma_threshold=bright_luma_threshold,
         )
         measurements[f"{topic}/decoded_frame_count"] = stats.frame_count
         measurements[f"{topic}/black_frame_pct"] = stats.black_frame_pct
+        measurements[f"{topic}/overexposed_frame_pct"] = stats.overexposed_frame_pct
         measurements[f"{topic}/freeze_total_s"] = stats.freeze_total_s
         measurements[f"{topic}/luma_avg_mean"] = stats.luma_avg_mean
         measurements[f"{topic}/luma_avg_min"] = stats.luma_avg_min

--- a/src/hflow/ffmpeg/_instrument.py
+++ b/src/hflow/ffmpeg/_instrument.py
@@ -39,6 +39,8 @@ class FrameStats:
     duration_s: float
     black_frame_count: int
     black_frame_pct: float  # 0.0-100.0, denominator = frame_count
+    overexposed_frame_count: int
+    overexposed_frame_pct: float  # 0.0-100.0, denominator = frame_count
     freeze_intervals: list[tuple[float, float]]  # (start_s, end_s) pairs
     freeze_total_s: float
     luma_avg_mean: float
@@ -143,7 +145,9 @@ def _collect_freeze_intervals(
     return intervals
 
 
-def _stats_from_instrument_output(output_text: str) -> FrameStats:
+def _stats_from_instrument_output(
+    output_text: str, *, bright_luma_threshold: float = 235.0
+) -> FrameStats:
     """Pure aggregation of the instrument's stdout (testable on synthetic text)."""
     frames = _parse_metadata_print_frames(output_text)
     if not frames:
@@ -170,12 +174,16 @@ def _stats_from_instrument_output(output_text: str) -> FrameStats:
         _parse_finite_float(pblack_text, f"{_BLACKFRAME_PBLACK_KEY} of frame {frame_index}")
         black_frame_count += 1
 
+    overexposed_frame_count = sum(1 for v in luma_avg_values if v >= bright_luma_threshold)
+
     freeze_intervals = _collect_freeze_intervals(frames, duration_s)
     return FrameStats(
         frame_count=frame_count,
         duration_s=duration_s,
         black_frame_count=black_frame_count,
         black_frame_pct=100.0 * black_frame_count / frame_count,
+        overexposed_frame_count=overexposed_frame_count,
+        overexposed_frame_pct=100.0 * overexposed_frame_count / frame_count,
         freeze_intervals=freeze_intervals,
         freeze_total_s=sum(end_s - start_s for start_s, end_s in freeze_intervals),
         luma_avg_mean=statistics.fmean(luma_avg_values),
@@ -191,6 +199,7 @@ def frame_stats(
     black_pixel_threshold: int = 32,
     freeze_noise_db: float = -60.0,
     freeze_min_duration_s: float = 2.0,
+    bright_luma_threshold: float = 235.0,
 ) -> FrameStats:
     """Run the instrument over ``video`` and aggregate.
 
@@ -200,6 +209,9 @@ def frame_stats(
     - ``freezedetect=n={noise}dB:d={duration}`` yields freeze intervals; an
       unterminated freeze at EOF closes at the video duration.
     - ``signalstats`` yields per-frame YAVG, aggregated to mean/min/max.
+    - Frames with average luma at or above ``bright_luma_threshold`` are
+      counted as overexposed; ``overexposed_frame_pct`` uses the same
+      frame-count denominator as ``black_frame_pct``.
     """
     filter_graph = (
         f"blackframe=amount={black_frame_amount_pct}:threshold={black_pixel_threshold},"
@@ -222,4 +234,6 @@ def frame_stats(
     if completed.returncode != 0:
         stderr_tail = "\n".join(completed.stderr.strip().splitlines()[-5:])
         raise RuntimeError(f"ffmpeg instrument pass failed for {video}: {stderr_tail}")
-    return _stats_from_instrument_output(completed.stdout)
+    return _stats_from_instrument_output(
+        completed.stdout, bright_luma_threshold=bright_luma_threshold
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -163,6 +163,10 @@ def test_camera_frame_stats_sees_the_injected_black_segment(tmp_path: Path) -> N
     assert isinstance(black_frame_pct, float)
     # 1 s of 4 s is black; decode boundaries make the exact count fuzzy.
     assert 10.0 < black_frame_pct < 50.0
+    # Non-bright fixture: overexposed_frame_pct should be 0.0 at default threshold.
+    overexposed_frame_pct = result.measurements[f"{camera_topic}/overexposed_frame_pct"]
+    assert isinstance(overexposed_frame_pct, float)
+    assert overexposed_frame_pct == 0.0
     message_count = result.measurements[f"{camera_topic}/message_count"]
     decoded_frame_count = result.measurements[f"{camera_topic}/decoded_frame_count"]
     assert message_count == decoded_frame_count

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -304,6 +304,27 @@ def test_synthetic_output_aggregates_exactly() -> None:
     assert stats.luma_avg_max == pytest.approx(100.0)
     assert stats.freeze_intervals == []
     assert stats.freeze_total_s == 0.0
+    # Default threshold 235.0: none of 100, 10, 40 are >= 235
+    assert stats.overexposed_frame_count == 0
+    assert stats.overexposed_frame_pct == 0.0
+
+
+def test_synthetic_overexposed_aggregates_exactly() -> None:
+    # YAVG: 100 (normal), 240 (overexposed), 250 (overexposed) at default threshold 235.0
+    output = (
+        "frame:0    pts:0    pts_time:0\n"
+        "lavfi.signalstats.YAVG=100\n"
+        "frame:1    pts:512   pts_time:0.5\n"
+        "lavfi.signalstats.YAVG=240\n"
+        "frame:2    pts:1024  pts_time:1\n"
+        "lavfi.signalstats.YAVG=250\n"
+    )
+    stats = _stats_from_instrument_output(output)
+    assert stats.frame_count == 3
+    assert stats.overexposed_frame_count == 2
+    assert stats.overexposed_frame_pct == pytest.approx(66.666, abs=0.1)
+    assert stats.luma_avg_min == pytest.approx(100.0)
+    assert stats.luma_avg_max == pytest.approx(250.0)
 
 
 def test_synthetic_freeze_intervals_including_unterminated() -> None:
@@ -385,6 +406,39 @@ def black_tail_video(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="module")
+def bright_tail_video(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """4s of testsrc2 followed by 2s of white, 10 fps, h264: 60 frames total."""
+    output = tmp_path_factory.mktemp("videos") / "bright_tail.mp4"
+    subprocess.run(
+        [
+            _system_ffmpeg(),
+            "-hide_banner",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x120:rate=10:duration=4,format=yuv420p",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=white:size=160x120:rate=10:duration=2,format=yuv420p",
+            "-filter_complex",
+            "[0:v][1:v]concat=n=2:v=1:a=0[out]",
+            "-map",
+            "[out]",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            str(output),
+        ],
+        capture_output=True,
+        check=True,
+    )
+    return output
+
+
+@pytest.fixture(scope="module")
 def frozen_tail_video(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """2s of testsrc2 then the last frame held (cloned) for 3s, 10 fps."""
     output = tmp_path_factory.mktemp("videos") / "frozen_tail.mp4"
@@ -422,6 +476,23 @@ def test_frame_stats_black_segment(black_tail_video: Path) -> None:
     assert stats.luma_avg_min < 32.0
     assert stats.luma_avg_min <= stats.luma_avg_mean <= stats.luma_avg_max
     assert stats.luma_avg_max > 64.0
+    assert stats.freeze_intervals == []
+    # Default threshold 235.0: testsrc2 max YAVG is well below.
+    assert stats.overexposed_frame_count == 0
+    assert stats.overexposed_frame_pct == 0.0
+
+
+def test_frame_stats_bright_segment(bright_tail_video: Path) -> None:
+    # freeze_min_duration_s > the 2s white segment so no freeze fires here.
+    # Use a lower threshold to catch the white segment (limited-range white ~235).
+    stats = frame_stats(bright_tail_video, freeze_min_duration_s=3.0, bright_luma_threshold=200.0)
+    assert stats.frame_count == 60
+    assert stats.duration_s == pytest.approx(6.0, abs=0.3)
+    # 20 of 60 frames are white/overexposed; allow encoder edge effects.
+    assert 10.0 < stats.overexposed_frame_pct < 50.0
+    # Encoded limited-range white lands near YAVG=235.
+    assert stats.luma_avg_max > 200.0
+    assert stats.luma_avg_min <= stats.luma_avg_mean <= stats.luma_avg_max
     assert stats.freeze_intervals == []
 
 


### PR DESCRIPTION
## Summary
Adds `overexposed_frame_pct` to `FrameStats` and records it per camera topic in `camera_frame_stats`. Closes #33.

Blackout already has `black_frame_pct`, but the symmetric failure (blown highlights from bad exposure, IR flood, or sun in frame) had no counterpart, and `luma_avg_max` alone cannot distinguish one bright frame from a thousand. The new measurement is the percentage of frames whose average luma is at or above `bright_luma_threshold` (default 235.0; thresholds stay user-owned), computed from the existing `luma_avg_values` list with the same frame-count denominator as `black_frame_pct`. No new ffmpeg filter, no second decode pass.

## Changes
- `src/hflow/ffmpeg/_instrument.py`: `FrameStats` gains `overexposed_frame_count` and `overexposed_frame_pct`; `frame_stats()` and `_stats_from_instrument_output()` gain `bright_luma_threshold`.
- `src/hflow/checks.py`: `camera_frame_stats` threads the threshold and records `{topic}/overexposed_frame_pct` next to `black_frame_pct`.
- `tests/test_ffmpeg.py`: synthetic instrument-output test with exact math at the default threshold, plus a white-tail real-video test exercising the threshold parameter.
- `tests/test_checks.py`: asserts the measurement is surfaced as 0.0 on a non-bright camera fixture.

## Validation
- uv run ruff check --fix && uv run ruff format
- uv run ty check (only pre-existing Windows platform diagnostics; none in the new code)
- uv run pytest -q tests/test_ffmpeg.py tests/test_checks.py (all new tests pass; 2 pre-existing Windows failures unrelated to this change: test_env_override_wins, test_local_install_extracts_both_binaries_and_executes)

## Checklist
- [x] Outcome-focused tests for the new measurement (synthetic exact math, real video, checks surfacing)
- [x] Docstrings updated where thresholds and measurements are documented
- [x] ruff, ty, and pytest run
- [x] git status contains no unrelated files