### PR TITLE
feat(cli): add stale --exit-code to gate CI on stale episodes

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -201,6 +201,17 @@ importing anything. Staleness follows the source recording, not the episode
 id: reprocessing mints a new content-addressed `episode_id`, and a source
 whose newest run already carries the current versions is not stale.
 
+Add `--exit-code` to make the command exit 1 when any stale episode is found,
+so a CI job or a pre-training checklist can fail on drift the way
+`hflow doctor` already does:
+
+```bash
+hflow stale --catalog data/catalog --pipeline pipeline.py --exit-code
+```
+
+Without the flag the command always exits 0, so existing pipes into
+`xargs hflow ingest` keep working.
+
 ### Coverage denominators
 
 Every `CurationReport` carries (and `summary()` always prints) which checks

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -98,6 +98,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--pipeline-version",
         help="compare against this pipeline_version hash directly (no pipeline import)",
     )
+    stale_parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help=(
+            "exit 1 when at least one stale episode is found (like "
+            "`git diff --exit-code`), so CI can gate on it; without this flag the "
+            "command always exits 0"
+        ),
+    )
 
     doctor_parser = subparsers.add_parser(
         "doctor",
@@ -331,6 +340,8 @@ def _command_stale(arguments: argparse.Namespace) -> int:
         + (f" / schema_version {schema_version}" if schema_version is not None else ""),
         file=sys.stderr,
     )
+    if arguments.exit_code and stale:
+        return 1
     return 0
 
 

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -386,6 +386,57 @@ def test_cli_stale_reports_a_broken_pipeline_file_instead_of_crashing(
     assert "boom at import time" in capsys.readouterr().err
 
 
+def test_cli_stale_exit_code_returns_one_when_episodes_are_behind(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog = Catalog(tmp_path / "catalog")
+    catalog.append_episode(
+        canonical_path=_fake_canonical(tmp_path),
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[],
+        source_uri="episodes-in/run_0001.mcap",
+    )
+    exit_code = cli_main(
+        [
+            "stale",
+            "--catalog",
+            str(tmp_path / "catalog"),
+            "--pipeline-version",
+            "somethingnewer",
+            "--exit-code",
+        ]
+    )
+    assert exit_code == 1
+    # The flag only changes the exit code; the pipeable URI list is unchanged.
+    assert capsys.readouterr().out.splitlines() == ["episodes-in/run_0001.mcap"]
+
+
+def test_cli_stale_exit_code_returns_zero_when_nothing_is_behind(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog = Catalog(tmp_path / "catalog")
+    catalog.append_episode(
+        canonical_path=_fake_canonical(tmp_path),
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[],
+        source_uri="episodes-in/run_0001.mcap",
+    )
+    exit_code = cli_main(
+        [
+            "stale",
+            "--catalog",
+            str(tmp_path / "catalog"),
+            "--pipeline-version",
+            FAKE_STAMPS.pipeline_version,
+            "--exit-code",
+        ]
+    )
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+
+
 def test_append_accepts_non_json_measurement_scalars(tmp_path: Path) -> None:
     """numpy scalars are user data: they must fingerprint, not crash the append."""
     import numpy as np


### PR DESCRIPTION
Closes #30.

`_command_stale` returns 0 whatever it finds, so `hflow stale` cannot fail a CI job or a pre-training checklist the way `hflow doctor` already does.

Adds `--exit-code` to the `stale` subparser, named after `git diff --exit-code`. With the flag set and at least one stale episode printed, the command returns 1. Everything else is untouched: no flag means exit 0 as before, the parse and load failure paths still return 2, and stdout stays the bare URI list, so the `xargs hflow ingest` pipe in `docs/CATALOG.md` is unaffected. Documented next to that pipe.

Tests cover both directions against the existing catalog fixtures: an episode behind the pipeline version exits 1 and still prints the URI, an up to date catalog exits 0. The default path was already covered by `test_cli_stale_prints_source_uris_for_ingest`, which asserts exit 0 on a stale catalog with no flag, so that one is the guard on the pipe.

Both new tests fail on unmodified `main` with `unrecognized arguments: --exit-code`, so they pin the behavior rather than just describing it.

### Validation

macOS, `uv sync --locked --all-extras`.

```
uv run pytest -q tests/test_catalog_curation.py -k cli_stale   4 passed
uv run pytest -q                                               301 passed, 5 failed, 6 skipped
uv run ruff check                                              clean
uv run ruff format --check                                     88 files already formatted
uv run ty check                                                clean
```

The 5 failures are all in `tests/test_ffmpeg.py` and `tests/test_run_profiles.py::test_media_stage_records_a_contact_sheet_artifact`, and they fail identically on unmodified `main` on this host. Base is 299 passed with the same 5 red, so this takes the suite to 301 and moves nothing else.