### PR TITLE
cli: add --api-port to hflow up

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -348,10 +348,13 @@ docker compose --file data/runtime/docker-compose.yaml logs airflow-dag-processo
 `ingest` prints the same hint (right after a fresh `up`, the DAG may still
 be parsing; retry in a few seconds).
 
-**Port 8080 is taken.** The port lives in the bundle's `.env` as `API_PORT`
-(re-renders don't change a preserved `.env`, so editing it sticks):
-`hflow down`, edit `API_PORT`, `hflow up` again. The API only ever binds
-to `127.0.0.1`, so two bundles on different ports coexist fine.
+**Port 8080 is taken.** Pick a different port up front with
+`hflow up --api-port 9090` (default: `8080`). For a bundle that already
+exists, the flag has no effect on a later `hflow up` -- an existing `.env`
+is never rewritten, so user edits survive re-renders -- so instead:
+`hflow down`, edit `API_PORT` in the bundle's `.env`, `hflow up` again. The
+API only ever binds to `127.0.0.1`, so two bundles on different ports
+coexist fine.
 
 **`up` failed partway.** Whatever started is deliberately left running: the
 state *is* the diagnosis. `hflow status` to look, `docker compose ... logs

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -157,6 +157,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="user requirements file for the task venv (default: hflow only)",
     )
+    up_parser.add_argument(
+        "--api-port",
+        type=int,
+        default=8080,
+        help="host port the Airflow API binds to (default: 8080)",
+    )
 
     deploy_parser = subparsers.add_parser(
         "deploy",
@@ -354,6 +360,7 @@ def _command_up(arguments: argparse.Namespace) -> int:
         app_variable=app_variable,
         requirements_file=arguments.requirements,
         hflow_source=hflow_source,
+        api_port=arguments.api_port,
     )
     # A bucket data root has no local directory to host the bundle: ./runtime.
     default_bundle_dir = (

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -119,6 +119,32 @@ def test_up_renders_starts_and_prints(
     assert "rendering" not in output
 
 
+def test_up_honors_api_port(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_root = tmp_path / "data"
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(data_root),
+            "--api-port",
+            "9090",
+        ]
+    )
+    assert exit_code == 0
+    bundle_dir = data_root / "runtime"
+    assert "API_PORT=9090" in (bundle_dir / ".env").read_text().splitlines()
+    output, _errors = capsys.readouterr()
+    assert "http://127.0.0.1:9090" in output
+
+
 def test_start_runtime_emits_progress_events_in_phase_order(
     compose_calls: list[list[str]],
     healthy_client: None,


### PR DESCRIPTION
Fixes #7.

## Current behavior

The runtime config already supports a custom API port -- `RuntimeConfig.api_port: int = 8080`, rendered into the bundle's `.env` as `API_PORT` -- but `hflow up` never passed it, so `docs/RUNTIME.md`'s "Port 8080 is taken" entry had to document a manual `.env`-edit workaround.

## Change

- Added `--api-port` (type `int`, default `8080`, matching `RuntimeConfig`'s own default) to the `up` subparser, forwarded into the `RuntimeConfig(...)` construction in `_command_up`.
- Updated the "Port 8080 is taken" troubleshooting entry in `docs/RUNTIME.md` to point at the flag -- while keeping the existing, still-true caveat: an existing bundle's `.env` is create-if-absent and never rewritten (so secrets and user edits survive re-renders), so `--api-port` only takes effect on a bundle's *first* render. For an already-rendered bundle, `.env` still needs a direct edit.

## Testing

New test `test_up_honors_api_port` (`tests/test_runtime_cli.py`), following the existing `test_up_renders_starts_and_prints` pattern (compose subprocess and Airflow health stubbed, no Docker): runs `hflow up --api-port 9090` and asserts the rendered bundle's `.env` contains `API_PORT=9090` and the printed summary uses `http://127.0.0.1:9090`.

```bash
uv run pytest -q       # 298 passed, 3 skipped; unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH)
uv run ruff check --fix
uv run ruff format
uv run ty check
docker run --rm -v "$PWD:/data" -w /data lycheeverse/lychee:latest --no-progress --include-fragments \
  --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' \
  --exclude-path references/mcap-spec.md \
  --exclude-path references/foxglove-CompressedVideo.proto .
# 230 Total, 0 Errors
```

(lychee wasn't on PATH in this sandbox; ran it via the official Docker image instead of installing.)