### PR TITLE
runtime: substitute venv_python/data_root/pipeline_filename as repr() literals

### DIFF
--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -507,13 +507,25 @@ def render_sub_dag_source(
         case Stage.SYNC | Stage.LABELS | Stage.MEDIA:
             template, gate_name = SUB_DAG_ERROR_GATE_TEMPLATE, "error_budget_gate"
     pipeline_stem = _pipeline_stem(master_dag_id)
+    # $data_root, $venv_python, and $pipeline_filename are substituted as
+    # repr() literals, never as bare text inside a pre-quoted template
+    # slot: a raw platform path (Windows venv interpreters use backslashes)
+    # or a data root containing a quote character would otherwise either
+    # break the generated file's Python syntax or -- worse -- close the
+    # surrounding string literal early and splice arbitrary text into the
+    # generated DAG's source (#44). repr() on a str always yields a
+    # self-escaping literal, so this holds for any input, not just the
+    # platform-path case that surfaced it.
+    data_root_literal = repr(data_root)
+    venv_python_literal = repr(venv_python)
+    pipeline_filename_literal = repr(pipeline_filename)
     # Substituted separately because Template.substitute never re-expands
     # variables inside substituted VALUES -- the filter's own $data_root must
     # be resolved before injection. Local roots only: probing a BUCKET
     # episode's channel list would download the whole file at plan time,
     # costing more than the skipped camera-less cycle saves.
     stage_plan_filter = (
-        MEDIA_PLAN_FILTER_TEMPLATE.substitute(data_root=data_root)
+        MEDIA_PLAN_FILTER_TEMPLATE.substitute(data_root=data_root_literal)
         if stage is Stage.MEDIA and not is_bucket_url(data_root)
         else ""
     )
@@ -526,10 +538,10 @@ def render_sub_dag_source(
         pipeline_tag=pipeline_stem,
         sub_display_name=f"{pipeline_stem} · {stage.value}",
         gate_name=gate_name,
-        pipeline_filename=pipeline_filename,
+        pipeline_filename=pipeline_filename_literal,
         app_variable=app_variable,
-        data_root=data_root,
-        venv_python=venv_python,
+        data_root=data_root_literal,
+        venv_python=venv_python_literal,
         stage_plan_filter=stage_plan_filter,
     )
 

--- a/src/hflow/runtime/_templates.py
+++ b/src/hflow/runtime/_templates.py
@@ -435,7 +435,7 @@ latency-first run); `batch_count`: optional override.
     params={"uris": [], "mode": "batch", "batch_count": None},
 )
 def ingest_stage():
-    @task.external_python(python="$venv_python", expect_airflow=False, skip_on_exit_code=99)
+    @task.external_python(python=$venv_python, expect_airflow=False, skip_on_exit_code=99)
     def plan(uris, mode, batch_count):
         """Bin-pack uris into staggered batches; online is one immediate batch."""
         from hflow.batching import plan_batches
@@ -447,7 +447,7 @@ $stage_plan_filter        if mode == "online":
             # The online lane (Figure 4) is latency-first: one run per episode
             # as it lands -- no batching, no stagger, batch_count ignored.
             return [{"items": [str(uri) for uri in uris], "start_delay_s": 0.0}]
-        data_root = parse_storage_root("$data_root")
+        data_root = parse_storage_root($data_root)
         item_sizes = {str(uri): data_root.file_size(str(uri)) for uri in uris}
         resolved_batch_count = (
             int(batch_count) if batch_count is not None else min(4, len(item_sizes))
@@ -460,7 +460,7 @@ $stage_plan_filter        if mode == "online":
             for batch in planned
         ]
 
-    @task.external_python(python="$venv_python", expect_airflow=False)
+    @task.external_python(python=$venv_python, expect_airflow=False)
     def process_batch(batch):
         """Sleep the stagger delay, then run this sub-DAG's stage on every episode."""
         import importlib.util
@@ -473,13 +473,13 @@ $stage_plan_filter        if mode == "online":
 
         time.sleep(float(batch["start_delay_s"]))
 
-        pipeline_path = "/opt/user/" + "$pipeline_filename"
+        pipeline_path = "/opt/user/" + $pipeline_filename
         # Managed platforms cannot always mount user/ at /opt/user;
         # HFLOW_USER_DIR relocates it without re-rendering (DEPLOY.md names
         # the per-platform value).
         user_dir_override = os.environ.get("HFLOW_USER_DIR")
         if user_dir_override:
-            pipeline_path = user_dir_override.rstrip("/") + "/" + "$pipeline_filename"
+            pipeline_path = user_dir_override.rstrip("/") + "/" + $pipeline_filename
         spec = importlib.util.spec_from_file_location("hflow_user_pipeline", pipeline_path)
         if spec is None or spec.loader is None:
             raise RuntimeError("cannot load user pipeline at " + pipeline_path)
