### PR TITLE
feat(cli): add up --api-port so a new bundle can pick its port

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -359,10 +359,12 @@ docker compose --file data/runtime/docker-compose.yaml logs airflow-dag-processo
 `ingest` prints the same hint (right after a fresh `up`, the DAG may still
 be parsing; retry in a few seconds).
 
-**Port 8080 is taken.** The port lives in the bundle's `.env` as `API_PORT`
-(re-renders don't change a preserved `.env`, so editing it sticks):
-`hflow down`, edit `API_PORT`, `hflow up` again. The API only ever binds
-to `127.0.0.1`, so two bundles on different ports coexist fine.
+**Port 8080 is taken.** For a bundle that does not exist yet, pass the port:
+`hflow up --api-port 9090`. For one already rendered, the `.env` on disk wins
+(re-renders never overwrite a preserved `.env`, so `--api-port` does nothing
+there and editing does stick): `hflow down`, edit `API_PORT`, `hflow up`
+again. The API only ever binds to `127.0.0.1`, so two bundles on different
+ports coexist fine.
 
 **`up` failed partway.** Whatever started is deliberately left running: the
 state *is* the diagnosis. `hflow status` to look, `docker compose ... logs

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -21,6 +21,9 @@ DEFAULT_DATA_ROOT = Path("./data")
 DEFAULT_CATALOG_DIR = "./data/catalog"
 DEFAULT_BUNDLE_DIR = DEFAULT_DATA_ROOT / "runtime"
 DEFAULT_DEPLOY_OUTPUT_DIR = Path("./deploy")
+# Mirrors RuntimeConfig.api_port; kept here so the parser can state it without
+# importing the runtime package, which `up` defers until it actually runs.
+DEFAULT_API_PORT = 8080
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -150,6 +153,17 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="where to render the bundle (default: <data-root>/runtime; ./runtime for bucket URLs)",
+    )
+    up_parser.add_argument(
+        "--api-port",
+        type=int,
+        default=DEFAULT_API_PORT,
+        help=(
+            "host port for the Airflow API, written into a new bundle's .env as "
+            f"API_PORT (default: {DEFAULT_API_PORT}). An existing .env is never "
+            "rewritten, so this only takes effect on a bundle that does not have "
+            "one yet"
+        ),
     )
     up_parser.add_argument(
         "--hflow-source",
@@ -365,6 +379,7 @@ def _command_up(arguments: argparse.Namespace) -> int:
         app_variable=app_variable,
         requirements_file=arguments.requirements,
         hflow_source=hflow_source,
+        api_port=arguments.api_port,
     )
     # A bucket data root has no local directory to host the bundle: ./runtime.
     default_bundle_dir = (

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -226,6 +226,82 @@ def test_up_honors_bundle_dir_and_hflow_source(
     assert compose_calls[0][0] == str(bundle_dir / "docker-compose.yaml")
 
 
+def test_up_api_port_reaches_the_rendered_env(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    """--api-port is the whole point: it has to land in the bundle's .env."""
+    bundle_dir = tmp_path / "runtime"
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+            "--api-port",
+            "9090",
+        ]
+    )
+    assert exit_code == 0
+    assert "API_PORT=9090" in (bundle_dir / ".env").read_text()
+
+
+def test_up_without_api_port_keeps_8080(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    """The flag is additive: omitting it has to leave existing bundles where they were."""
+    bundle_dir = tmp_path / "runtime"
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+        ]
+    )
+    assert exit_code == 0
+    assert "API_PORT=8080" in (bundle_dir / ".env").read_text()
+
+
+def test_up_api_port_does_not_rewrite_a_preserved_env(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    """A second up with a different port leaves the first .env alone.
+
+    Rendering is create-if-absent so an existing .env keeps its secrets and any
+    user edits, which means --api-port only reaches a bundle that has none yet.
+    docs/RUNTIME.md says so under "Port 8080 is taken"; this is what makes that
+    true rather than a claim.
+    """
+    bundle_dir = tmp_path / "runtime"
+    common = [
+        "up",
+        "--pipeline",
+        str(pipeline_file),
+        "--data-root",
+        str(tmp_path / "data"),
+        "--bundle-dir",
+        str(bundle_dir),
+    ]
+    assert main([*common, "--api-port", "9090"]) == 0
+    assert main([*common, "--api-port", "9091"]) == 0
+    assert "API_PORT=9090" in (bundle_dir / ".env").read_text()
+
+
 def test_up_from_published_install_uses_matching_distribution(
     compose_calls: list[list[str]],
     healthy_client: None,


### PR DESCRIPTION
Closes #7.

`RuntimeConfig.api_port` already reached the bundle as `API_PORT` and `started_summary` already read it back, so the printed URL follows the port on its own. The flag was the only missing link. Adds `--api-port` to the `up` subparser and forwards it into the `RuntimeConfig(...)` in `_command_up`.

### One thing the issue did not account for

The troubleshooting entry could not just be replaced with the flag. Rendering is create-if-absent, `_bundle.py` says so directly:

```
# Report what is actually in effect: the .env on disk wins over config
# (a re-render with a changed port does not change a preserved .env).
```

and `hflow down` only runs `compose_down`, so it leaves the bundle and its `.env` on disk. `--api-port` therefore does nothing for a bundle that already exists, and the down/edit/up workaround is still the answer there. So the entry now covers both cases instead of pointing only at the flag, and the flag's own help says where it applies.

Tell me if you would rather `--api-port` overwrite a preserved `.env` when passed explicitly. That is a real change to the create-if-absent contract, since the same file holds the JWT secret and admin password, so I did not want to make that call inside a feature issue. Happy to send it as a follow-up.

I also left the port unvalidated, per the question on the issue. Nothing stops `--api-port 70000` reaching Compose today. Say the word and I will add the range check.

### Tests

Three in `tests/test_runtime_cli.py`, all through `main()` with the existing Docker stubs, so none of them need a daemon:

- `--api-port 9090` lands as `API_PORT=9090` in the rendered `.env`
- omitting it still yields `8080`, so existing bundles do not move
- a second `up` at a different port leaves the first `.env` alone, which is what makes the doc claim above true rather than asserted

The first and third fail on unmodified `main` with `unrecognized arguments: --api-port`. The second passes on both, by design: it is the guard on the unchanged path.

Nothing new was needed at the bundle layer. `test_env_created_with_config_values_and_secrets` and `test_env_preserved_on_rerender` already cover it.

### Validation

macOS, `uv sync --locked --all-extras`.

```
uv run pytest -q            305 passed, 5 failed, 6 skipped
uv run ruff check           All checks passed
uv run ruff format --check  88 files already formatted
uv run ty check             All checks passed
```

Base is 302 passed with the same 5 red, all ffmpeg and host-specific on this machine, so this adds three and moves nothing else.