### PR TITLE
examples/stress: reproducible synthetic benchmark

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,29 @@ contact-sheet artifacts for the accepted set.
 
 Guide and expected artifacts: [`egocentric/README.md`](./egocentric/README.md)
 
+## Synthetic stress corpus
+
+**Use it for:** a repeatable throughput measurement over a corpus large enough
+to be worth timing, with no download.
+
+**Prerequisites:** the normal development environment plus `ffmpeg` on `PATH`;
+no Docker, network, or API key. Two hundred episodes take a few minutes and
+about 1 GB of disk.
+
+```bash
+uv run python examples/stress/synthetic.py --episodes 200 --seed 42
+```
+
+The example plans a seeded corpus (2 to 10 s, one to three cameras at 10, 15,
+or 30 Hz, with black segments and joint jumps injected at a fixed rate), writes
+it to `./stress_corpus`, runs `App.process` over every episode, and prints the
+per-episode wall time and the distribution of check statuses. The same
+`--episodes` and `--seed` always plan the same corpus, so runs before and after
+a change are comparable. Use `--generate-only` to build a corpus without
+ingesting it, and `--ingest-only` to re-run against one you already have.
+
+Code: [`stress/synthetic.py`](./stress/synthetic.py)
+
 ## Example requirements
 
 Keep examples small enough to read, but complete enough to execute from the

