### PR TITLE
refactor: centralize nanoseconds constant

### DIFF
--- a/src/hflow/format.py
+++ b/src/hflow/format.py
@@ -41,11 +41,14 @@ EPISODE_KEY_ROBOT_SOFTWARE_VERSION = "robot_software_version"
 # download for camera-less episodes.
 FFMPEG_VERSION_NOT_USED = "not-used"
 
+# Log times, publish times, and every resampling grid are nanoseconds since
+# the epoch, so the conversion factor is shared rather than re-spelled.
+NANOSECONDS_PER_SECOND = 1_000_000_000
+
 # Version of the grid-resampling alignment policy (``hflow.resample``).
 # Multi-rate alignment is where format converters silently diverge
 # (docs/ARCHITECTURE.md, "Transform"), so the policy is explicit and
 # versioned: bump this when the grid or selection semantics change.
-NANOSECONDS_PER_SECOND = 1_000_000_000
 RESAMPLE_POLICY_VERSION = "1"
 
 # ``provenance/v1`` keys written when derived channels are present:

--- a/src/hflow/format.py
+++ b/src/hflow/format.py
@@ -45,6 +45,7 @@ FFMPEG_VERSION_NOT_USED = "not-used"
 # Multi-rate alignment is where format converters silently diverge
 # (docs/ARCHITECTURE.md, "Transform"), so the policy is explicit and
 # versioned: bump this when the grid or selection semantics change.
+NANOSECONDS_PER_SECOND = 1_000_000_000
 RESAMPLE_POLICY_VERSION = "1"
 
 # ``provenance/v1`` keys written when derived channels are present:

--- a/src/hflow/resample.py
+++ b/src/hflow/resample.py
@@ -26,10 +26,10 @@ from typing import TYPE_CHECKING, Literal, assert_never
 
 import numpy as np
 
+from hflow.format import NANOSECONDS_PER_SECOND
+
 if TYPE_CHECKING:
     from hflow.episode import ChannelData
-
-NANOSECONDS_PER_SECOND = 1_000_000_000
 
 ResamplePolicy = Literal["interpolate", "nearest"]
 

--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -45,8 +45,7 @@ from pathlib import Path
 from mcap.writer import Writer
 
 from hflow.ffmpeg import ffmpeg_path
-
-NANOSECONDS_PER_SECOND = 1_000_000_000
+from hflow.format import NANOSECONDS_PER_SECOND
 
 JOINT_STATES_TOPIC = "/joint_states"
 JOINT_STATE_SCHEMA_NAME = "sensor_msgs/msg/JointState"


### PR DESCRIPTION
## Summary

Define `NANOSECONDS_PER_SECOND` once in `hflow.format` and import it from `resample` and `testing`.

Closes #63.

## Why

The identical time-unit constant was maintained in two modules. Moving it to the established shared format-constants module removes that duplication without changing behavior.

## Validation

- `uv sync --locked --all-extras` — passed.
- `uv run ruff check --fix` — passed.
- `uv run ruff format` — 88 files left unchanged.
- `uv run ty check` — passed.
- `uv run pytest -q` in Debian with Python 3.11 and FFmpeg — 307 passed, 3 skipped.
- `rg -n "NANOSECONDS_PER_SECOND = " src/hflow/` — exactly one definition.

## Checklist

- [x] N/A — no business logic changed; the full existing test suite covers the moved imports.
- [x] N/A — no behavior, flags, formats, or requirements changed.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