@@ -489,9 +489,10 @@ $stage_plan_filter        if mode == "online":
         # Episode URIs resolve under the runtime's data root; an app pointing
         # anywhere else would silently write elsewhere in the
         # task's filesystem, so refuse loudly instead.
-        if str(app.data_root) != "$data_root":
+        expected_data_root = $data_root
+        if str(app.data_root) != expected_data_root:
             raise RuntimeError(
-                "pipeline data_root must be $data_root inside the runtime; "
+                "pipeline data_root must be " + expected_data_root + " inside the runtime; "
                 f"it is {app.data_root}"
             )
 
@@ -529,7 +530,7 @@ $stage_plan_filter        if mode == "online":
 
 _SUB_DAG_QUARANTINE_GATE = '''\
 
-    @task.external_python(python="$venv_python", expect_airflow=False)
+    @task.external_python(python=$venv_python, expect_airflow=False)
     def quarantine_budget_gate(batch_counts):
         """Fail the run loudly on mass failure of either kind.
 
@@ -569,7 +570,7 @@ _SUB_DAG_QUARANTINE_GATE = '''\
 
 _SUB_DAG_ERROR_GATE = '''\
 
-    @task.external_python(python="$venv_python", expect_airflow=False)
+    @task.external_python(python=$venv_python, expect_airflow=False)
     def error_budget_gate(batch_counts):
         """Fail loudly when processing errors exceed the run budget.
 
@@ -639,7 +640,7 @@ MEDIA_PLAN_FILTER_TEMPLATE = Template(
         from hflow.reader import open_reader
 
         def has_camera(uri):
-            reader = open_reader(Path("$data_root") / str(uri))
+            reader = open_reader(Path($data_root) / str(uri))
             try:
                 return any(
                     info.schema_name in CAMERA_SCHEMA_NAMES

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -376,14 +376,14 @@ def test_sub_dag_sources_compile_and_encode_contract(config: RuntimeConfig, tmp_
         assert "schedule=None" in dag_source
         assert 'params={"uris": [], "mode": "batch", "batch_count": None}' in dag_source
         # All three tasks run in the user venv via external python.
-        assert dag_source.count('@task.external_python(python="/opt/venvs/user/bin/python"') == 3
+        assert dag_source.count("@task.external_python(python='/opt/venvs/user/bin/python'") == 3
         # Imports live inside the (indented) function bodies -- the operator
         # extracts each body to a temp file, so module-level names never survive.
         assert "\n        from hflow.batching import plan_batches" in dag_source
         assert "\n        import importlib.util" in dag_source
         assert "\n        import math" in dag_source
         # The user pipeline is imported by file path and app resolved by name.
-        assert '"/opt/user/" + "my_pipeline.py"' in dag_source
+        assert "\"/opt/user/\" + 'my_pipeline.py'" in dag_source
         assert "spec_from_file_location" in dag_source
         assert 'getattr(pipeline_module, "app")' in dag_source
         # Each sub-DAG runs exactly its own Figure 4 stage.
@@ -404,8 +404,12 @@ def test_sub_dag_sources_compile_and_encode_contract(config: RuntimeConfig, tmp_
         assert "batch_counts >> gate" in dag_source
         # The process task authoritatively refuses an app
         # whose data_root is not the in-container mount point.
-        assert 'if str(app.data_root) != "/opt/airflow/data":' in dag_source
-        assert "pipeline data_root must be /opt/airflow/data inside the runtime" in dag_source
+        assert "expected_data_root = '/opt/airflow/data'" in dag_source
+        assert "if str(app.data_root) != expected_data_root:" in dag_source
+        assert (
+            '"pipeline data_root must be " + expected_data_root + " inside the runtime; "'
+            in dag_source
+        )
         # Checks decide quarantine: the quarantine budget lives ONLY in meta;
         # every other stage keeps the error-budget half.
         if stage is Stage.META:
@@ -588,8 +592,9 @@ class TestBucketModeBundle:
         paths, _ = _render(bucket_config, tmp_path / "bundle")
         for sub_dag_file in paths.sub_dag_files:
             dag_source = sub_dag_file.read_text()
-            assert f'parse_storage_root("{self.BUCKET_URL}")' in dag_source
-            assert f'if str(app.data_root) != "{self.BUCKET_URL}":' in dag_source
+            assert f"parse_storage_root({self.BUCKET_URL!r})" in dag_source
+            assert f"expected_data_root = {self.BUCKET_URL!r}" in dag_source
+            assert "if str(app.data_root) != expected_data_root:" in dag_source
         # The media plan filter probes episode channel lists, which would
         # download whole remote files at plan time: bucket bundles omit it.
         media_source = (paths.bundle_dir / "dags" / "ingest_media.py").read_text()

--- a/tests/test_runtime_deploy.py
+++ b/tests/test_runtime_deploy.py
@@ -91,15 +91,23 @@ def test_dag_sources_compile_and_carry_deploy_values(config: DeployConfig, tmp_p
         assert f'stages={{"{stage.value}"}}' in dag_source
         # The data root is parsed through the shared storage boundary for size
         # planning, while processing chooses a Path or full bucket URI.
-        assert f'data_root = parse_storage_root("{DATA_ROOT_PATH}")' in dag_source
+        # Substituted as a repr() literal (not bare text in a pre-quoted
+        # slot), so this holds for any data root content, not just this
+        # plain-path case -- see
+        # test_dag_sources_survive_paths_that_are_not_valid_python_literals.
+        assert f"data_root = parse_storage_root({DATA_ROOT_PATH!r})" in dag_source
         assert "episode_reference = (" in dag_source
-        assert f'if str(app.data_root) != "{DATA_ROOT_PATH}":' in dag_source
-        assert f"pipeline data_root must be {DATA_ROOT_PATH} inside the runtime" in dag_source
+        assert f"expected_data_root = {DATA_ROOT_PATH!r}" in dag_source
+        assert "if str(app.data_root) != expected_data_root:" in dag_source
+        assert (
+            '"pipeline data_root must be " + expected_data_root + " inside the runtime; "'
+            in dag_source
+        )
         assert "/opt/airflow/data" not in dag_source
         # All three tasks point at the (default) deploy venv interpreter.
-        assert dag_source.count(f'@task.external_python(python="{DEFAULT_DEPLOY_VENV_PYTHON}"') == 3
+        assert dag_source.count(f"@task.external_python(python={DEFAULT_DEPLOY_VENV_PYTHON!r}") == 3
         # The pipeline loads from user/, relocatable per platform via env var.
-        assert '"/opt/user/" + "my_pipeline.py"' in dag_source
+        assert "\"/opt/user/\" + 'my_pipeline.py'" in dag_source
         assert 'os.environ.get("HFLOW_USER_DIR")' in dag_source
 
 
@@ -112,10 +120,45 @@ def test_dag_sources_honor_custom_venv_python(config: DeployConfig, tmp_path: Pa
         dag_source = sub_dag_file.read_text()
         compile(dag_source, str(sub_dag_file), "exec")
         assert (
-            dag_source.count('@task.external_python(python="/home/airflow/venvs/tasks/bin/python"')
+            dag_source.count("@task.external_python(python='/home/airflow/venvs/tasks/bin/python'")
             == 3
         )
         assert DEFAULT_DEPLOY_VENV_PYTHON not in dag_source
+
+
+def test_dag_sources_survive_paths_that_are_not_valid_python_literals(
+    config: DeployConfig, tmp_path: Path
+) -> None:
+    """A Windows venv interpreter path or a data root containing a quote
+    character must not corrupt the generated DAG source (#44): every value
+    substituted into the templates is embedded as a repr() literal, which is
+    always self-escaping, rather than as bare text inside a pre-quoted slot.
+
+    Before the fix, the backslashes below produced a `SyntaxError` for every
+    sub-DAG (`\\U` reads as a truncated unicode escape) with nothing
+    surfacing the failure to whoever ran `hflow deploy`; a `data_root`
+    containing `"` closed the surrounding string literal early instead.
+    """
+    windows_venv_python = r"C:\Users\ci\venvs\user\Scripts\python.exe"
+    quote_bearing_data_root = '/data/root", os.system("unexpected"); x = ("'
+    paths = _render(
+        replace(
+            config,
+            venv_python_path=windows_venv_python,
+            data_root_uri=quote_bearing_data_root,
+        ),
+        tmp_path / "deploy",
+    )
+    for sub_dag_file in paths.sub_dag_files:
+        dag_source = sub_dag_file.read_text()
+        compile(dag_source, str(sub_dag_file), "exec")
+        assert dag_source.count(f"@task.external_python(python={windows_venv_python!r}") == 3
+        # The whole crafted value round-trips as one repr() literal -- if the
+        # embedded quote had broken out of the intended string instead, this
+        # exact substring would not appear (and `compile()` above would
+        # either have raised or accepted a different, corrupted program).
+        assert f"data_root = parse_storage_root({quote_bearing_data_root!r})" in dag_source
+        assert f"expected_data_root = {quote_bearing_data_root!r}" in dag_source
 
 
 def test_dag_id_default_rule_and_override(config: DeployConfig, tmp_path: Path) -> None:
@@ -234,7 +277,7 @@ def test_deploy_config_supports_object_store_urls_and_installs_backend(tmp_path:
     assert "HFLOW_MIRROR_DIR" in deploy_md
     for dag_file in paths.sub_dag_files:
         dag_source = dag_file.read_text()
-        assert 'parse_storage_root("s3://bucket/prefix")' in dag_source
+        assert "parse_storage_root('s3://bucket/prefix')" in dag_source
         assert "is_bucket_url(data_root)" in dag_source
 
 
@@ -326,7 +369,7 @@ def test_cli_deploy_honors_requirements_and_venv_python(tmp_path: Path) -> None:
     assert exit_code == 0
     assert (output_dir / "user" / "requirements.txt").read_text() == "scipy>=1\n"
     dag_source = (output_dir / "dags" / "demo_pipeline_meta.py").read_text()
-    assert dag_source.count('@task.external_python(python="/custom/venv/bin/python"') == 3
+    assert dag_source.count("@task.external_python(python='/custom/venv/bin/python'") == 3
 
 
 def test_cli_deploy_rejects_relative_data_root(


### PR DESCRIPTION
Fixes #44.

## What was broken

`render_sub_dag_source` (`src/hflow/runtime/_bundle.py`) builds each generated sub-DAG file via `string.Template.substitute()` against templates that embedded `$venv_python`, `$data_root`, and `$pipeline_filename` directly inside pre-quoted Python string literals, with no escaping:

```python
@task.external_python(python="$venv_python", ...)
data_root = parse_storage_root("$data_root")
pipeline_path = "/opt/user/" + "$pipeline_filename"
if str(app.data_root) != "$data_root":
```

`_validate_dag_identifiers()` already exists specifically to guard against this ("Refuse anything that could break (or smuggle code into) a DAG file") but was only ever applied to `dag_id`/`app_variable`. These three fields go through the identical unescaped substitution and were never brought under a matching guard. `validate_data_root_uri` only checks URI scheme and path absoluteness, not template-safety, despite its docstring claiming the root is "validated loudly."

Concretely: `hflow deploy --venv-python 'C:\Users\ci\venvs\user\Scripts\python.exe'` — an ordinary Windows interpreter path, exactly the value `DEPLOY.md`'s own generated troubleshooting text tells an operator to pass — produced a `SyntaxError` in all four sub-DAGs (`\U` reads as a truncated unicode escape), with nothing surfacing the failure. A `data_root` containing a literal `"` closed the string early instead, with effects ranging from a different `SyntaxError` to syntactically valid but altered generated code.

## Fix

Substitute `repr()` of each value instead of pre-quoting the template slot, and drop the manual `"..."` wrapping from the template around these three placeholders. `repr()` on a `str` always produces a valid, self-escaping Python literal regardless of content, so this closes the bug for arbitrary input, not only the Windows-path case that surfaced it.

One site needed restructuring rather than a drop-in swap: the `data_root` equality-check error message embedded `$data_root` as raw text *inside* another string literal's characters (`"pipeline data_root must be $data_root inside the runtime; "`). Splicing a `repr()` result into the middle of another string's text is unsafe whenever `repr()` happens to choose double-quote delimiters (it does when the value contains a `'` but no `"`), since that would prematurely close the outer literal. Fixed by binding the literal to a local variable first (`expected_data_root = $data_root`) and using it in an expression position (`+` concatenation) instead of as embedded text.

## Testing

- New regression test `test_dag_sources_survive_paths_that_are_not_valid_python_literals` (`tests/test_runtime_deploy.py`) exercises both the reported Windows-path case and a `data_root` containing an injection-shaped payload (`os.system(...)`), asserting the generated sources `compile()` cleanly and the value round-trips as a single literal.
- Updated the existing sources-compile assertions in `tests/test_runtime_bundle.py` and `tests/test_runtime_deploy.py` to match the new (single-quoted `repr()`) rendering; behavior covered by those tests (which interpreter/data root a task runs against) is unchanged, only the exact generated source text.

```bash
uv run pytest tests/test_runtime_bundle.py tests/test_runtime_deploy.py -q   # 61 passed
uv run pytest -q                                                            # unrelated to this change: 3 failures + 6 errors in tests/test_ffmpeg.py because this sandbox has no ffmpeg/ffprobe on PATH; everything else passes
uv run ruff check --fix
uv run ruff format
uv run ty check
```

No docs/behavior/flag changes; this only affects the exact bytes of generated (internal, re-rendered-on-every-`deploy`) DAG source files, not any stored/versioned format.
