### PR TITLE
Closes #2

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from hflow import __version__
 from hflow.curation import curate, stale_episodes
 from hflow.doctor import diagnose
 from hflow.runtime._deploy import DEFAULT_DEPLOY_VENV_PYTHON
@@ -25,6 +26,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hflow",
         description="Open-source robotics data pipeline.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"hflow{__version__}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import pytest
+from pytest import CaptureFixture
+
+from hflow import __version__
+from hflow.cli import _build_parser
+
+
+def test_cli_version(capsys: CaptureFixture) -> None:
+    with pytest.raises(SystemExit) as exception:
+        _build_parser().parse_args(["--version"])
+
+    assert exception.value.code == 0
+    assert f"hflow{__version__}" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds "--version" flag to CLI, allowing users to see their version.

## Why

There was no standard "--version" flag to get version from cli, only way was with {uv run python -c "import hflow; print(hflow.__version__)"}

## Validation
uv run pytest tests/test_cli.py
configfile: pyproject.toml
collected 1 item

tests\test_cli.py .  

uv run ruff check --fix
All checks passed!

uv run ruff format
84 files left unchanged
uv run ty check
Only remaining errors are isolated to Linux models like "os.getuid" and "fcntl").

## Checklist

- [x ] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x ] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x ] I ran the relevant pytest suite.
- [x ] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x ] I preserved stored-data compatibility or documented an explicit version change.