--- a/examples/stress/synthetic.py
+++ b/examples/stress/synthetic.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Synthetic stress corpus generator and ingest runner for hflow."""
+
+import argparse
+import hashlib
+import random
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+from hflow.app import App
+from hflow.checks import (
+    action_rate,
+    camera_frame_stats,
+    episode_duration,
+    idle_fraction,
+    joint_discontinuity,
+    timestamp_regularity,
+)
+from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+from hflow.transform import TransformConfig, write_canonical_episode
+
+DEFAULT_EPISODES = 200
+DEFAULT_SEED = 42
+DEFAULT_OUTPUT_DIR = "./stress_corpus"
+
+CONVERTER_VERSION = "stress-synthetic-1.0"
+JOINT_STATES_TOPIC = "/joint_states"
+
+
+@dataclass(frozen=True)
+class EpisodePlan:
+    index: int
+    duration_s: float
+    num_cameras: int
+    image_hz: float
+    has_black_segment: bool
+    black_segment: tuple[float, float] | None
+    has_joint_jump: bool
+    joint_jump_at_s: float | None
+
+
+def _check_ffmpeg() -> None:
+    try:
+        subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("ERROR: ffmpeg not found. Install: sudo apt install ffmpeg", file=sys.stderr)
+        sys.exit(1)
+
+
+def _check_hflow_env() -> None:
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("hflow") is None:
+            raise ImportError
+    except ImportError:
+        print("ERROR: hflow not installed. Run `uv sync --locked --all-extras`", file=sys.stderr)
+        sys.exit(1)
+
+
+def _compute_pipeline_version() -> str:
+    return hashlib.sha256(b"stress-synthetic-1.0").hexdigest()[:12]
+
+
+def _plan_episodes(num_episodes: int, seed: int) -> list[EpisodePlan]:
+    rng = random.Random(seed)
+    plans: list[EpisodePlan] = []
+    for i in range(num_episodes):
+        duration = rng.uniform(2.0, 10.0)
+        num_cameras = rng.randint(1, 3)
+        img_hz = rng.choice([10.0, 15.0, 30.0])
+        has_black = rng.random() < 0.2
+        black_seg: tuple[float, float] | None = None
+        if rng.random() < 0.2:
+            start = rng.uniform(0.0, max(0.0, duration - 2.0))
+            end = min(start + rng.uniform(0.5, 2.0), duration)
+            black_seg = (start, end)
+        has_jump = rng.random() < 0.2
+        jump_at = rng.uniform(0.5, duration - 0.5) if rng.random() < 0.2 else None
+        img_hz = rng.choice([10.0, 15.0, 30.0])
+        plans.append(
+            EpisodePlan(i, duration, num_cameras, img_hz, has_black, black_seg, has_jump, jump_at)
+        )
+    return plans
+
+
+def generate_corpus(output_dir: Path, plans: list[EpisodePlan]) -> None:
+    # Clean up existing episode files to ensure reproducibility
+    for old_file in output_dir.glob("episode_*.mcap"):
+        old_file.unlink(missing_ok=True)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for plan in plans:
+        spec = SyntheticEpisodeSpec(
+            duration_s=plan.duration_s,
+            cameras=tuple(f"cam_{j}" for j in range(plan.num_cameras)),
+            image_hz=plan.image_hz,
+            image_width=320,
+            image_height=240,
+            joint_hz=100.0,
+            joint_count=7,
+            black_segment=plan.black_segment,
+            joint_jump_at_s=plan.joint_jump_at_s,
+            joint_jump_rad=0.8,
+            timestamp_offset_segment=None,
+            start_time_ns=1_755_000_000_000_000_000 + plan.index * 1_000_000_000_000,
+            task="stress_test",
+            operator="synthetic",
+            success=True,
+            robot_software_version="stress-1.0",
+            seed=plan.index,
+        )
+        with tempfile.NamedTemporaryFile(suffix=".mcap", delete=False) as tmp:
+            input_mcap = Path(tmp.name)
+        try:
+            synthesize_episode(input_mcap, spec)
+            output_path = output_dir / f"episode_{plan.index:06d}.mcap"
+            write_canonical_episode(
+                input_mcap,
+                output_path,
+                TransformConfig(),
+                source_uri=f"stress://synthetic/ep_{plan.index:04d}",
+            )
+        finally:
+            input_mcap.unlink(missing_ok=True)
+        if (plan.index + 1) % 10 == 0:
+            print(f"generated {plan.index + 1}/{len(plans)} episodes")
+
+
+def run_ingest(corpus_dir: Path, data_root: Path) -> list[dict]:
+    import hflow as hflow_module
+
+    app = App("stress-test", data_root=data_root)
+    app.check()(timestamp_regularity)
+    app.check()(joint_discontinuity)
+    app.check()(camera_frame_stats)
+    app.check()(idle_fraction)
+    app.check()(episode_duration)
+
+    @app.check(name="action_rate_check")
+    def action_rate_check(ep: hflow_module.Episode) -> hflow_module.CheckResult:
+        return action_rate(ep, topics=["/joint_states"])
+
+    mcap_files = sorted(corpus_dir.glob("episode_*.mcap"))
+    print(f"Found {len(mcap_files)} episodes to ingest")
+
+    results: list[dict] = []
+    for i, mcap in enumerate(mcap_files):
+        ep_start = time.perf_counter()
+        ep_index = int(mcap.stem.split("_")[-1])
+        print(f"Processing {i + 1}/{len(mcap_files)}: {mcap.name}")
+        try:
+            report = app.process(str(mcap), record=True)
+            ep_duration = time.perf_counter() - ep_start
+            check_statuses = {run.check.name: run.status.name for run in report.checks}
+            results.append(
+                {
+                    "episode_index": ep_index,
+                    "duration_s": ep_duration,
+                    "status": "OK",
+                    "check_statuses": dict(check_statuses),
+                }
+            )
+            print(f"  OK: {ep_duration:.2f}s")
+        except Exception as e:
+            ep_duration = time.perf_counter() - ep_start
+            results.append(
+                {
+                    "episode_index": ep_index,
+                    "duration_s": ep_duration,
+                    "status": "ERROR",
+                    "error": str(e),
+                }
+            )
+            print(f"  FAILED: {e}")
+    return results
+
+
+def print_summary(results: list[dict], ingest_time: float) -> None:
+    ok = sum(1 for r in results if r.get("status") == "OK")
+    err = sum(1 for r in results if r.get("status") == "ERROR")
+    total = len(results)
+    avg_ms = sum(r["duration_s"] for r in results) / total * 1000 if total else 0
+    status_counts: dict[str, int] = {}
+    for r in results:
+        for s in r.get("check_statuses", {}).values():
+            status_counts[s] = status_counts.get(s, 0) + 1
+
+    print("\n" + "=" * 60)
+    print("STRESS TEST SUMMARY")
+    print("=" * 60)
+    print(f"Episodes: {len(results)} | OK: {ok} | ERROR: {err}")
+    print(f"Total time: {ingest_time:.1f}s | Avg/ep: {avg_ms:.0f}ms")
+    print("\nCheck status distribution:")
+    for k, v in sorted(status_counts.items()):
+        print(f"  {k}: {v}")
+    if any(r.get("status") == "ERROR" for r in results):
+        print("\nErrors:")
+        for r in results:
+            if r.get("status") == "ERROR":
+                print(f"  ep_{r['episode_index']:04d}: {r.get('error')}")
+    print("=" * 60)
+
+
+def _check_ffmpeg() -> None:
+    try:
+        subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("ERROR: ffmpeg not found. Install: sudo apt install ffmpeg", file=sys.stderr)
+        sys.exit(1)
+
+
+def _check_hflow_env() -> None:
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("hflow") is None:
+            raise ImportError
+    except ImportError:
+        print("ERROR: hflow not installed. Run `uv sync --locked --all-extras`", file=sys.stderr)
+        sys.exit(1)
+
+
+def _compute_pipeline_version() -> str:
+    return hashlib.sha256(b"stress-synthetic-1.0").hexdigest()[:12]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Synthetic stress corpus generator + ingest for hflow",
+    )
+    parser.add_argument("--output-dir", type=Path, default="./stress_corpus")
+    parser.add_argument("--episodes", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--generate-only", action="store_true")
+    parser.add_argument("--ingest-only", action="store_true")
+    parser.add_argument("--data-root", type=Path, default="./data")
+    args = parser.parse_args()
+
+    if args.generate_only and args.ingest_only:
+        print("ERROR: --generate-only and --ingest-only are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
+    corpus_dir = args.output_dir
+    _check_ffmpeg()
+    _check_hflow_env()
+
+    if not args.ingest_only:
+        print(f"Generating {args.episodes} episodes in {corpus_dir} (seed={args.seed})")
+        gen_start = time.perf_counter()
+        plans = _plan_episodes(args.episodes, args.seed)
+        generate_corpus(args.output_dir, plans)
+        print(f"\nGeneration complete in {time.perf_counter() - gen_start:.1f}s")
+
+    if not args.generate_only:
+        corpus_dir = args.output_dir
+        if not corpus_dir.exists():
+            print(f"ERROR: corpus directory {corpus_dir} does not exist", file=sys.stderr)
+            sys.exit(1)
+        print(f"\nIngesting episodes from {corpus_dir}")
+        ingest_start = time.perf_counter()
+        results = run_ingest(corpus_dir, args.data_root)
+        ingest_time = time.perf_counter() - ingest_start
+        print_summary(results, ingest_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/stress/synthetic.py
+++ b/examples/stress/synthetic.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
-"""Synthetic stress corpus generator and ingest runner for hflow."""
+"""Generate a seeded synthetic corpus and run the local ingest path over it.
+
+The point is a repeatable number. A given ``--episodes``/``--seed`` pair always
+plans the same corpus, so a run today and a run after a change are directly
+comparable. Nothing here is a fixture: the corpus lands under ``--output-dir``
+and the catalog under ``--data-root``, both of which are ignored trees.
+"""
 
 import argparse
-import hashlib
 import random
+import shutil
 import subprocess
 import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    pass
-
-from hflow.app import App
+import hflow
 from hflow.checks import (
     action_rate,
     camera_frame_stats,
@@ -29,79 +31,80 @@ from hflow.transform import TransformConfig, write_canonical_episode
 
 DEFAULT_EPISODES = 200
 DEFAULT_SEED = 42
-DEFAULT_OUTPUT_DIR = "./stress_corpus"
+DEFAULT_OUTPUT_DIR = Path("./stress_corpus")
+DEFAULT_DATA_ROOT = Path("./data")
 
-CONVERTER_VERSION = "stress-synthetic-1.0"
 JOINT_STATES_TOPIC = "/joint_states"
+FAULT_PROBABILITY = 0.2
+IMAGE_RATES_HZ = (10.0, 15.0, 30.0)
+EPISODE_START_TIME_NS = 1_755_000_000_000_000_000
 
 
 @dataclass(frozen=True)
 class EpisodePlan:
+    """One episode's shape, drawn from the seeded planner."""
+
     index: int
     duration_s: float
     num_cameras: int
     image_hz: float
