### PR TITLE
fix(runtime): reject a non-int api_port at construction

### DIFF
--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -217,6 +217,16 @@ class RuntimeConfig:
         # library caller building a RuntimeConfig directly gets the same answer
         # as the command line. Compose reports an out-of-range port only once
         # containers are starting, well past the point it is useful.
+        #
+        # Type first, because the range test cannot do it. `isinstance` would
+        # not either: bool subclasses int, so True is 1 to a comparison and
+        # would pass the range on its way to rendering API_PORT=True. The
+        # value is only ever str()-ed from here on, so nothing downstream
+        # would object.
+        if type(self.api_port) is not int:
+            raise ValueError(
+                f"api_port must be an int, not {type(self.api_port).__name__}: {self.api_port!r}"
+            )
         if not MIN_PORT <= self.api_port <= MAX_PORT:
             raise ValueError(f"api_port {self.api_port!r} is not in {MIN_PORT}-{MAX_PORT}")
 

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -218,12 +218,20 @@ class RuntimeConfig:
         # as the command line. Compose reports an out-of-range port only once
         # containers are starting, well past the point it is useful.
         #
-        # Type first, because the range test cannot do it. `isinstance` would
-        # not either: bool subclasses int, so True is 1 to a comparison and
-        # would pass the range on its way to rendering API_PORT=True. The
-        # value is only ever str()-ed from here on, so nothing downstream
-        # would object.
-        if type(self.api_port) is not int:
+        # Type first, because the range test cannot do it. bool subclasses int,
+        # so True is 1 to a comparison and would pass the range on its way to
+        # rendering API_PORT=True. The value is only ever str()-ed from here on,
+        # so nothing downstream would object.
+        #
+        # `isinstance` and not `type(...) is int`, so an IntEnum member is
+        # accepted: it is an int by every test Python has, and CONTRIBUTING
+        # asks for typed variants over bare literals. A numpy integer is not
+        # an int and is refused. That is a narrower line than the one
+        # measurement values get in catalog.py, where non-JSON scalars are
+        # user data accommodated with a repr fingerprint rather than a crash.
+        # A config field is not user data: it is set once, rendered into a
+        # .env that is never rewritten, and interpolated into api_base_url.
+        if not isinstance(self.api_port, int) or isinstance(self.api_port, bool):
             raise ValueError(
                 f"api_port must be an int, not {type(self.api_port).__name__}: {self.api_port!r}"
             )

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -838,3 +838,35 @@ def test_api_port_inside_the_tcp_range_is_accepted(config: RuntimeConfig, good_p
     from dataclasses import replace
 
     assert replace(config, api_port=good_port).api_port == good_port
+
+
+def test_api_port_true_is_rejected_even_though_it_passes_the_range(
+    config: RuntimeConfig,
+) -> None:
+    """bool is the case the range check cannot catch.
+
+    True == 1, so the range test passes it, and the value is only ever str()-ed
+    after that. Without this it reaches the rendered .env as API_PORT=True.
+    """
+    from dataclasses import replace
+
+    with pytest.raises(ValueError, match="api_port must be an int, not bool: True"):
+        replace(config, api_port=True)
+
+
+@pytest.mark.parametrize(
+    ("bad_port", "type_name"),
+    [("8080", "str"), (8080.0, "float"), (None, "NoneType"), (True, "bool")],
+)
+def test_api_port_of_the_wrong_type_is_rejected_at_construction(
+    config: RuntimeConfig, bad_port: object, type_name: str
+) -> None:
+    """The field is annotated int, so anything else is refused where it is set.
+
+    A str used to render a working bundle by accident, since the value is only
+    str()-ed; a float rendered API_PORT=8080.0, which Compose will not take.
+    """
+    from dataclasses import replace
+
+    with pytest.raises(ValueError, match=f"api_port must be an int, not {type_name}"):
+        replace(config, api_port=bad_port)

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -847,6 +847,9 @@ def test_api_port_true_is_rejected_even_though_it_passes_the_range(
 
     True == 1, so the range test passes it, and the value is only ever str()-ed
     after that. Without this it reaches the rendered .env as API_PORT=True.
+    False is covered alongside the other wrong types below, where it is the
+    weaker case: it is 0, so the range check would reject it anyway, just with
+    the wrong reason.
     """
     from dataclasses import replace
 
@@ -856,15 +859,18 @@ def test_api_port_true_is_rejected_even_though_it_passes_the_range(
 
 @pytest.mark.parametrize(
     ("bad_port", "type_name"),
-    [("8080", "str"), (8080.0, "float"), (None, "NoneType"), (True, "bool")],
+    [("8080", "str"), (8080.0, "float"), (None, "NoneType"), (True, "bool"), (False, "bool")],
 )
 def test_api_port_of_the_wrong_type_is_rejected_at_construction(
     config: RuntimeConfig, bad_port: object, type_name: str
 ) -> None:
     """The field is annotated int, so anything else is refused where it is set.
 
-    A str used to render a working bundle by accident, since the value is only
-    str()-ed; a float rendered API_PORT=8080.0, which Compose will not take.
+    Two different prior behaviors end up here. A float passed the range check
+    and rendered API_PORT=8080.0, which Compose will not take. A str or None
+    failed the range check instead, but as a TypeError from the comparison,
+    which nothing catches: `_command_up` handles ValueError only, so it left
+    a traceback. Reporting the type first turns both into one ValueError.
     """
     from dataclasses import replace
 

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -857,6 +857,39 @@ def test_api_port_true_is_rejected_even_though_it_passes_the_range(
         replace(config, api_port=True)
 
 
+def test_api_port_accepts_an_int_enum_member(config: RuntimeConfig) -> None:
+    """An IntEnum member is an int, and CONTRIBUTING asks for typed variants.
+
+    This is why the test is `isinstance` and not `type(...) is int`. The member
+    renders as bare digits on 3.11+, so the .env it produces is identical to the
+    one a plain int produces.
+    """
+    from dataclasses import replace
+    from enum import IntEnum
+
+    class Port(IntEnum):
+        API = 9090
+
+    assert replace(config, api_port=Port.API).api_port == 9090
+
+
+def test_api_port_rejects_a_numpy_integer(config: RuntimeConfig) -> None:
+    """A numpy integer is not an int, and a config field is not user data.
+
+    catalog.py accommodates numpy scalars in measurements because those are user
+    data mid-append and a crash would cost the whole episode. api_port is set
+    once by the caller, rendered into a .env that is never rewritten, and
+    interpolated into api_base_url, so refusing it costs one line at the call
+    site and nothing downstream.
+    """
+    from dataclasses import replace
+
+    import numpy as np
+
+    with pytest.raises(ValueError, match="api_port must be an int, not int64"):
+        replace(config, api_port=np.int64(9090))
+
+
 @pytest.mark.parametrize(
     ("bad_port", "type_name"),
     [("8080", "str"), (8080.0, "float"), (None, "NoneType"), (True, "bool"), (False, "bool")],


### PR DESCRIPTION
## Summary

`RuntimeConfig(api_port=True)` no longer builds. The range check added in #84 cannot catch a bool, because `True == 1` satisfies it, and the value is only ever `str()`-ed after that, so it rendered `API_PORT=True` into the bundle and nothing downstream objected. Construction now refuses a non-int first, with the same `ValueError` the CLI already handles.

Closes #85.

## Why

The type test is `isinstance(self.api_port, int) and not isinstance(..., bool)` rather than `type(...) is int`. The issue suggested the stricter form, so here is the reasoning for the narrower one, and the precedent it follows.

An `IntEnum` member passes. It is an int by every test Python has, `ty` cannot flag it because it really is an int subclass, and it stringifies to bare digits on 3.11+, so the `.env` it renders is byte-identical to the one a plain int renders. CONTRIBUTING asks for typed variants over bare literals, so rejecting one would refuse the style the project recommends.

A numpy integer is refused. This is the half worth arguing, because `str(np.int64(8080))` is also `'8080'`, so it too would have rendered a correct bundle. `test_append_accepts_non_json_measurement_scalars` sets the opposite precedent for measurements: numpy scalars are user data arriving mid-append, and `catalog.py` fingerprints them with `default=repr` rather than crashing the whole episode over one value in a dict of many.

`api_port` is not that kind of surface. It is set once by the caller, it is rendered into a `.env` that is never rewritten, and it is interpolated into `api_base_url`, which the health wait dials and `started_summary` prints. There is no partial-success path to protect: refusing costs the caller one line at the call site and happens before anything is written, whereas accommodating means carrying a non-int through every one of those uses on the strength of `str()` alone.

`ValueError` for both halves, including the cases where `TypeError` is the more classically correct type, because `_command_up` catches `ValueError` and a `TypeError` escapes as a traceback.

Two prior behaviors collapse into this one error. A float passed the range check and rendered `API_PORT=8080.0`, which Compose will not take. A str or None failed the range check as a `TypeError` from the comparison, which nothing catches.

## Validation

```
uv run pytest tests/test_runtime_bundle.py tests/test_runtime_cli.py -q   78 passed
uv run ruff check .                                                      All checks passed!
uv run ruff format --check .                                             96 files already formatted
uv run ty check                                                          All checks passed!
```

Against unmodified `main` at f9ac687, 7 of the new tests fail:

```
FAILED test_api_port_true_is_rejected_even_though_it_passes_the_range
FAILED test_api_port_rejects_a_numpy_integer
FAILED test_api_port_of_the_wrong_type_is_rejected_at_construction[8080-str]
FAILED test_api_port_of_the_wrong_type_is_rejected_at_construction[8080.0-float]
FAILED test_api_port_of_the_wrong_type_is_rejected_at_construction[None-NoneType]
FAILED test_api_port_of_the_wrong_type_is_rejected_at_construction[True-bool]
FAILED test_api_port_of_the_wrong_type_is_rejected_at_construction[False-bool]
7 failed, 71 passed
```

`test_api_port_accepts_an_int_enum_member` passes on `main` too, since `main` has no type check at all. It is a guard rail against a later tightening, not a proof of this change.

`False` is in the wrong-type list rather than beside `True` on purpose. It is `0`, so the range check rejects it either way, just with the wrong reason.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements. No doc change: the `--help` text and RUNTIME.md already state the 1-65535 range, and no documented behavior changes for a caller who was passing an int.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.