### PR TITLE
fix(app): reject checks that cannot accept the episode at registration

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -299,23 +299,32 @@ class EnrichmentRunReport:
         return CheckStatus.MEASURED
 
 
-def _unsatisfiable_check_parameters(function: Callable[..., object]) -> list[str]:
-    """Names of required parameters a registered check could never receive.
+def _unsatisfiable_check_parameters(
+    function: Callable[..., object],
+) -> tuple[list[str], bool]:
+    """Required parameters a registered check could never receive.
 
     At run time a check is called with exactly one argument: the canonical
     episode (``registered.function(canonical_episode)``). A check is only
-    satisfiable if every remaining parameter is optional (has a default) or
-    is a ``*args``/``**kwargs`` sink. Parameters whose defaults the runtime
-    call cannot supply (required positional-or-keyword beyond the episode,
-    required keyword-only) would make every episode fail with a
-    ``TypeError`` that the App records as an infrastructure error at ingest
-    time. Returning their names lets registration reject them up front.
+    satisfiable if it can accept that episode positionally and every other
+    parameter is optional (has a default) or is a ``*args``/``**kwargs``
+    sink. Parameters the runtime call cannot supply (required
+    positional-or-keyword beyond the episode, required keyword-only) would
+    make every episode fail with a ``TypeError`` that the App records as an
+    infrastructure error at ingest time.
+
+    Returns ``(surplus, accepts_episode)``: the names of required parameters
+    beyond the episode, and whether the signature has any slot that can
+    receive the episode positionally (a plain parameter, or ``*args``, which
+    absorbs it). ``**kwargs`` alone is not a slot: it cannot absorb a
+    positional argument.
     """
     try:
         parameters = inspect.signature(function).parameters.values()
     except (TypeError, ValueError):
-        return []
+        return [], True
     seen_episode = False
+    sees_varargs = False
     unsatisfiable: list[str] = []
     for parameter in parameters:
         if parameter.kind in (
@@ -328,12 +337,14 @@ def _unsatisfiable_check_parameters(function: Callable[..., object]) -> list[str
                 seen_episode = True
                 continue
             unsatisfiable.append(parameter.name)
+        elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            sees_varargs = True
         elif (
             parameter.kind is inspect.Parameter.KEYWORD_ONLY
             and parameter.default is inspect.Parameter.empty
         ):
             unsatisfiable.append(parameter.name)
-    return unsatisfiable
+    return unsatisfiable, seen_episode or sees_varargs
 
 
 def _execute_enrichment(
@@ -618,7 +629,7 @@ class App:
                 raise ValueError("pass name=... when registering a callable without __name__")
             if check_name in self._registered_step_names():
                 raise ValueError(f"a step named {check_name!r} is already registered")
-            unsatisfiable = _unsatisfiable_check_parameters(function)
+            unsatisfiable, accepts_episode = _unsatisfiable_check_parameters(function)
             if unsatisfiable:
                 unsatisfiable_list = ", ".join(sorted(unsatisfiable))
                 raise ValueError(
@@ -629,6 +640,15 @@ class App:
                     f"    def {check_name}_check(ep: hflow.Episode) -> hflow.CheckResult:\n"
                     f"        return {getattr(function, '__name__', check_name)}(ep, {unsatisfiable_list.split(', ')[0]}=...)\n"
                 )
+            if not accepts_episode:
+                raise ValueError(
+                    f"check {check_name!r} cannot accept the episode: it must take "
+                    "the canonical episode as its first positional parameter, e.g.\n\n"
+                    f"    @app.check()\n"
+                    f"    def {check_name}_check(ep: hflow.Episode) -> hflow.CheckResult:\n"
+                    "        ...\n"
+                )
+
             requires_set = frozenset(requires) if requires is not None else frozenset()
             self.checks.append(
                 RegisteredCheck(

--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -318,6 +318,11 @@ def _unsatisfiable_check_parameters(
     receive the episode positionally (a plain parameter, or ``*args``, which
     absorbs it). ``**kwargs`` alone is not a slot: it cannot absorb a
     positional argument.
+
+    A default on the first positional parameter does not stop it being the
+    episode's slot. ``def check(episode=None)`` is called as
+    ``check(canonical_episode)`` and the default is simply never used, so it
+    is satisfiable and must keep registering.
     """
     try:
         parameters = inspect.signature(function).parameters.values()
