### PR TITLE
curation: rank measurements_latest by the episode's own recorded_at

### DIFF
--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -11,7 +11,9 @@ Views registered on the connection:
 - ``episodes_raw``, ``check_runs``, ``measurements``, ``tags``,
   ``intervals`` -- the long tables, exactly as stored.
 - ``episodes_latest`` -- one row per episode_id (most recent append).
-- ``measurements_latest`` -- one row per (episode_id, key), most recent.
+- ``measurements_latest`` -- one row per (episode_id, key), most recent by
+  the OWNING episode's recorded_at (joined in), not the measurement row's
+  own -- the latter can go stale independently of the episode it belongs to.
 - ``episodes`` -- the wide view for everyday queries: latest episode rows,
   a ``status`` column (``'quarantined'``/``'ok'``), and one numeric column
   per measurement key (booleans as 0/1; text-valued measurements stay in the
@@ -178,10 +180,31 @@ def open_catalog_connection(catalog_root: "Path | str | StorageRoot") -> duckdb.
         """
         CREATE VIEW measurements_latest AS
         SELECT * EXCLUDE (row_rank) FROM (
-            SELECT *, row_number() OVER (
-                PARTITION BY episode_id, key
-                ORDER BY recorded_at DESC, run_fingerprint DESC
-            ) AS row_rank FROM measurements
+            SELECT
+                m.* EXCLUDE (recorded_at),
+                -- Rank (and report) by the EPISODE's recorded_at, not this
+                -- table's own: episodes/<file_stem>.parquet is the only file
+                -- create-if-absent guarantees a single writer for, so it is
+                -- the sole trustworthy recorded_at once episodes_latest has
+                -- already picked a winner. A repair pass that wins the
+                -- episodes race can still crash before reaching measurements
+                -- (see #51) -- a later retry then early-returns on
+                -- exists(episodes) and never revisits it, leaving this
+                -- table's own recorded_at stale forever. Ranking off it
+                -- directly could then pick a different run_fingerprint than
+                -- episodes_latest for the same episode_id, stitching rows
+                -- from two different runs together. The inner join also
+                -- means a run whose episodes file hasn't landed yet (crash
+                -- debris mid-append, not yet retried) is invisible here,
+                -- matching append_episode's own "episodes existing is what
+                -- proves an append complete" idiom.
+                e.recorded_at,
+                row_number() OVER (
+                    PARTITION BY m.episode_id, m.key
+                    ORDER BY e.recorded_at DESC, m.run_fingerprint DESC
+                ) AS row_rank
+            FROM measurements m
+            JOIN episodes_raw e USING (episode_id, run_fingerprint)
         ) WHERE row_rank = 1
         """
     )

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1,5 +1,6 @@
 """Catalog appends and curation queries (issues #16/#17)."""
 
+import tempfile
 from pathlib import Path
 from typing import cast
 
@@ -549,6 +550,80 @@ def test_concurrent_append_of_the_identical_outcome_keeps_one_recorded_at(
             ).fetchall()
             timestamps.update(value for (value,) in rows)
         assert len(timestamps) == 1, f"mixed recorded_at across tables: {timestamps}"
