### PR TITLE
catalog: repair dependent recorded_at only after winning the episodes race

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -443,8 +443,16 @@ class Catalog:
             # Build every table file locally first, then store dependents
             # before the episodes file (see above). store_file_if_absent is
             # atomic in both modes: rename-into-place locally, a conditional
-            # put (PutMode::Create) on a bucket -- so a racing worker
-            # appending the same outcome loses cleanly instead of duplicating.
+            # put (PutMode::Create) on a bucket.
+            #
+            # A dependent's create-if-absent can lose to either a genuinely
+            # stale file (a crashed earlier append -- its episodes file never
+            # landed, or we would have returned written=False above) or a
+            # LIVE concurrent racer appending the identical outcome right
+            # now: those two cases are indistinguishable from here (both
+            # look like "the dependent exists, episodes doesn't"), so a
+            # dependent that loses here is deliberately left alone instead
+            # of guessed at -- see the repair pass below.
             with tempfile.TemporaryDirectory(prefix="hflow-catalog-append-") as staging_name:
                 staging_dir = Path(staging_name)
                 for table_name in _TABLE_NAMES:
@@ -454,20 +462,34 @@ class Catalog:
                 for table_name in ("check_runs", "measurements", "tags", "intervals"):
                     staged_file = staging_dir / f"{table_name}.parquet"
                     dependent_key = f"{table_name}/{file_stem}.parquet"
-                    if not self.location.store_file_if_absent(staged_file, dependent_key):
-                        # A crashed earlier append left this dependent behind
-                        # (its episodes file never landed, or we would have
-                        # returned written=False above). Replace it so every
-                        # file of ONE append carries one recorded_at -- mixed
-                        # timestamps would let the per-key "latest" views
-                        # attribute another run's rows to this one. Safe to
-                        # delete: without its episodes file the run is
-                        # invisible (manifest-last).
-                        self.location.delete(dependent_key)
-                        self.location.store_file_if_absent(staged_file, dependent_key)
+                    self.location.store_file_if_absent(staged_file, dependent_key)
                 episodes_created = self.location.store_file_if_absent(
                     staging_dir / "episodes.parquet", f"episodes/{file_stem}.parquet"
                 )
+                if episodes_created:
+                    # store_file_if_absent on episodes is atomic, so at most
+                    # one caller ever observes True: we are now the unique,
+                    # durable owner of this file_stem, whether this is a
+                    # solo append, the winner of a race against a concurrent
+                    # duplicate, or a retry repairing a crashed earlier
+                    # attempt. Force every dependent to carry OUR
+                    # recorded_at -- unconditionally, since a losing
+                    # dependent write above (crash debris or a concurrent
+                    # racer that did not go on to win episodes) may hold a
+                    # different one. Every file of ONE append must carry one
+                    # recorded_at: the per-key "latest" views (curation.py)
+                    # each independently rank rows by (recorded_at,
+                    # run_fingerprint) per table, so a mismatch could let
+                    # them pick two different runs as "latest" for the same
+                    # episode and stitch together rows that never belonged
+                    # to the same outcome. ``publish`` is an unconditional
+                    # atomic replace (rename-into-place locally, a plain put
+                    # on a bucket) -- safe here because we already hold the
+                    # unique win on episodes.
+                    for table_name in ("check_runs", "measurements", "tags", "intervals"):
+                        staged_file = staging_dir / f"{table_name}.parquet"
+                        dependent_key = f"{table_name}/{file_stem}.parquet"
+                        self.location.publish(staged_file, dependent_key)
         finally:
             connection.close()
 

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -473,6 +473,86 @@ def test_crash_repaired_append_keeps_one_recorded_at_across_tables(tmp_path: Pat
         connection.close()
 
 
+def test_concurrent_append_of_the_identical_outcome_keeps_one_recorded_at(
+    tmp_path: Path,
+) -> None:
+    """Two callers racing ``append_episode`` for the identical outcome (a
+    retried or duplicate-dispatched batch task, not a crash) must not split
+    one outcome's tables across two different recorded_at values.
+
+    Before the fix, a dependent table that lost its create-if-absent race
+    was unconditionally deleted and rewritten with the losing caller's OWN
+    recorded_at, independently per table -- so the caller that ultimately
+    won ``episodes`` (the durability marker) could end up with dependents
+    stamped by the OTHER caller, and different dependent tables could even
+    disagree with each other.
+    """
+    import threading
+
+    import duckdb
+
+    canonical = _fake_canonical(tmp_path)
+    catalog = Catalog(tmp_path / "catalog")
+    row = _check_row()
+
+    # A storage-boundary test double: gate the first two dependent-table
+    # writes on a barrier so both threads are guaranteed to reach
+    # append_episode's dependent-write loop at the same time, forcing the
+    # real interleaving a natural race only produces intermittently.
+    barrier = threading.Barrier(2)
+    released = 0
+    release_lock = threading.Lock()
+    real_location = catalog.location
+
+    class GatedLocation:
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_location, name)
+
+        def store_file_if_absent(self, local_file: Path, relative: str) -> bool:
+            nonlocal released
+            with release_lock:
+                released += 1
+                should_wait = released <= 2
+            if should_wait:
+                barrier.wait(timeout=5)
+            return real_location.store_file_if_absent(local_file, relative)
+
+    catalog.location = cast("hflow.storage.StorageRoot", GatedLocation())
+
+    results: dict[str, hflow.catalog.AppendResult] = {}
+
+    def append_same_outcome(label: str) -> None:
+        results[label] = catalog.append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+    threads = [threading.Thread(target=append_same_outcome, args=(label,)) for label in "AB"]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert {result.written for result in results.values()} == {True, False}
+    stem = f"{results['A'].episode_id}-{results['A'].run_fingerprint}"
+
+    connection = duckdb.connect()
+    try:
+        timestamps = set()
+        for table_name in ("episodes", "check_runs", "measurements", "tags", "intervals"):
+            table_file = tmp_path / "catalog" / table_name / f"{stem}.parquet"
+            assert table_file.is_file(), f"{table_name} file missing after the race"
+            rows = connection.execute(
+                f"SELECT DISTINCT CAST(recorded_at AS VARCHAR) FROM read_parquet('{table_file}')"
+            ).fetchall()
+            timestamps.update(value for (value,) in rows)
+        assert len(timestamps) == 1, f"mixed recorded_at across tables: {timestamps}"
+    finally:
+        connection.close()
+
+
 def test_curate_accepts_file_url_output(tmp_path: Path) -> None:
     catalog = Catalog(tmp_path / "catalog")
     canonical = tmp_path / "e.canonical.mcap"