@@ -331,10 +336,12 @@ def _unsatisfiable_check_parameters(
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         ):
-            if parameter.default is not inspect.Parameter.empty:
-                continue
             if not seen_episode:
+                # The first positional slot takes the episode whether or not
+                # it has a default, so claim it before testing for one.
                 seen_episode = True
+                continue
+            if parameter.default is not inspect.Parameter.empty:
                 continue
             unsatisfiable.append(parameter.name)
         elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -219,6 +219,40 @@ def test_check_with_optional_extra_parameter_registers() -> None:
     assert {check.name for check in app.checks} == {"optional_topic"}
 
 
+def test_check_without_episode_parameter_fails_at_registration() -> None:
+    app = hflow.App("signature-zeroarg", data_root=Path("/tmp"))
+
+    def no_episode() -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"n": 1})
+
+    with pytest.raises(ValueError, match="cannot accept the episode"):
+        app.check()(cast(hflow.steps.CheckFunction, no_episode))
+
+    assert app.checks == []
+
+
+def test_check_with_only_kwargs_fails_at_registration() -> None:
+    app = hflow.App("signature-kwargs-only", data_root=Path("/tmp"))
+
+    def kwargs_only(**kwargs: object) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"n": len(kwargs)})
+
+    with pytest.raises(ValueError, match="cannot accept the episode"):
+        app.check()(cast(hflow.steps.CheckFunction, kwargs_only))
+
+    assert app.checks == []
+
+
+def test_check_with_varargs_registers() -> None:
+    app = hflow.App("signature-varargs", data_root=Path("/tmp"))
+
+    @app.check()
+    def varargs_check(*args: object) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"n": len(args)})
+
+    assert {check.name for check in app.checks} == {"varargs_check"}
+
+
 _STEP_VERSION_GLOBAL_THRESHOLD = 0.1
 
 

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -253,6 +253,29 @@ def test_check_with_varargs_registers() -> None:
     assert {check.name for check in app.checks} == {"varargs_check"}
 
 
+def test_check_whose_episode_parameter_has_a_default_registers_and_runs() -> None:
+    """A default on the episode parameter does not stop it receiving the episode.
+
+    The check is called as ``function(canonical_episode)``, so the default is
+    never used and the signature is satisfiable. An earlier form of the
+    accepts-the-episode test skipped every defaulted positional parameter
+    before claiming the episode's slot, which rejected this at registration
+    even though it had always worked.
+    """
+    app = hflow.App("signature-defaulted-episode", data_root=Path("/tmp"))
+
+    @app.check()
+    def defaulted_episode(episode: hflow.Episode | None = None) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"episode_arrived": episode is not None})
+
+    assert {check.name for check in app.checks} == {"defaulted_episode"}
+    # Registration is the regression, but assert it is callable the way the
+    # runtime calls it, so the test fails if the call convention ever changes.
+    assert app.checks[0].function(cast(hflow.Episode, object())).measurements == {
+        "episode_arrived": True
+    }
+
+
 _STEP_VERSION_GLOBAL_THRESHOLD = 0.1
 
 


### PR DESCRIPTION
Fixes #93

The mirror of #91: `def f()` (or `def f(**kwargs)`, `def f(*, episode)`) registers successfully and then fails once per episode with `TypeError: takes 0 positional arguments but 1 was given`, recorded as `ERROR` per episode.

**Change:** `_unsatisfiable_check_parameters` now returns `(surplus, accepts_episode)` — whether the signature has any slot that can receive the episode positionally (a plain parameter, or `*args` which absorbs it; `**kwargs` alone is not a slot). `App.check()` raises `ValueError` naming the check and stating the required signature when there is no slot.

Behavior per the issue's cases (verified):
- `def f()` -> rejected
- `def f(**kwargs)` -> rejected
- `def f(episode)`, `def f(episode, *, threshold=1.0)`, `def f(*args)` -> register
- `def f(*, episode)` -> rejected (surplus path, as noted in the issue)

**Tests added:** no-episode rejected, kwargs-only rejected, varargs registers (plus the #91 tests still pass).

**Validation:**
- ruff check: clean
- ruff format --check: clean
- ty check: clean
- pytest -q: 376 passed, 3 skipped; only pre-existing `test_ffmpeg.py` env failures (no ffmpeg binaries in WSL; identical on clean main)