### PR TITLE
refactor: use format.py constants for metadata record names in testing.py

### DIFF
--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -45,7 +45,11 @@ from pathlib import Path
 from mcap.writer import Writer
 
 from hflow.ffmpeg import ffmpeg_path
-from hflow.format import NANOSECONDS_PER_SECOND
+from hflow.format import (
+    EPISODE_KEY_ROBOT_SOFTWARE_VERSION,
+    METADATA_RECORD_EPISODE,
+    NANOSECONDS_PER_SECOND,
+)
 
 JOINT_STATES_TOPIC = "/joint_states"
 JOINT_STATE_SCHEMA_NAME = "sensor_msgs/msg/JointState"
@@ -471,7 +475,7 @@ def _video_episode_metadata(spec: VideoEpisodeSpec) -> dict[str, str]:
     metadata = {
         "task": spec.task,
         "operator": spec.operator,
-        "robot_software_version": spec.robot_software_version,
+        EPISODE_KEY_ROBOT_SOFTWARE_VERSION: spec.robot_software_version,
     }
     if spec.success is not None:
         metadata["success"] = "true" if spec.success else "false"
@@ -479,7 +483,7 @@ def _video_episode_metadata(spec: VideoEpisodeSpec) -> dict[str, str]:
         "task",
         "operator",
         "success",
-        "robot_software_version",
+        EPISODE_KEY_ROBOT_SOFTWARE_VERSION,
     }
     additional_metadata_keys: set[str] = set()
     for metadata_key, metadata_value in spec.metadata:
@@ -529,7 +533,9 @@ def write_video_episode(
             message_encoding="cdr",
             schema_id=schema_id,
         )
-        writer.add_metadata(name="episode/v1", data=_video_episode_metadata(resolved_spec))
+        writer.add_metadata(
+            name=METADATA_RECORD_EPISODE, data=_video_episode_metadata(resolved_spec)
+        )
         for sequence, (log_time_ns, payload) in enumerate(camera_messages):
             writer.add_message(
                 channel_id=channel_id,
@@ -667,12 +673,12 @@ def synthesize_episode(output: Path | str, spec: SyntheticEpisodeSpec | None = N
             for topic, schema_name in channel_topics
         ]
         writer.add_metadata(
-            name="episode/v1",
+            name=METADATA_RECORD_EPISODE,
             data={
                 "task": resolved_spec.task,
                 "operator": resolved_spec.operator,
                 "success": "true" if resolved_spec.success else "false",
-                "robot_software_version": resolved_spec.robot_software_version,
+                EPISODE_KEY_ROBOT_SOFTWARE_VERSION: resolved_spec.robot_software_version,
             },
         )
         writer.add_attachment(


### PR DESCRIPTION
## What changed

`src/hflow/testing.py` spelled format-owned metadata strings by hand at five sites (`"episode/v1"` and `"robot_software_version"`). It now imports and uses the constants that own those names, `METADATA_RECORD_EPISODE` and `EPISODE_KEY_ROBOT_SOFTWARE_VERSION` from `hflow/format.py`, mirroring the pattern already used in `transform.py` (its metadata handling at `transform.py:444-446`).

Sites changed (per issue #62):
- `_video_episode_metadata`: dict key + `reserved_metadata_keys` entry
- `_write_video_episode` (video fixture): `writer.add_metadata(name=...)`
- `_write_episode_with_channels` (channel fixture): `writer.add_metadata(name=...)` + metadata dict key

Runtime behavior is unchanged — the constants hold the same strings.

## Validation (run in WSL2, since HFlow imports `fcntl` and native Windows cannot import it)

```bash
uv sync --locked --all-extras
uv run ruff check        # All checks passed!
uv run ruff format --check  # 96 files already formatted
uv run ty check          # All checks passed!
uv run pytest -q         # 371 passed, 3 skipped; 3 failed + 6 errors all in tests/test_ffmpeg.py
```

The `tests/test_ffmpeg.py` failures are environment-only on this machine (they need real `ffmpeg`/`ffprobe` binaries on PATH): I ran the same file on a clean `main` worktree and got the identical `3 failed, 18 passed, 1 skipped, 6 errors`, so they are pre-existing and unrelated to this change.

Also verified the issue's DoD grep is now empty:

```bash
rg 'name="episode/v1"|"robot_software_version"' src/hflow/testing.py   # no output
```

Fixes #62