### PR TITLE
checks: add required_topics, the missing-topic QC built-in

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -368,6 +368,38 @@ def action_rate(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
     return CheckResult(measurements={"action_rate_hz": action_rate_hz})
 
 
+def required_topics(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
+    """Presence and message volume of each requested topic.
+
+    The cheapest, most common corpus-level QC question: did this rig record
+    everything it was supposed to? Presence is derived from
+    :attr:`Episode.channels` (never :meth:`Episode.channel`, which raises
+    when a topic maps to more than one channel) and summed across every
+    channel matching the topic, so a duplicated topic never raises here. A
+    topic counts as present when at least one matching channel carries a
+    message -- an empty channel is schema without a recording.
+
+    Evidence only, no verdict: the pass/fail cut belongs in curation SQL,
+    e.g.::
+
+        SELECT episode_id FROM episodes WHERE missing_topic_count > 0
+    """
+    message_counts: dict[str, int] = dict.fromkeys(topics, 0)
+    for info in episode.channels.values():
+        if info.topic in message_counts:
+            message_counts[info.topic] += info.message_count
+    measurements: dict[str, MeasurementValue] = {}
+    missing_topic_count = 0
+    for topic in topics:
+        message_count = message_counts[topic]
+        measurements[f"{topic}/present"] = message_count > 0
+        measurements[f"{topic}/message_count"] = message_count
+        if message_count == 0:
+            missing_topic_count += 1
+    measurements["missing_topic_count"] = missing_topic_count
+    return CheckResult(measurements=measurements)
+
+
 def content_digest(episode: Episode) -> CheckResult:
     """A stable digest of the episode's message content, for duplicate hunts.
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -12,6 +12,7 @@ from hflow.checks import (
     episode_duration,
     idle_fraction,
     joint_discontinuity,
+    required_topics,
     timestamp_regularity,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
@@ -128,6 +129,29 @@ def test_action_rate_matches_the_synthesized_rate(jittery_episode: hflow.Episode
     assert isinstance(action_rate_hz, float)
     # the synthetic joint stream runs at 100 Hz by SyntheticEpisodeSpec default
     assert action_rate_hz == pytest.approx(100.0, abs=0.5)
+
+
+def test_required_topics_all_present(jittery_episode: hflow.Episode) -> None:
+    result = required_topics(
+        jittery_episode, topics=["/joint_states", "/wrist_cam/compressed"]
+    ).measurements
+    assert result["/joint_states/present"] is True
+    assert result["/wrist_cam/compressed/present"] is True
+    joint_states_count = result["/joint_states/message_count"]
+    wrist_cam_count = result["/wrist_cam/compressed/message_count"]
+    assert isinstance(joint_states_count, int) and joint_states_count > 0
+    assert isinstance(wrist_cam_count, int) and wrist_cam_count > 0
+    assert result["missing_topic_count"] == 0
+
+
+def test_required_topics_reports_a_missing_topic(jittery_episode: hflow.Episode) -> None:
+    result = required_topics(
+        jittery_episode, topics=["/joint_states", "/no_such_topic"]
+    ).measurements
+    assert result["/joint_states/present"] is True
+    assert result["/no_such_topic/present"] is False
+    assert result["/no_such_topic/message_count"] == 0
+    assert result["missing_topic_count"] == 1
 
 
 def test_content_digest_identifies_duplicate_content(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #6.

## What was missing

`src/hflow/checks.py` ships built-in checks for timestamps, joints, cameras, idle segments, duration, and digest -- but nothing answered the cheapest and most common corpus-level QC question: did this rig record every topic it was supposed to?

## Change

Added `required_topics(episode, *, topics)`, following `episode_duration`'s evidence-only shape (docstring pointing at the curation query where the pass/fail policy lives, no verdict). For each requested topic, records:

- `f"{topic}/present"` -- boolean
- `f"{topic}/message_count"` -- int

plus a `missing_topic_count` summary.

Presence is derived from `Episode.channels` (`dict[int, TopicInfo]`), summed across every channel whose `topic` matches -- never `Episode.channel()`, which explicitly raises `ValueError` when a topic maps to more than one channel (`episode.py`'s `_resolve_channel_info`). A topic counts present when the summed message count is > 0 (an empty channel is schema without a recording, matching `episode_duration`'s own `message_count >= 1` presence convention).

No `__all__` to update -- `checks.py` has none; the module is imported and used as `hflow.checks.<name>`, same as every sibling.

## Testing

Two new tests in `tests/test_checks.py`, using the existing module-scoped `jittery_episode` synthetic fixture:
- `test_required_topics_all_present`: `/joint_states` and `/wrist_cam/compressed` both present with positive message counts, `missing_topic_count == 0`.
- `test_required_topics_reports_a_missing_topic`: a topic name not in the file reports `present=False`, `message_count=0`, and `missing_topic_count == 1`, alongside a genuinely present topic.

```bash
uv run pytest -q       # 299 passed, 3 skipped; unrelated: tests/test_ffmpeg.py fails/errors in this sandbox (no ffmpeg/ffprobe on PATH)
uv run ruff check --fix
uv run ruff format
uv run ty check
```