+    finally:
+        connection.close()
+
+
+def test_measurements_latest_ranks_by_the_owning_episodes_recorded_at(tmp_path: Path) -> None:
+    """A dependent table's own recorded_at can go permanently stale: a repair
+    pass that wins the episodes race can crash before reaching measurements
+    (#51), and a later retry early-returns on exists(episodes) and never
+    revisits it. measurements_latest must still agree with episodes_latest
+    on which run is newest -- ranking (and reporting) off the episode's own
+    recorded_at, the one column create-if-absent guarantees a single writer
+    for, rather than this table's own, possibly-stale, column.
+    """
+    import time
+
+    import duckdb
+
+    canonical = _fake_canonical(tmp_path)
+    catalog = Catalog(tmp_path / "catalog")
+
+    older = catalog.append_episode(
+        canonical_path=canonical,
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[_check_row(version="v1", value=1.0)],
+    )
+    time.sleep(0.01)
+    newer = catalog.append_episode(
+        canonical_path=canonical,
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[_check_row(version="v2", value=2.0)],
+    )
+    assert older.written and newer.written
+    assert older.run_fingerprint != newer.run_fingerprint
+
+    # Simulate a repair pass that won `episodes` for the NEWER run but
+    # crashed before repairing `measurements`: that table's file is left
+    # with a stale recorded_at older than even the OLDER run's, despite
+    # `episodes` (the source of truth) correctly carrying the newest one.
+    stale_file = (
+        tmp_path
+        / "catalog"
+        / "measurements"
+        / f"{newer.episode_id}-{newer.run_fingerprint}.parquet"
+    )
+    connection = duckdb.connect()
+    try:
+        with tempfile.TemporaryDirectory(prefix="hflow-test-corrupt-") as staging_name:
+            staged = Path(staging_name) / "measurements.parquet"
+            connection.execute(
+                f"""
+                COPY (
+                    SELECT * REPLACE ('2000-01-01 00:00:00+00'::TIMESTAMPTZ AS recorded_at)
+                    FROM read_parquet('{stale_file}')
+                ) TO '{staged}' (FORMAT PARQUET)
+                """
+            )
+            staged.replace(stale_file)
+    finally:
+        connection.close()
+
+    connection = open_catalog_connection(tmp_path / "catalog")
+    try:
+        # episodes_latest ranks off its own always-authoritative recorded_at,
+        # so it is unaffected and still correctly calls the newer run latest.
+        assert connection.execute("SELECT run_fingerprint FROM episodes_latest").fetchone() == (
+            newer.run_fingerprint,
+        )
+        # measurements_latest must agree, despite its own corrupted column --
+        # before the fix, it picked the OLDER run's value (1.0) here.
+        assert connection.execute(
+            "SELECT value_double FROM measurements_latest WHERE key = 'example_metric'"
+        ).fetchone() == (2.0,)
     finally:
         connection.close()
 


### PR DESCRIPTION
Fixes #51.

## The gap

#47 made `episodes/<file_stem>.parquet` the single source of truth for `recorded_at` on a given append -- but only for the `episodes` table itself. `measurements_latest` still ranks rows by *its own* `recorded_at` column:

```sql
CREATE VIEW measurements_latest AS
SELECT * EXCLUDE (row_rank) FROM (
    SELECT *, row_number() OVER (
        PARTITION BY episode_id, key
        ORDER BY recorded_at DESC, run_fingerprint DESC
    ) AS row_rank FROM measurements
) WHERE row_rank = 1
```

A repair pass that wins the `episodes` race can still crash before reaching `measurements` (`Catalog.append_episode`'s repair loop in `src/hflow/catalog.py`). Because `exists(episodes/...)` is the *only* thing a later retry checks before early-returning, that dependent's `recorded_at` is never revisited -- it can be permanently older or newer than the episode it belongs to. `measurements_latest` and `episodes_latest` can then disagree about which run is "latest" for the same `episode_id`, reproducing the class of bug #47 fixed, just from a narrower crash window instead of a live race.

## Fix

Join `measurements` to `episodes_raw` on `(episode_id, run_fingerprint)` and rank -- and report -- `recorded_at` from the episode side, the one column `create-if-absent` guarantees a single writer for. `episodes_latest` itself needed no change (it already IS the authoritative source). The inner join also means a run whose `episodes` file hasn't landed yet (an append still mid-flight or crashed before completing) is invisible in `measurements_latest`, matching `append_episode`'s own idiom that `episodes` existing is what proves an append complete.

## Testing

New regression test `test_measurements_latest_ranks_by_the_owning_episodes_recorded_at` (`tests/test_catalog_curation.py`): records an older and a newer run of the same episode, then corrupts the newer run's `measurements` file to carry an older `recorded_at` than the older run's (simulating the crash-mid-repair window). Confirmed it fails against pre-fix code (picks the stale 1.0 instead of 2.0) and passes with the fix.

```bash
uv run pytest tests/test_catalog_curation.py -q   # 19 passed
uv run pytest -q                                  # unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH); everything else passes: 298 passed, 3 skipped
uv run ruff check --fix
uv run ruff format
uv run ty check
```

No stored-format changes -- this only changes which `recorded_at` a `measurements_latest` row reports and how it's ranked, never what's stored on disk.