### PR TITLE
examples/egocentric: fail loudly, not with a raw traceback, when hf is missing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,9 +53,11 @@ Code: [`openai_vision/pipeline.py`](./openai_vision/pipeline.py)
 download, declared fault injection, local processing, Airflow scheduling,
 inspection with Foxglove and DuckDB, and SQL curation.
 
-**Prerequisites:** accepted Hugging Face dataset terms, `hf` authentication,
-network access, and about 2.5 GB of disk (a ~1 GB pinned download plus the
-generated corpus). Docker is needed only for the Airflow path.
+**Prerequisites:** accepted Hugging Face dataset terms, the `hf` CLI
+authenticated (`uv tool install -U huggingface_hub`, then
+`hf auth login`), network access, and about 2.5 GB of disk (a ~1 GB pinned
+download plus the generated corpus). Docker is needed only for the Airflow
+path.
 
 ```bash
 uv run python examples/egocentric/prepare.py

--- a/examples/egocentric/README.md
+++ b/examples/egocentric/README.md
@@ -27,8 +27,9 @@ declared data you can edit (see [inject your own faults](#inject-your-own-faults
 
 ## Prerequisites
 
-- A Hugging Face account that has accepted the dataset's access terms, and an
-  authenticated `hf` CLI (`hf auth login`).
+- A Hugging Face account that has accepted the dataset's access terms, and the
+  `hf` CLI, authenticated: `uv tool install -U huggingface_hub` then
+  `hf auth login`.
 - Network access and disk: a ~1 GB download, about 2.5 GB total once the
   sources are extracted and the 96 episodes (~640 MB) are written.
 - Docker with Compose v2 (only for the [Airflow path](#run-it-under-airflow)).

--- a/examples/egocentric/prepare.py
+++ b/examples/egocentric/prepare.py
@@ -307,6 +307,12 @@ def _ensure_source_archive(manifest: CorpusManifest, data_root: Path) -> Path:
     download_root = data_root / "huggingface"
     archive_path = download_root / manifest.archive.path
     if not archive_path.is_file():
+        if shutil.which("hf") is None:
+            raise RuntimeError(
+                "the `hf` CLI is required to download this dataset but is not on PATH. "
+                "Install it with `uv tool install -U huggingface_hub`, then "
+                "`hf auth login`."
+            )
         command = [
             "hf",
             "download",


### PR DESCRIPTION
## The gap

Following the egocentric example's README exactly from a clean environment:

```bash
uv sync --locked --all-extras
uv run python examples/egocentric/prepare.py
```

crashes with an uncaught `FileNotFoundError: [Errno 2] No such file or directory: 'hf'`.

`prepare.py` shells out to the `hf` CLI to download the pinned corpus, but that CLI is never declared as something to install: it's absent from `pyproject.toml` (main deps, extras, and the dev group), and neither `examples/README.md` nor `examples/egocentric/README.md` says how to get it -- both just say "authenticated `hf` CLI" as if it already exists on your machine.

## Fix

- `prepare.py`: check `shutil.which("hf")` before shelling out and raise the same style of friendly `RuntimeError` the code already uses for a failed download, instead of letting a bare `FileNotFoundError` traceback surface.
- Both READMEs: tell you how to actually get the CLI (`uv tool install -U huggingface_hub`, then `hf auth login`).

## Testing

Reproduced the original crash from a clean environment (no `hf` on PATH), confirmed the fix now raises a clear, actionable error instead.

Then installed and authenticated `hf` and ran the documented workflow against the real pinned corpus end to end:

```bash
uv run python examples/egocentric/prepare.py
uv run python examples/egocentric/pipeline.py data/egocentric/landing/*.mcap
uv run hflow curate --catalog data/egocentric/catalog --sql-file examples/egocentric/curate.sql --output data/egocentric/manifest.parquet
```

- Archive downloads and hashes verify against the pinned manifest.
- All 96 episodes generate, 6 with the manifest's declared faults (blackout at 14/29/44, freeze at 59/74/89).
- Pipeline: 90 `ok`, 6 `quarantined`; the three blackout episodes show `black_frame_pct` ≈ 15, and all six show `freeze_total_s` ≈ 3 -- exactly what the README describes.
- Curate: 90-row manifest, `camera_health` coverage 96/96 -- matches the README.

```bash
uv run ruff check --fix
uv run ruff format
uv run ty check
```

All pass.