### PR TITLE
cli: add hflow curate --dry-run; fix manifest: None in the report

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -64,11 +64,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_CATALOG_DIR,
         help=f"catalog directory or object-store prefix (default: {DEFAULT_CATALOG_DIR})",
     )
-    curate_parser.add_argument(
+    curate_output_group = curate_parser.add_mutually_exclusive_group()
+    curate_output_group.add_argument(
         "--output",
         "-o",
         default="./data/manifest.parquet",
         help="manifest path or object-store URL (default: ./data/manifest.parquet)",
+    )
+    curate_output_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run the query and print row count/coverage without writing a manifest",
     )
 
     stale_parser = subparsers.add_parser(
@@ -489,7 +495,8 @@ def _command_curate(arguments: argparse.Namespace) -> int:
         return 2
     try:
         sql = arguments.sql if arguments.sql is not None else arguments.sql_file.read_text()
-        report = curate(arguments.catalog, sql, output=arguments.output)
+        output = None if arguments.dry_run else arguments.output
+        report = curate(arguments.catalog, sql, output=output)
     except (ValueError, FileNotFoundError) as error:
         print(f"curate: {error}", file=sys.stderr)
         return 2

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -74,8 +74,11 @@ class CurationReport:
     coverage: list[CheckCoverage]
 
     def summary(self) -> str:
+        manifest_label = (
+            "(not written; dry run)" if self.manifest_path is None else str(self.manifest_path)
+        )
         lines = [
-            f"manifest: {self.manifest_path} ({self.row_count} rows, "
+            f"manifest: {manifest_label} ({self.row_count} rows, "
             f"from {self.total_episodes} cataloged episodes)"
         ]
         lines.append("coverage (episodes each check ran on):")

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -274,6 +274,42 @@ def test_cli_curate_requires_exactly_one_sql_source(tmp_path: Path) -> None:
     assert cli_main(["curate", "--catalog", str(tmp_path)]) == 2
 
 
+def test_cli_curate_dry_run_prints_without_writing(
+    recorded_data_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = cli_main(
+        [
+            "curate",
+            "SELECT episode_id, task FROM episodes WHERE status != 'quarantined'",
+            "--catalog",
+            str(recorded_data_root / "catalog"),
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    printed = capsys.readouterr().out
+    assert "1 rows" in printed
+    assert "coverage" in printed
+    assert "manifest: (not written; dry run)" in printed
+    assert "None" not in printed
+
+
+def test_cli_curate_rejects_dry_run_with_output(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        cli_main(
+            [
+                "curate",
+                "SELECT 1",
+                "--catalog",
+                str(tmp_path),
+                "--dry-run",
+                "--output",
+                str(tmp_path / "manifest.parquet"),
+            ]
+        )
+    assert exit_info.value.code == 2
+
+
 def test_stale_episodes_lists_only_episodes_behind_the_current_versions(tmp_path: Path) -> None:
     catalog = Catalog(tmp_path / "catalog")
     stale_stamps = FAKE_STAMPS


### PR DESCRIPTION
Fixes #8.

## Two related rough edges

1. **The library supports dry runs, the CLI couldn't reach them.** `curate(...)` already documents: "With `output=None` the query still runs (row count + coverage reporting) but nothing is written." But `--output` always defaulted to `./data/manifest.parquet` with no way to opt out.
2. **The report rendered the `None` case badly.** `CurationReport.summary()` printed the literal `manifest: None (12 rows, from 40 cataloged episodes)` when no manifest was written.

## Change

- Added `--dry-run` to the `curate` subparser, in a mutually exclusive group with `--output` (`add_mutually_exclusive_group()`, as suggested in the issue). `_command_curate` passes `output=None` to `curate()` when set.
- `CurationReport.summary()` now branches on `manifest_path is None` and renders `manifest: (not written; dry run)` instead of the `None` literal.

## Testing

Two new tests in `tests/test_catalog_curation.py`:
- `test_cli_curate_dry_run_prints_without_writing`: `hflow curate ... --dry-run` prints row count and coverage, and the summary reads `manifest: (not written; dry run)` with no literal `None` anywhere in the output.
- `test_cli_curate_rejects_dry_run_with_output`: `--dry-run --output x.parquet` together raises `SystemExit(2)` from argparse (matching the existing pattern for `--profile` in `test_ingest_rejects_unknown_profile`).

```bash
uv run pytest -q       # 299 passed, 3 skipped; unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH)
uv run ruff check --fix
uv run ruff format
uv run ty check
```