### PR DESCRIPTION
Fixes #46.

## What was broken

Two callers appending the identical outcome concurrently to `Catalog` (e.g. a retried or duplicate-dispatched Airflow batch task) both pass the `exists("episodes/...")` early-return check -- it and the dependent-table write loop are not one atomic operation. The old fallback treated any dependent that lost its create-if-absent race as certain crash debris and unconditionally deleted + overwrote it with the *current* caller's own `recorded_at`:

```python
if not self.location.store_file_if_absent(staged_file, dependent_key):
    # A crashed earlier append left this dependent behind ...
    self.location.delete(dependent_key)
    self.location.store_file_if_absent(staged_file, dependent_key)
```

That reasoning can't actually distinguish "stale debris from an abandoned attempt" from "a live sibling racer computing the identical outcome right now" -- both look identical from here (dependent exists, `episodes` doesn't). Each of the 4 dependent tables raced and "repaired" independently, so the `episodes` file and its dependents could end up with different `recorded_at` values for one outcome, and the dependents could even disagree with *each other*.

This isn't just cosmetic: `curation.py`'s `episodes_latest`/`measurements_latest` views each independently rank rows by `(recorded_at DESC, run_fingerprint DESC)` per table. On an episode with more than one recorded run, a mismatch introduced by this race could make the two views pick different `run_fingerprint`s as "latest" and the `episodes` view's join would then stitch together rows from two different runs.

## Fix

Don't guess at dependent-write time. `store_file_if_absent` on `episodes` is atomic, so at most one caller ever observes `True` for a given `file_stem` -- defer any repair until that unique winner is known:

```python
episodes_created = self.location.store_file_if_absent(...)
if episodes_created:
    # We are now the unique, durable owner of this file_stem.
    for table_name in (...):
        self.location.publish(staged_file, dependent_key)  # unconditional atomic replace
```

The loser of the `episodes` race does nothing further -- its own dependent writes, if any transiently won, get overwritten by the winner's repair pass. `StorageRoot.publish` is already an unconditional atomic replace used elsewhere for exactly this "overwrite is correct" case, so no new storage primitive was needed.

This correctly handles both scenarios that need different treatment:
- **True crash-repair** (sequential retry after a crash, no live racer): the retry is the only caller running, so it always wins `episodes` and repairs the stale dependents left by the crashed attempt -- unchanged behavior, still covered by the existing `test_crash_repaired_append_keeps_one_recorded_at_across_tables`.
- **Concurrent race** (two callers truly in parallel): exactly one wins `episodes` and repairs *all* dependents to its own `recorded_at`, including ones the other caller initially won -- the new bug this PR fixes.

## Testing

New regression test `test_concurrent_append_of_the_identical_outcome_keeps_one_recorded_at` (`tests/test_catalog_curation.py`) uses a small storage-boundary test double (a barrier gating `store_file_if_absent`) to force two threads to interleave reliably rather than intermittently, then asserts all 5 tables carry one `recorded_at`. Confirmed it fails against the pre-fix code (`mixed recorded_at across tables: {...}`, 2 distinct values) and passes with the fix.

```bash
uv run pytest tests/test_catalog_curation.py -q   # 17 passed
uv run pytest -q                                  # unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH); everything else passes: 277 passed, 2 skipped
uv run ruff check --fix
uv run ruff format
uv run ty check
```

No stored-format changes -- this only affects which `recorded_at` a dependent's row content carries, never which rows exist or what they otherwise contain (guaranteed identical by `file_stem` = `episode_id`-`run_fingerprint`, which already encodes the full observable outcome).
