### PR TITLE
fix(runtime): reject an out-of-range api_port at construction

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -405,7 +405,8 @@ docker compose --file data/runtime/docker-compose.yaml logs airflow-dag-processo
 be parsing; retry in a few seconds).
 
 **Port 8080 is taken.** For a bundle that does not exist yet, pass the port:
-`hflow up --api-port 9090`. For one already rendered, the `.env` on disk wins
+`hflow up --api-port 9090` (1 to 65535; anything outside that is refused before
+the bundle is rendered). For one already rendered, the `.env` on disk wins
 (re-renders never overwrite a preserved `.env`, so `--api-port` does nothing
 there and editing does stick): `hflow down`, edit `API_PORT`, `hflow up`
 again. The API binds to `127.0.0.1` by default (`API_BIND_HOST` in `.env`

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -491,14 +491,21 @@ def _command_up(arguments: argparse.Namespace) -> int:
     hflow_source = (
         arguments.hflow_source if arguments.hflow_source is not None else infer_hflow_source()
     )
-    config = RuntimeConfig(
-        pipeline_file=pipeline_file,
-        data_root=arguments.data_root,
-        app_variable=app_variable,
-        requirements_file=arguments.requirements,
-        hflow_source=hflow_source,
-        api_port=arguments.api_port,
-    )
+    try:
+        config = RuntimeConfig(
+            pipeline_file=pipeline_file,
+            data_root=arguments.data_root,
+            app_variable=app_variable,
+            requirements_file=arguments.requirements,
+            hflow_source=hflow_source,
+            api_port=arguments.api_port,
+        )
+    except ValueError as error:
+        # Its own block, not the start_runtime handler below: nothing has been
+        # rendered or started yet, so that handler's teardown advice would all
+        # be false.
+        print(f"up: {error}", file=sys.stderr)
+        return 2
     # A bucket data root has no local directory to host the bundle: ./runtime.
     default_bundle_dir = (
         Path(RUNTIME_BUNDLE_DIRECTORY_NAME)

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -213,9 +213,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_API_PORT,
         help=(
             "host port for the Airflow API, written into a new bundle's .env as "
-            f"API_PORT (default: {DEFAULT_API_PORT}). An existing .env is never "
-            "rewritten, so this only takes effect on a bundle that does not have "
-            "one yet"
+            f"API_PORT (default: {DEFAULT_API_PORT}, range 1-65535). An existing "
+            ".env is never rewritten, so this only takes effect on a bundle that "
+            "does not have one yet"
         ),
     )
     up_parser.add_argument(

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -92,6 +92,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_AIRFLOW_IMAGE = "apache/airflow:3.3.1"
 DEFAULT_POSTGRES_IMAGE = "postgres:16"
+# TCP port range, less port 0, which is "any free port" to bind(2) and not
+# something a published Compose port can be.
+MIN_PORT = 1
+MAX_PORT = 65535
 
 # Where a LOCAL host data root is mounted inside every runtime container; the
 # user's App must be constructed with exactly this data_root or its outputs
@@ -206,6 +210,14 @@ class RuntimeConfig:
     admin_password: str | None = None  # None: generated once into .env
     task_queue: str | None = None
     xcom_objectstorage_url: str | None = None
+
+    def __post_init__(self) -> None:
+        # A range invariant of the field, checked where the field is set, so a
+        # library caller building a RuntimeConfig directly gets the same answer
+        # as the command line. Compose reports an out-of-range port only once
+        # containers are starting, well past the point it is useful.
+        if not MIN_PORT <= self.api_port <= MAX_PORT:
+            raise ValueError(f"api_port {self.api_port!r} is not in {MIN_PORT}-{MAX_PORT}")
 
     def resolved_dag_id(self) -> str:
         if self.dag_id is not None:

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -92,8 +92,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_AIRFLOW_IMAGE = "apache/airflow:3.3.1"
 DEFAULT_POSTGRES_IMAGE = "postgres:16"
-# TCP port range, less port 0, which is "any free port" to bind(2) and not
-# something a published Compose port can be.
+# TCP port range. 0 is excluded on purpose: it means "any free port" to bind(2),
+# but this value is also interpolated into api_base_url, which the health wait
+# dials and started_summary prints, and http://127.0.0.1:0 is not dialable.
 MIN_PORT = 1
 MAX_PORT = 65535
 

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -828,7 +828,7 @@ def test_api_port_outside_the_tcp_range_is_rejected_at_construction(
     """
     from dataclasses import replace
 
-    with pytest.raises(ValueError, match=str(bad_port)):
+    with pytest.raises(ValueError, match=rf"api_port {bad_port} is not in 1-65535"):
         replace(config, api_port=bad_port)
 
 

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -815,3 +815,26 @@ class TestBucketModeBundle:
         assert environment["AWS_ACCESS_KEY_ID"] == "${AWS_ACCESS_KEY_ID}"
         assert environment["AWS_SECRET_ACCESS_KEY"] == "${AWS_SECRET_ACCESS_KEY}"
         assert "AWS_SESSION_TOKEN" not in environment
+
+
+@pytest.mark.parametrize("bad_port", [70000, 65536, 0, -1])
+def test_api_port_outside_the_tcp_range_is_rejected_at_construction(
+    config: RuntimeConfig, bad_port: int
+) -> None:
+    """The invariant belongs to the field, so it holds for library callers too.
+
+    render_bundle is never reached: Compose would otherwise be the first thing
+    to complain, long after the bundle is on disk.
+    """
+    from dataclasses import replace
+
+    with pytest.raises(ValueError, match=str(bad_port)):
+        replace(config, api_port=bad_port)
+
+
+@pytest.mark.parametrize("good_port", [1, 8080, 65535])
+def test_api_port_inside_the_tcp_range_is_accepted(config: RuntimeConfig, good_port: int) -> None:
+    """Both ends of the range are legal, so the check cannot be exclusive."""
+    from dataclasses import replace
+
+    assert replace(config, api_port=good_port).api_port == good_port

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -302,6 +302,42 @@ def test_up_api_port_does_not_rewrite_a_preserved_env(
     assert "API_PORT=9090" in (bundle_dir / ".env").read_text()
 
 
+def test_up_rejects_an_out_of_range_api_port_before_rendering(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An argument error is reported as one, and nothing is left behind.
+
+    The bundle directory staying absent is the point: validation happens
+    before render_bundle, so there is no half-made bundle and no compose call
+    to explain.
+    """
+    bundle_dir = tmp_path / "runtime"
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+            "--api-port",
+            "70000",
+        ]
+    )
+    assert exit_code == 2
+    assert not bundle_dir.exists()
+    assert compose_calls == []
+    error_output = capsys.readouterr().err
+    assert "up: api_port 70000 is not in 1-65535" in error_output
+    assert "Traceback" not in error_output
+    assert "containers may still be running" not in error_output
+
+
 def test_up_from_published_install_uses_matching_distribution(
     compose_calls: list[list[str]],
     healthy_client: None,

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -332,10 +332,43 @@ def test_up_rejects_an_out_of_range_api_port_before_rendering(
     assert exit_code == 2
     assert not bundle_dir.exists()
     assert compose_calls == []
-    error_output = capsys.readouterr().err
+    streams = capsys.readouterr()
+    assert streams.out == ""
+    error_output = streams.err
     assert "up: api_port 70000 is not in 1-65535" in error_output
     assert "Traceback" not in error_output
     assert "containers may still be running" not in error_output
+
+
+def test_up_rejects_an_out_of_range_api_port_on_an_existing_bundle(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    """The port is checked even where it could not have taken effect anyway.
+
+    An existing .env is preserved, so --api-port is inert on a bundle that
+    already has one. Validating before that is still the useful answer: the
+    alternative is accepting a port, ignoring it, and reporting success. The
+    preserved .env is left exactly as it was.
+    """
+    bundle_dir = tmp_path / "runtime"
+    common = [
+        "up",
+        "--pipeline",
+        str(pipeline_file),
+        "--data-root",
+        str(tmp_path / "data"),
+        "--bundle-dir",
+        str(bundle_dir),
+    ]
+    assert main([*common, "--api-port", "9090"]) == 0
+    calls_after_first_up = len(compose_calls)
+
+    assert main([*common, "--api-port", "70000"]) == 2
+    assert "API_PORT=9090" in (bundle_dir / ".env").read_text()
+    assert len(compose_calls) == calls_after_first_up
 
 
 def test_up_from_published_install_uses_matching_distribution(


### PR DESCRIPTION
Closes #83.

## Summary

`hflow up --api-port 70000` now exits 2 with `up: api_port 70000 is not in 1-65535` and renders nothing. Before this it exited 0 and printed `Airflow UI: http://127.0.0.1:70000` with a full bundle on disk, leaving Compose to complain later.

`RuntimeConfig.__post_init__` holds the invariant, so a library caller gets the same answer as the command line. `_command_up` catches it in its own block.

## Why

The port is not only published by Compose. It is interpolated into `api_base_url` at `_bundle.py:946`, which `start_runtime` then polls for health and `started_summary` prints. An unusable port therefore costs the full 300s wait before failing, having printed a URL nobody can open.

That is also why the range starts at 1. Port 0 means "any free port" to `bind(2)`, never to `connect(2)`. The repo's own "any free port" case already resolves 0 to a real number before construction, in `_free_port` in `tests/test_runtime_integration.py`.

The error block is separate from the `start_runtime` handler on purpose. That one returns 1 and prints teardown advice naming containers, and at this point nothing has started, so all of it would be false.

`load_bundle` still reads `API_PORT` back out of a rendered `.env` with no range check. That asymmetry is deliberate: a `.env` is stored state that survives re-renders, so validating there would break a hand-edited bundle that works today.

The render-time identifier guards are untouched, per the issue.

### One thing I did not change, so you can decide

The check is a numeric comparison, so it says nothing about type, and there are two ends to that.

A non-int `api_port` from a library caller now raises `TypeError` rather than `ValueError`, and the new handler does not catch it. That one is narrow: the field is annotated `int`, `ty` flags it, and argparse converts before `RuntimeConfig` is reached, so the command line cannot reach it.

`bool` is the more interesting half, and it predates this change. `RuntimeConfig(api_port=True)` passes the range check, because `True == 1`, and renders `API_PORT=True` into the `.env`. `ty` will not flag it either, since `bool` is a subtype of `int`. So it is wrong before and after, just never checked.

One guard closes both. I left it out because the issue asked to keep this to the port invariant, and the `bool` case is not a regression from this PR. Say the word and I will add it here or send it separately.

## Validation

macOS, `uv sync --locked --all-extras`, verified in a clean clone of this branch.

```
uv run pytest -q            372 passed, 5 failed, 6 skipped
uv run ruff check           All checks passed
uv run ruff format --check  96 files already formatted
uv run ty check             All checks passed
```

Base is 363 passed with the same 5 red, all ffmpeg and host-specific on this machine. CI is green on 3.11 and 3.14.

Six new cases, none needing Docker:

- construction rejects 70000, 65536, 0 and -1, matching the whole message rather than the bare number
- construction accepts 1, 8080 and 65535, so the range cannot quietly become exclusive
- `up --api-port 70000` exits 2 with no bundle directory, no compose call, empty stdout, no traceback, and none of the "containers may still be running" advice
- `up --api-port 70000` against a bundle that already exists also exits 2 and leaves its `.env` untouched

All six fail on `main`. The three acceptance cases pass on both, by design.

That last test covers a behavior change worth naming. A preserved `.env` wins over the flag, so `--api-port` was inert on an existing bundle and an out-of-range value used to exit 0 silently. It now fails. Refusing a port beats accepting one, ignoring it, and reporting success, but it is a change for a script that always passes the flag.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.