-    has_black_segment: bool
     black_segment: tuple[float, float] | None
-    has_joint_jump: bool
     joint_jump_at_s: float | None
 
 
-def _check_ffmpeg() -> None:
+def _require_ffmpeg() -> None:
+    if shutil.which("ffmpeg") is None:
+        print(
+            "ERROR: ffmpeg not found on PATH. Install it (for example "
+            "`sudo apt install ffmpeg`) and run again.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     try:
         subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        print("ERROR: ffmpeg not found. Install: sudo apt install ffmpeg", file=sys.stderr)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"ERROR: ffmpeg is on PATH but not runnable: {exc}", file=sys.stderr)
         sys.exit(1)
-
-
-def _check_hflow_env() -> None:
-    try:
-        import importlib.util
-
-        if importlib.util.find_spec("hflow") is None:
-            raise ImportError
-    except ImportError:
-        print("ERROR: hflow not installed. Run `uv sync --locked --all-extras`", file=sys.stderr)
-        sys.exit(1)
-
-
-def _compute_pipeline_version() -> str:
-    return hashlib.sha256(b"stress-synthetic-1.0").hexdigest()[:12]
 
 
 def _plan_episodes(num_episodes: int, seed: int) -> list[EpisodePlan]:
+    """Draw the corpus plan. Same arguments in, same plan out."""
     rng = random.Random(seed)
     plans: list[EpisodePlan] = []
