### PR TITLE
episode: expose ChannelData.publish_times

### DIFF
--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -113,6 +113,15 @@ class ChannelData:
         return self._log_times
 
     @property
+    def publish_times(self) -> np.ndarray:
+        """Publish times in nanoseconds, shape (n,). Does not decode.
+
+        Unlike ``timestamps`` (log time, always ascending), publish time is
+        set by the message's source and is not guaranteed ascending.
+        """
+        return self._publish_times
+
+    @property
     def raw(self) -> list[bytes]:
         """Raw encoded message payloads. Does not decode."""
         return self._raw

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -137,6 +137,17 @@ def test_canonical_episode_accessors(
         assert abs(frames[1].log_time_ns - frames[0].log_time_ns - 466_666_667) <= 1
 
 
+def test_channel_publish_times_are_reachable(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+) -> None:
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        channel = episode.channel("/joint_states")
+        publish_times = channel.publish_times
+        assert isinstance(publish_times, np.ndarray)
+        assert publish_times.shape == (len(channel),)
+
+
 def test_arrow_export(report_and_app: tuple[hflow.TestReport, hflow.App]) -> None:
     report, _app = report_and_app
     with hflow.Episode(report.canonical_path) as episode:


### PR DESCRIPTION
Fixes #4.

## What was missing

`ChannelData` stores per-message publish times but never exposed them: the constructor accepts `publish_times` and assigns `self._publish_times` (`src/hflow/episode.py`), and `Episode.channel()` faithfully concatenates them from the reader -- but there was no property, so the data was plumbed end to end and then unreachable.

## Change

Added a `publish_times` property directly below `timestamps`, following the same pattern, returning `self._publish_times`. The docstring notes these are publish times (not log times) and, unlike `timestamps`, are not guaranteed ascending.

## Testing

New test `test_channel_publish_times_are_reachable` (`tests/test_end_to_end.py`), using the existing synthetic-episode fixture: asserts `ep.channel("/joint_states").publish_times` is an `np.ndarray` with shape `(len(channel),)`.

```bash
uv run pytest -q       # 298 passed, 3 skipped; unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH)
uv run ruff check --fix
uv run ruff format
uv run ty check
```