### PR TITLE
docs: document runtime global and deploy flags

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -26,6 +26,14 @@ with per-task logs) instead of your terminal.
 No cloud account, no billing, no telemetry: everything below is containers on
 your machine, and the only recurring costs are disk and CPU.
 
+### Global flags
+
+The following options apply to the `hflow` command itself and must appear
+before the subcommand:
+
+- `--version` prints the installed HFlow version and exits.
+- `-v`, `--verbose` enables verbose logging.
+
 ## What `up` builds: anatomy of the bundle
 
 ```bash
@@ -313,7 +321,10 @@ Cloud Composer, or self-managed), skip the Compose runtime entirely:
 hflow deploy --pipeline pipeline.py --data-root-uri s3://my-bucket/robot-data
 ```
 
-This emits plain files under `./deploy/` and calls no platform API: the same
+This emits plain files under `./deploy/` (or the directory passed with
+`--output-dir`) and calls no platform API. Use `--requirements` to provide a
+user requirements file for the task venv; it has the same meaning here as for
+`hflow up`. The output contains the same
 five ingest DAGs the Compose runtime generates (one set of templates, rendered
 against your data root and your workers' venv interpreter, overridable with
 `--venv-python`; each file is named after its dag id so synced dags/ folders


### PR DESCRIPTION
## Summary
Document the global `hflow` flags and the `deploy` options that were recently added to the CLI reference.

## Why
Resolves #72. Users can now find `--version`, `-v/--verbose`, `deploy --output-dir`, and `deploy --requirements` in `docs/RUNTIME.md`, with wording aligned to the current CLI help and behavior.

## User impact
The runtime reference is more complete and no product behavior changes.

## Validation
- `uv run python - <<'PY' ...` (asserted all four option names are documented)
- `git diff --check`
- Markdown link check not run: `lychee` is not installed in the environment.

## Unverified
The full `lychee` command from CONTRIBUTING.md was not run because the tool is unavailable locally.