-    for i in range(num_episodes):
-        duration = rng.uniform(2.0, 10.0)
+    for index in range(num_episodes):
+        duration_s = rng.uniform(2.0, 10.0)
         num_cameras = rng.randint(1, 3)
-        img_hz = rng.choice([10.0, 15.0, 30.0])
-        has_black = rng.random() < 0.2
-        black_seg: tuple[float, float] | None = None
-        if rng.random() < 0.2:
-            start = rng.uniform(0.0, max(0.0, duration - 2.0))
-            end = min(start + rng.uniform(0.5, 2.0), duration)
-            black_seg = (start, end)
-        has_jump = rng.random() < 0.2
-        jump_at = rng.uniform(0.5, duration - 0.5) if rng.random() < 0.2 else None
-        img_hz = rng.choice([10.0, 15.0, 30.0])
+        image_hz = rng.choice(IMAGE_RATES_HZ)
+        black_segment: tuple[float, float] | None = None
+        if rng.random() < FAULT_PROBABILITY:
+            start = rng.uniform(0.0, max(0.0, duration_s - 2.0))
+            black_segment = (start, min(start + rng.uniform(0.5, 2.0), duration_s))
+        joint_jump_at_s = (
+            rng.uniform(0.5, duration_s - 0.5) if rng.random() < FAULT_PROBABILITY else None
+        )
         plans.append(
-            EpisodePlan(i, duration, num_cameras, img_hz, has_black, black_seg, has_jump, jump_at)
+            EpisodePlan(
+                index=index,
+                duration_s=duration_s,
+                num_cameras=num_cameras,
+                image_hz=image_hz,
+                black_segment=black_segment,
+                joint_jump_at_s=joint_jump_at_s,
+            )
         )
     return plans
 
 
 def generate_corpus(output_dir: Path, plans: list[EpisodePlan]) -> None:
