### PR TITLE
docs: add a single HFLOW_* environment variable reference page

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,16 @@
+# Environment variables
+
+Every `HFLOW_*` environment variable HFlow reads, in one place. Each is also
+documented where it applies (linked below); this page exists to answer "how
+do I point at my own ffmpeg *and* relocate the mirror cache?" without
+crossing pages.
+
+| Variable | Purpose | Default | Applies to |
+|---|---|---|---|
+| `HFLOW_FFMPEG` | Explicit override for the ffmpeg binary path -- skips the pinned auto-download entirely. | Unset: the pinned static build is auto-downloaded and sha256-verified (Linux); the PATH binary with a loud warning on platforms with no pinned build (macOS, native Windows). | Any pipeline run; also how the test suite pins a known ffmpeg (see [CONTRIBUTING.md](../CONTRIBUTING.md)). |
+| `HFLOW_FFPROBE` | Explicit override for the ffprobe binary path. | Unset with `HFLOW_FFMPEG` also unset: same pinned/PATH resolution as ffmpeg. Unset with `HFLOW_FFMPEG` set: the `ffprobe` sibling next to the overridden ffmpeg, falling back to PATH with a warning. | Same as `HFLOW_FFMPEG`. |
+| `HFLOW_MIRROR_DIR` | Overrides the base directory for the local mirror a bucket data root spools through. | `$XDG_CACHE_HOME/hflow/mirrors`, else `~/.cache/hflow/mirrors`. | Bucket data roots (local runs and Airflow workers) -- see [RUNTIME.md](./RUNTIME.md) and [CATALOG.md](./CATALOG.md). |
+| `HFLOW_USER_DIR` | Absolute path where a deployed Airflow worker finds `user/` (your pipeline file), for platforms that cannot mount it at the default path. | `/opt/user` | Runtime deployments only, set on the Airflow components -- see [RUNTIME.md](./RUNTIME.md#bring-your-own-airflow-hflow-deploy) and the generated `DEPLOY.md`. |
+| `HFLOW_NETWORK_TESTS` | Opts in to the real-download ffmpeg integration test. | Unset (test skipped). | Development only -- see [CONTRIBUTING.md](../CONTRIBUTING.md#tests). |
+| `HFLOW_DOCKER_TESTS` | Opts in to the Docker-based Airflow runtime integration test. | Unset (test skipped). | Development only -- see [CONTRIBUTING.md](../CONTRIBUTING.md#tests). |
+| `HFLOW_TEST_BUCKET_URL` | Live object-store URL (e.g. `gs://bucket/tmp-prefix`) that opts in to a real round-trip test against that bucket. | Unset (test skipped). | Development only, when changing `hflow.storage`. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ contracts.
 - [Catalog tables and curation API](./CATALOG.md)
 - [Runtime commands and configuration](./RUNTIME.md)
 - [Native-video provider protocol](./PROVIDERS.md)
+- [Environment variables](./ENVIRONMENT.md)
 
 ## Explanation
 


### PR DESCRIPTION
Fixes #9.

## The gap

HFlow recognizes seven `HFLOW_*` environment variables, documented across five different places with no single reference -- and `HFLOW_TEST_BUCKET_URL` wasn't documented anywhere at all (grepped `HFLOW_` under `src/` and `tests/` to enumerate authoritatively; the issue listed six, there are seven).

## Change

Adds `docs/ENVIRONMENT.md`: one table (variable, purpose, default, where it applies), linked to the existing pages that own each variable's operational detail rather than duplicating it. Linked from `docs/README.md`'s Reference section, per the documentation contract (one primary purpose per page, linked from the index).

Left the existing per-topic docs (README.md Requirements, RUNTIME.md, CATALOG.md, CONTRIBUTING.md, generated DEPLOY.md) untouched -- this page is the lookup table, not a replacement for where each variable is explained in context.

## Testing

```bash
docker run --rm -v "$PWD:/data" -w /data lycheeverse/lychee:latest --no-progress --include-fragments \
  --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' \
  --exclude-path references/mcap-spec.md \
  --exclude-path references/foxglove-CompressedVideo.proto .
# 237 Total, 0 Errors

uv run pytest -q       # 297 passed, 3 skipped; unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH)
uv run ruff check --fix
uv run ruff format
uv run ty check
```

(lychee wasn't on PATH in this sandbox; ran it via the official Docker image instead of installing.)