### PR TITLE
testing: include offending values in validation error messages

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -557,7 +557,7 @@ class App:
         ``hflow.to_grid`` or construct a ``DerivedSeries`` directly.
         """
         if not topic:
-            raise ValueError("derived channel topic must not be empty")
+            raise ValueError(f"derived channel topic must not be empty, got {topic!r}")
 
         def register(function: DerivedFunction) -> DerivedFunction:
             if any(registered.topic == topic for registered in self.derived):

--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -202,7 +202,7 @@ def compute_check_version(
     that cannot be inspected safely.
     """
     if declared_version is not None and not declared_version:
-        raise ValueError("declared step version must not be empty")
+        raise ValueError(f"declared step version must not be empty for step {name!r}")
 
     implementation_identity = _callable_implementation_identity(
         function,

--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -343,14 +343,17 @@ def _validate_video_episode_spec(spec: VideoEpisodeSpec) -> None:
             f"got {spec.image_width}x{spec.image_height}"
         )
     if not spec.camera_name.strip():
-        raise ValueError("camera_name must not be empty")
+        raise ValueError(f"camera_name must not be empty, got {spec.camera_name!r}")
     _validate_video_fault_segment("black_segment", spec.black_segment, spec.duration_s)
     _validate_video_fault_segment("freeze_segment", spec.freeze_segment, spec.duration_s)
     if spec.black_segment is not None and spec.freeze_segment is not None:
         black_start_s, black_end_s = spec.black_segment
         freeze_start_s, freeze_end_s = spec.freeze_segment
         if max(black_start_s, freeze_start_s) < min(black_end_s, freeze_end_s):
-            raise ValueError("black_segment and freeze_segment must not overlap")
+            raise ValueError(
+                f"black_segment and freeze_segment must not overlap, "
+                f"got {spec.black_segment!r} and {spec.freeze_segment!r}"
+            )
 
 
 def _render_source_video_frames(


### PR DESCRIPTION
## What changed

Four validation errors now include the offending value(s), matching the pattern already used by every other raise in `_validate_video_episode_spec` (e.g. `source_start_s must be >= 0, got ...`):

- `src/hflow/testing.py` — `camera_name must not be empty, got {spec.camera_name!r}` (the check is `.strip()`-based, so `""` vs `"   "` is exactly the distinction the message should surface)
- `src/hflow/testing.py` — `black_segment and freeze_segment must not overlap, got {spec.black_segment!r} and {spec.freeze_segment!r}`
- `src/hflow/steps.py` — `declared step version must not be empty for step {name!r}` (the optional stretch named in the issue; `name` is in scope)
- `src/hflow/app.py` — `derived channel topic must not be empty, got {topic!r}` (optional stretch)

No test asserts these strings (per the issue), so nothing else needed updating.

## Validation

```bash
uv run ruff check src/hflow/testing.py src/hflow/steps.py src/hflow/app.py   # All checks passed!
uv run ruff format --check ...                                               # already formatted
uv run ty check                                                              # All checks passed!
uv run pytest -q                                                             # 298 passed, 3 skipped
```

`tests/test_ffmpeg.py` shows `3 failed, 6 errors` both on this branch and on clean `main` (verified in a detached worktree) — pre-existing WSL/environment ffmpeg-binary detection issues, unaffected by this change.

Fixes #65