-    # Clean up existing episode files to ensure reproducibility
-    for old_file in output_dir.glob("episode_*.mcap"):
-        old_file.unlink(missing_ok=True)
-
+    """Write one canonical episode per plan, replacing any previous corpus."""
     output_dir.mkdir(parents=True, exist_ok=True)
+    for stale_episode in output_dir.glob("episode_*.mcap"):
+        stale_episode.unlink(missing_ok=True)
+
     for plan in plans:
         spec = SyntheticEpisodeSpec(
             duration_s=plan.duration_s,
-            cameras=tuple(f"cam_{j}" for j in range(plan.num_cameras)),
+            cameras=tuple(f"cam_{camera}" for camera in range(plan.num_cameras)),
             image_hz=plan.image_hz,
             image_width=320,
             image_height=240,
@@ -111,7 +114,7 @@ def generate_corpus(output_dir: Path, plans: list[EpisodePlan]) -> None:
             joint_jump_at_s=plan.joint_jump_at_s,
             joint_jump_rad=0.8,
             timestamp_offset_segment=None,
-            start_time_ns=1_755_000_000_000_000_000 + plan.index * 1_000_000_000_000,
+            start_time_ns=EPISODE_START_TIME_NS + plan.index * 1_000_000_000_000,
             task="stress_test",
             operator="synthetic",
             success=True,
@@ -122,10 +125,9 @@ def generate_corpus(output_dir: Path, plans: list[EpisodePlan]) -> None:
             input_mcap = Path(tmp.name)
         try:
             synthesize_episode(input_mcap, spec)
-            output_path = output_dir / f"episode_{plan.index:06d}.mcap"
             write_canonical_episode(
                 input_mcap,
-                output_path,
+                output_dir / f"episode_{plan.index:06d}.mcap",
                 TransformConfig(),
                 source_uri=f"stress://synthetic/ep_{plan.index:04d}",
             )
@@ -136,9 +138,8 @@ def generate_corpus(output_dir: Path, plans: list[EpisodePlan]) -> None:
 
 
 def run_ingest(corpus_dir: Path, data_root: Path) -> list[dict]:
-    import hflow as hflow_module
-
-    app = App("stress-test", data_root=data_root)
+    """Process every episode in the corpus, timing each one."""
+    app = hflow.App("stress-test", data_root=data_root)
     app.check()(timestamp_regularity)
     app.check()(joint_discontinuity)
     app.check()(camera_frame_stats)
@@ -146,131 +147,104 @@ def run_ingest(corpus_dir: Path, data_root: Path) -> list[dict]:
     app.check()(episode_duration)
 
     @app.check(name="action_rate_check")
-    def action_rate_check(ep: hflow_module.Episode) -> hflow_module.CheckResult:
-        return action_rate(ep, topics=["/joint_states"])
+    def action_rate_check(episode: hflow.Episode) -> hflow.CheckResult:
+        return action_rate(episode, topics=[JOINT_STATES_TOPIC])
 
     mcap_files = sorted(corpus_dir.glob("episode_*.mcap"))
     print(f"Found {len(mcap_files)} episodes to ingest")
 
     results: list[dict] = []
-    for i, mcap in enumerate(mcap_files):
-        ep_start = time.perf_counter()
-        ep_index = int(mcap.stem.split("_")[-1])
-        print(f"Processing {i + 1}/{len(mcap_files)}: {mcap.name}")
+    for position, mcap in enumerate(mcap_files, start=1):
+        episode_index = int(mcap.stem.split("_")[-1])
+        print(f"Processing {position}/{len(mcap_files)}: {mcap.name}")
+        started = time.perf_counter()
         try:
             report = app.process(str(mcap), record=True)
-            ep_duration = time.perf_counter() - ep_start
-            check_statuses = {run.check.name: run.status.name for run in report.checks}
+        except Exception as exc:
+            elapsed_s = time.perf_counter() - started
             results.append(
                 {
-                    "episode_index": ep_index,
-                    "duration_s": ep_duration,
-                    "status": "OK",
-                    "check_statuses": dict(check_statuses),
-                }
-            )
-            print(f"  OK: {ep_duration:.2f}s")
-        except Exception as e:
-            ep_duration = time.perf_counter() - ep_start
-            results.append(
-                {
-                    "episode_index": ep_index,
-                    "duration_s": ep_duration,
+                    "episode_index": episode_index,
+                    "duration_s": elapsed_s,
                     "status": "ERROR",
-                    "error": str(e),
+                    "error": str(exc),
+                    "check_statuses": {},
                 }
             )
-            print(f"  FAILED: {e}")
+            print(f"  FAILED: {exc}")
+            continue
+        elapsed_s = time.perf_counter() - started
+        results.append(
+            {
+                "episode_index": episode_index,
+                "duration_s": elapsed_s,
+                "status": "OK",
+                "check_statuses": {run.check.name: run.status.name for run in report.checks},
+            }
+        )
+        print(f"  OK: {elapsed_s:.2f}s")
     return results
 
 
-def print_summary(results: list[dict], ingest_time: float) -> None:
-    ok = sum(1 for r in results if r.get("status") == "OK")
-    err = sum(1 for r in results if r.get("status") == "ERROR")
+def print_summary(results: list[dict], ingest_time_s: float) -> None:
+    """Print the per-run totals and the check status distribution."""
     total = len(results)
-    avg_ms = sum(r["duration_s"] for r in results) / total * 1000 if total else 0
+    ok = sum(1 for result in results if result["status"] == "OK")
+    errored = [result for result in results if result["status"] == "ERROR"]
+    average_ms = sum(result["duration_s"] for result in results) / total * 1000 if total else 0.0
     status_counts: dict[str, int] = {}
-    for r in results:
-        for s in r.get("check_statuses", {}).values():
-            status_counts[s] = status_counts.get(s, 0) + 1
+    for result in results:
+        for status in result["check_statuses"].values():
+            status_counts[status] = status_counts.get(status, 0) + 1
 
     print("\n" + "=" * 60)
     print("STRESS TEST SUMMARY")
     print("=" * 60)
-    print(f"Episodes: {len(results)} | OK: {ok} | ERROR: {err}")
-    print(f"Total time: {ingest_time:.1f}s | Avg/ep: {avg_ms:.0f}ms")
+    print(f"Episodes: {total} | OK: {ok} | ERROR: {len(errored)}")
+    print(f"Total time: {ingest_time_s:.1f}s | Avg/ep: {average_ms:.0f}ms")
     print("\nCheck status distribution:")
-    for k, v in sorted(status_counts.items()):
-        print(f"  {k}: {v}")
-    if any(r.get("status") == "ERROR" for r in results):
+    for status, count in sorted(status_counts.items()):
+        print(f"  {status}: {count}")
+    if errored:
         print("\nErrors:")
-        for r in results:
-            if r.get("status") == "ERROR":
-                print(f"  ep_{r['episode_index']:04d}: {r.get('error')}")
+        for result in errored:
+            print(f"  ep_{result['episode_index']:04d}: {result['error']}")
     print("=" * 60)
-
-
-def _check_ffmpeg() -> None:
-    try:
-        subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        print("ERROR: ffmpeg not found. Install: sudo apt install ffmpeg", file=sys.stderr)
-        sys.exit(1)
-
-
-def _check_hflow_env() -> None:
-    try:
-        import importlib.util
-
-        if importlib.util.find_spec("hflow") is None:
-            raise ImportError
-    except ImportError:
-        print("ERROR: hflow not installed. Run `uv sync --locked --all-extras`", file=sys.stderr)
-        sys.exit(1)
-
-
-def _compute_pipeline_version() -> str:
-    return hashlib.sha256(b"stress-synthetic-1.0").hexdigest()[:12]
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Synthetic stress corpus generator + ingest for hflow",
+        description="Generate a seeded synthetic corpus and run the local ingest path over it.",
     )
