### PR TITLE
fix(app): reject checks with required params beyond the episode at registration

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -15,6 +15,7 @@ quality outcome.
 """
 
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -296,6 +297,43 @@ class EnrichmentRunReport:
         if self.error is not None:
             return CheckStatus.ERROR
         return CheckStatus.MEASURED
+
+
+def _unsatisfiable_check_parameters(function: Callable[..., object]) -> list[str]:
+    """Names of required parameters a registered check could never receive.
+
+    At run time a check is called with exactly one argument: the canonical
+    episode (``registered.function(canonical_episode)``). A check is only
+    satisfiable if every remaining parameter is optional (has a default) or
+    is a ``*args``/``**kwargs`` sink. Parameters whose defaults the runtime
+    call cannot supply (required positional-or-keyword beyond the episode,
+    required keyword-only) would make every episode fail with a
+    ``TypeError`` that the App records as an infrastructure error at ingest
+    time. Returning their names lets registration reject them up front.
+    """
+    try:
+        parameters = inspect.signature(function).parameters.values()
+    except (TypeError, ValueError):
+        return []
+    seen_episode = False
+    unsatisfiable: list[str] = []
+    for parameter in parameters:
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            if parameter.default is not inspect.Parameter.empty:
+                continue
+            if not seen_episode:
+                seen_episode = True
+                continue
+            unsatisfiable.append(parameter.name)
+        elif (
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            and parameter.default is inspect.Parameter.empty
+        ):
+            unsatisfiable.append(parameter.name)
+    return unsatisfiable
 
 
 def _execute_enrichment(
@@ -580,6 +618,17 @@ class App:
                 raise ValueError("pass name=... when registering a callable without __name__")
             if check_name in self._registered_step_names():
                 raise ValueError(f"a step named {check_name!r} is already registered")
+            unsatisfiable = _unsatisfiable_check_parameters(function)
+            if unsatisfiable:
+                unsatisfiable_list = ", ".join(sorted(unsatisfiable))
+                raise ValueError(
+                    f"check {check_name!r} cannot be called with only an episode: "
+                    f"required parameter(s) without defaults: {unsatisfiable_list}. "
+                    "Wrap it in a function that binds them, e.g.\n\n"
+                    f"    @app.check()\n"
+                    f"    def {check_name}_check(ep: hflow.Episode) -> hflow.CheckResult:\n"
+                    f"        return {getattr(function, '__name__', check_name)}(ep, {unsatisfiable_list.split(', ')[0]}=...)\n"
+                )
             requires_set = frozenset(requires) if requires is not None else frozenset()
             self.checks.append(
                 RegisteredCheck(

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -195,6 +195,30 @@ def test_step_version_includes_captured_configuration() -> None:
     assert low_threshold_version != high_threshold_version
 
 
+def test_check_with_required_extra_parameter_fails_at_registration() -> None:
+    app = hflow.App("signature-guard", data_root=Path("/tmp"))
+
+    def requires_topics(ep: hflow.Episode, *, topics: list[str]) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"n": len(topics)})
+
+    with pytest.raises(ValueError, match="topics"):
+        app.check()(cast(hflow.steps.CheckFunction, requires_topics))
+
+    assert app.checks == []
+
+
+def test_check_with_optional_extra_parameter_registers() -> None:
+    app = hflow.App("signature-optional", data_root=Path("/tmp"))
+
+    @app.check()
+    def optional_topic(
+        ep: hflow.Episode, *, topics: tuple[str, ...] = ("/joint_states",)
+    ) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"n": len(topics)})
+
+    assert {check.name for check in app.checks} == {"optional_topic"}
+
+
 _STEP_VERSION_GLOBAL_THRESHOLD = 0.1
 
 


### PR DESCRIPTION
Fixes #86

`action_rate(episode, *, topics)` registers via `app.check()` without complaint, then fails once per episode at run time with `TypeError: missing 1 required keyword-only argument`, which App records as an infrastructure error and leaves the measurement column absent from the catalog.

**Change:** at registration, `App.check()` now inspects the function signature and rejects any required parameter beyond the single canonical episode — including required keyword-only parameters (e.g. `topics`) and required positional parameters — with a `ValueError` naming the unsatisfiable parameter(s) and showing the wrapper form:

```
check 'action_rate' cannot be called with only an episode: required parameter(s) without defaults: topics. Wrap it in a function that binds them, e.g.

    @app.check()
    def action_rate_check(ep: hflow.Episode) -> hflow.CheckResult:
        return action_rate(ep, topics=...)
```

Optional parameters (with defaults), `*args`/`**kwargs`, and episode-only checks are unaffected.

**Tests** (both in tests/test_processing_regressions.py):
- required keyword-only param → raises at registration, nothing registered
- optional keyword-only param with default → registers fine

**Validation:**
- ruff check: clean
- ruff format --check: clean
- ty check: clean
- pytest -q: 373 passed, 3 skipped; the only failures are the known pre-existing `test_ffmpeg.py` env errors (no ffmpeg binaries in WSL; identical on clean main, confirmed previously with Kingston)