### PR TITLE
fix(runtime): cap polling sleeps to timeout

### DIFF
--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -170,7 +170,10 @@ class AirflowClient:
                 last_status = health.summary()
             if on_poll is not None:
                 on_poll(last_status)
-            time.sleep(poll_interval_s)
+            remaining_s = deadline - time.monotonic()
+            if remaining_s <= 0:
+                break
+            time.sleep(min(poll_interval_s, remaining_s))
         raise TimeoutError(
             f"Airflow at {self.base_url} not healthy after {timeout_s:.0f}s (last: {last_status})"
         )

--- a/src/hflow/runtime/_lifecycle.py
+++ b/src/hflow/runtime/_lifecycle.py
@@ -104,7 +104,10 @@ def _wait_until_dag_registered(
         pending_dag_ids = still_pending
         if not pending_dag_ids:
             return
-        time.sleep(poll_interval_s)
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            break
+        time.sleep(min(poll_interval_s, remaining_s))
     raise TimeoutError(
         f"Airflow is healthy but the ingest DAG(s) {pending_dag_ids!r} never registered "
         f"within {timeout_s:.0f}s (last: {last_error}) -- the DAG file likely "

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -14,7 +14,7 @@ import pytest
 import hflow
 from hflow.cli import _parse_pipeline_spec, main
 from hflow.runtime import AirflowHealth, RuntimeConfig, render_bundle
-from hflow.runtime._client import AirflowClient
+from hflow.runtime._client import AirflowClient, AirflowClientError
 
 HEALTHY = AirflowHealth(
     components={
@@ -374,6 +374,39 @@ def test_start_runtime_waits_for_all_five_dags(
         "demo_pipeline_labels",
         "demo_pipeline_media",
     ]
+
+
+def test_dag_registration_poll_does_not_sleep_past_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hflow.runtime._lifecycle import _wait_until_dag_registered
+
+    class InstantlyAdvancingClock:
+        def __init__(self) -> None:
+            self.current_time_s = 0.0
+
+        def monotonic(self) -> float:
+            return self.current_time_s
+
+        def sleep(self, duration_s: float) -> None:
+            self.current_time_s += duration_s
+
+    def unavailable_dag(_self: AirflowClient, dag_id: str) -> dict[str, object]:
+        raise AirflowClientError(f"{dag_id} unavailable", status=404)
+
+    clock = InstantlyAdvancingClock()
+    monkeypatch.setattr("hflow.runtime._lifecycle.time", clock)
+    monkeypatch.setattr(AirflowClient, "dag", unavailable_dag)
+    client = AirflowClient("http://127.0.0.1:8080", "airflow", "password")
+
+    with pytest.raises(TimeoutError, match="never registered"):
+        _wait_until_dag_registered(
+            client,
+            ["demo_pipeline_ingest"],
+            timeout_s=0.3,
+            poll_interval_s=10.0,
+        )
+    assert clock.current_time_s == pytest.approx(0.3)
 
 
 def test_status_reports_health_hints_and_services(

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -209,4 +209,5 @@ def test_wait_until_healthy_times_out_with_last_status(stub_server: str) -> None
         pytest.raises(TimeoutError, match="scheduler=unhealthy"),
     ):
         monkeypatch.setattr("hflow.runtime._client.time", instantly_advancing_clock)
-        client.wait_until_healthy(timeout_s=0.3, poll_interval_s=0.1)
+        client.wait_until_healthy(timeout_s=0.3, poll_interval_s=10.0)
+    assert instantly_advancing_clock.current_time_s == pytest.approx(0.3)


### PR DESCRIPTION
## Summary

- cap Airflow health polling sleeps to the remaining timeout budget
- apply the same deadline-aware sleep to DAG registration polling
- add deterministic regression coverage for both runtime wait loops

## Root cause

Both loops checked the deadline only before polling, then always slept for the full `poll_interval_s`. When the configured interval exceeded the remaining budget, `hflow up` could exceed its timeout by nearly one full polling interval before raising.

The fix preserves the polling and error-reporting behavior while sleeping for `min(poll_interval_s, remaining_s)`.

## Verification

- `uv run pytest -q` — 308 passed, 3 skipped
- `uv run ruff check src/hflow/runtime/_client.py src/hflow/runtime/_lifecycle.py tests/test_runtime_client.py tests/test_runtime_cli.py`
- `uv run ruff format --check src/hflow/runtime/_client.py src/hflow/runtime/_lifecycle.py tests/test_runtime_client.py tests/test_runtime_cli.py`
- `uv run ty check`