-    parser.add_argument("--output-dir", type=Path, default="./stress_corpus")
-    parser.add_argument("--episodes", type=int, default=200)
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--episodes", type=int, default=DEFAULT_EPISODES)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--data-root", type=Path, default=DEFAULT_DATA_ROOT)
     parser.add_argument("--generate-only", action="store_true")
     parser.add_argument("--ingest-only", action="store_true")
-    parser.add_argument("--data-root", type=Path, default="./data")
     args = parser.parse_args()
 
     if args.generate_only and args.ingest_only:
         print("ERROR: --generate-only and --ingest-only are mutually exclusive", file=sys.stderr)
         sys.exit(1)
 
-    corpus_dir = args.output_dir
-    _check_ffmpeg()
-    _check_hflow_env()
+    _require_ffmpeg()
 
     if not args.ingest_only:
-        print(f"Generating {args.episodes} episodes in {corpus_dir} (seed={args.seed})")
-        gen_start = time.perf_counter()
-        plans = _plan_episodes(args.episodes, args.seed)
-        generate_corpus(args.output_dir, plans)
-        print(f"\nGeneration complete in {time.perf_counter() - gen_start:.1f}s")
+        print(f"Generating {args.episodes} episodes in {args.output_dir} (seed={args.seed})")
+        generation_started = time.perf_counter()
+        generate_corpus(args.output_dir, _plan_episodes(args.episodes, args.seed))
+        print(f"\nGeneration complete in {time.perf_counter() - generation_started:.1f}s")
 
     if not args.generate_only:
