### PR TITLE
feat(cli): accept multiple files in `hflow doctor`

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -127,8 +127,9 @@ A file claiming this convention must satisfy, in increasing strictness:
 4. **Video constraints**: every `foxglove.CompressedVideo` message is one Annex B access unit beginning with an AUD; every IDR access unit contains SPS and PPS; no B-frames; `format="h264"`.
 5. **Stamps**: `provenance/v1` present with `schema_version` and `pipeline_version`.
 
-`hflow doctor <file.mcap>` executes these checks and exits with status 0 for
-a conforming file or 1 when it reports violations.
+`hflow doctor <file.mcap> [more.mcap ...]` executes these checks against every
+file given, printing one report each, and exits with status 0 when all files
+conform or 1 when any reports violations.
 
 ## References
 

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -92,10 +92,12 @@ def _build_parser() -> argparse.ArgumentParser:
         description=(
             "Validate container integrity, metadata stamps, chunk-group layout, "
             "and in-band video constraints (docs/FORMAT.md, executable form). "
-            "Exit code 0 when conforming, 1 when not."
+            "Accepts multiple files; exit code 0 when all conform, 1 when any does not."
         ),
     )
-    doctor_parser.add_argument("file", help="the local path or object-store URL to check")
+    doctor_parser.add_argument(
+        "file", nargs="+", help="the local paths or object-store URLs to check"
+    )
 
     up_parser = subparsers.add_parser(
         "up",
@@ -490,13 +492,17 @@ def _command_curate(arguments: argparse.Namespace) -> int:
 
 
 def _command_doctor(arguments: argparse.Namespace) -> int:
-    try:
-        doctor_report = diagnose(arguments.file)
-    except (ValueError, FileNotFoundError) as error:
-        print(f"doctor: {error}", file=sys.stderr)
-        return 2
-    print(doctor_report.summary())
-    return 0 if doctor_report.conforming else 1
+    exit_code = 0
+    for file in arguments.file:
+        try:
+            doctor_report = diagnose(file)
+        except (ValueError, FileNotFoundError) as error:
+            print(f"doctor: {error}", file=sys.stderr)
+            return 2
+        print(doctor_report.summary())
+        if not doctor_report.conforming:
+            exit_code = 1
+    return exit_code
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -84,6 +84,16 @@ def test_cli_doctor_exit_codes(
     assert cli_main(["doctor", str(bogus)]) == 1
     assert "NOT CONFORMING" in capsys.readouterr().out
 
+    assert cli_main(["doctor", str(canonical_episode), str(canonical_episode)]) == 0
+    both_conforming = capsys.readouterr().out
+    assert both_conforming.count(str(canonical_episode)) == 2
+    assert "NOT CONFORMING" not in both_conforming
+
+    assert cli_main(["doctor", str(canonical_episode), str(bogus)]) == 1
+    mixed = capsys.readouterr().out
+    assert str(canonical_episode) in mixed
+    assert str(bogus) in mixed
+
 
 def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[str]) -> None:
     missing = "C:/definitely/not/here.mcap"


### PR DESCRIPTION
## Problem

`hflow doctor` accepted exactly one file, so validating a directory of episodes required a shell loop whose exit code only reflected the last invocation.

## Change

- `file` is now `nargs="+"`.
- `_command_doctor` diagnoses each file in turn, prints its report, and returns 1 if any file is non-conforming, 0 when all conform.
- A missing file still prints the one-line errno message and exits 2 (it stops there rather than diagnosing the remaining files).
- `diagnose()` is unchanged.

One deviation from the issue: it asks to prefix each summary with the file path when more than one file is given. `DoctorReport.summary()` already leads with `doctor: <path>`, so an extra prefix would duplicate it — the test asserts instead that every path appears in the output.

## User-visible outcome

```
$ hflow doctor a.canonical.mcap b.canonical.mcap
doctor: a.canonical.mcap
  conforming: no findings
  verdict: CONFORMING
doctor: b.canonical.mcap
  [error] ...
  verdict: NOT CONFORMING
$ echo $?
1
```

## Tests

Extended the existing `test_cli_doctor_exit_codes` in `tests/test_doctor.py` (rather than adding a parallel test) with the all-conforming and mixed multi-file cases.

## Docs

`docs/FORMAT.md` now documents the multi-file form and its exit semantics.

## Validation

```bash
uv run pytest -q                              # 289 passed, 3 skipped
uv run ruff check --fix && uv run ruff format # clean
uv run ty check                               # clean
```

The `tests/test_ffmpeg.py` failures/errors on my machine are pre-existing (no ffmpeg/ffprobe on PATH) and reproduce on a clean `main`.

Closes #29

https://claude.ai/code/session_01AEdPuniM5w5DjWBSP9q39X