### PR TITLE
feat-add-verbose-tags-to-cli

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -7,6 +7,7 @@ lives only here.
 """
 
 import argparse
+import logging
 import sys
 from pathlib import Path
 
@@ -25,6 +26,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hflow",
         description="Open-source robotics data pipeline.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -500,6 +507,13 @@ def _command_doctor(arguments: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     arguments = _build_parser().parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if arguments.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
     if arguments.command == "curate":
         return _command_curate(arguments)
     if arguments.command == "stale":

--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -12,7 +12,6 @@ standard library.
 """
 
 import json
-import logging
 import re
 import shutil
 import subprocess
@@ -38,8 +37,6 @@ from hflow.reader import EpisodeReader, TopicInfo, open_reader
 
 if TYPE_CHECKING:
     import pyarrow
-
-logger = logging.getLogger(__name__)
 
 RawDecoder = Callable[[bytes], Any]
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,5 +1,6 @@
 """The canonical episode format as an executable conformance check."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -93,6 +94,32 @@ def test_cli_doctor_exit_codes(
     mixed = capsys.readouterr().out
     assert str(canonical_episode) in mixed
     assert str(bogus) in mixed
+
+
+def test_cli_logs_library_warning_to_stderr(
+    canonical_episode: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = logging.getLogger("hflow.test")
+
+    def diagnose_with_warning(path: Path) -> object:
+        logger.warning("test library warning")
+        return diagnose(path)
+
+    monkeypatch.setattr("hflow.cli.diagnose", diagnose_with_warning)
+
+    root_logger = logging.getLogger()
+    handlers = root_logger.handlers.copy()
+    root_logger.handlers.clear()
+
+    try:
+        assert cli_main(["doctor", str(canonical_episode)]) == 0
+    finally:
+        root_logger.handlers[:] = handlers
+
+    captured = capsys.readouterr()
+    assert "WARNING hflow.test: test library warning" in captured.err
 
 
 def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

<!-- What user-visible outcome does this change produce? -->
Fixed the issue (#28) by adding the --verbose and -v cli arguments

## Why

<!-- What problem does it solve, and why is this the appropriate scope? -->

## Validation

<!-- List the exact commands you ran and their results. -->
1. `pytest`
```
 uv run pytest -q
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 66, column 17
     |
  66 | exclude-newer = "5 days"
     |                 ^^^^^^^^
  failed to parse year in date "5 days": failed to parse "5 da" as year (a four digit integer): invalid digit, expected 0-9 but got

......................................................................s......................................... [ 36%]
................................................................................................................ [ 72%]
....................s................................s.............................                              [100%]
304 passed, 3 skipped in 32.23s
```

2. `ruff`
```
 uv run ruff check --fix
uv run ruff format
uv run ty check
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 66, column 17
     |
  66 | exclude-newer = "5 days"
     |                 ^^^^^^^^
  failed to parse year in date "5 days": failed to parse "5 da" as year (a four digit integer): invalid digit, expected 0-9 but got

Found 3 errors (3 fixed, 0 remaining).
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 66, column 17
     |
  66 | exclude-newer = "5 days"
     |                 ^^^^^^^^
  failed to parse year in date "5 days": failed to parse "5 da" as year (a four digit integer): invalid digit, expected 0-9 but got

1 file reformatted, 86 files left unchanged
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 66, column 17
     |
  66 | exclude-newer = "5 days"
     |                 ^^^^^^^^
  failed to parse year in date "5 days": failed to parse "5 da" as year (a four digit integer): invalid digit, expected 0-9 but got

All checks passed!
```
## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [ ] I preserved stored-data compatibility or documented an explicit version change.