-        corpus_dir = args.output_dir
-        if not corpus_dir.exists():
-            print(f"ERROR: corpus directory {corpus_dir} does not exist", file=sys.stderr)
+        if not args.output_dir.exists():
+            print(f"ERROR: corpus directory {args.output_dir} does not exist", file=sys.stderr)
             sys.exit(1)
-        print(f"\nIngesting episodes from {corpus_dir}")
-        ingest_start = time.perf_counter()
-        results = run_ingest(corpus_dir, args.data_root)
-        ingest_time = time.perf_counter() - ingest_start
-        print_summary(results, ingest_time)
+        print(f"\nIngesting episodes from {args.output_dir}")
+        ingest_started = time.perf_counter()
+        results = run_ingest(args.output_dir, args.data_root)
+        print_summary(results, time.perf_counter() - ingest_started)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

Adds a one-command reproducible stress test at `examples/stress/synthetic.py`. It generates a seeded corpus of canonical MCAP episodes (2 to 10 s, 1 to 3 cameras at 10/15/30 Hz, 20% black segments, 20% joint jumps) and runs `app.process` over them, printing wall time per episode and a check status summary at the end.

One command:

```
uv run python examples/stress/synthetic.py --episodes 200 --seed 42
```

Same seed and episode count produces the same corpus, so a run today and a run next week are directly comparable. `--generate-only` skips ingest, `--ingest-only` reuses an existing corpus.

**Why**

The stress numbers from Discussion #48 were from a script I wrote on the fly. Kingston asked for them to be reproducible ("the next stress test is one command"), and the local batch path gap (Awkward 2) was also part of what kept `action_rate` silent. This turns the anecdote into a tool.

Kept it narrow on purpose: one new file under `examples/stress/`, no changes to hflow internals, no new dependencies. The whole thing is importable by someone else's script the way `examples/egocentric/prepare.py` is. `action_rate` is registered with the wrapper form so it keeps working cleanly once #86 lands.

**Validation**

```
uv run ruff check
uv run ruff format --check
uv run ty check
uv run pytest -q
```

All clean. pytest: 298 passed, 3 skipped.

Reproducibility run:

```
uv run python examples/stress/synthetic.py --episodes 30 --seed 7
uv run python examples/stress/synthetic.py --episodes 5 --seed 99
```

First run produced 30 episodes. Second run cleaned the corpus dir and printed "Found 5 episodes to ingest", "Episodes: 5 | OK: 5 | ERROR: 0", and "MEASURED: 30" (5 episodes times 6 checks). That was the gate I wanted to pass before sending this up.

**Checklist**

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
