### PR TITLE
fix(cli): report a missing pipeline file as bad input, not a crash

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -522,6 +522,14 @@ def _command_up(arguments: argparse.Namespace) -> int:
 
     try:
         paths, _ = start_runtime(config, bundle_dir, on_progress=print_progress_to_stderr)
+    except FileNotFoundError as error:
+        # Its own block, not the tuple below. This is raised while rendering the
+        # bundle, before any container exists, so the teardown advice attached to
+        # that handler would send the caller after containers that were never
+        # created. Same reason it exits 2 (bad input, nothing started) and not 1
+        # (started, then failed).
+        print(f"up: {error}", file=sys.stderr)
+        return 2
     except (ComposeError, TimeoutError) as error:
         # Deliberately leave whatever started running: the state is the
         # diagnosis. Tell the user how to look at it and how to tear it down.

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -58,6 +58,7 @@ extracts them to temp files):
    mass failure visible.
 """
 
+import errno
 import hashlib
 import json
 import logging
@@ -855,7 +856,9 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     bundle_directory = Path(bundle_dir)
     pipeline_source = Path(config.pipeline_file)
     if not pipeline_source.is_file():
-        raise FileNotFoundError(pipeline_source)
+        # Three-argument form, as storage.py does: str() then carries the errno
+        # text, so the CLI prints why the path failed and not just the path.
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))
 
     dags_dir = bundle_directory / "dags"
     logs_dir = bundle_directory / "logs"
@@ -889,7 +892,9 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
         if not requirements_source.is_file():
-            raise FileNotFoundError(requirements_source)
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)
+            )
         shutil.copyfile(requirements_source, user_dir / "requirements.txt")
 
     hflow_source = (

--- a/src/hflow/runtime/_deploy.py
+++ b/src/hflow/runtime/_deploy.py
@@ -29,6 +29,8 @@ spool-through-mirror boundary; workers therefore keep the processing core on
 local files without pretending bucket keys have ``pathlib.Path`` semantics.
 """
 
+import errno
+import os
 import shlex
 import shutil
 from dataclasses import dataclass
@@ -148,7 +150,7 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     output_directory = Path(output_dir)
     pipeline_source = Path(config.pipeline_file)
     if not pipeline_source.is_file():
-        raise FileNotFoundError(pipeline_source)
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))
 
     dags_dir = output_directory / "dags"
     user_dir = output_directory / "user"
@@ -163,7 +165,9 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
         if not requirements_source.is_file():
-            raise FileNotFoundError(requirements_source)
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)
+            )
         shutil.copyfile(requirements_source, user_dir / "requirements.txt")
         requirements_copied = True
 

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -441,6 +441,7 @@ def test_up_reports_a_missing_requirements_file_the_same_way(
     streams = capsys.readouterr()
     assert f"up: [Errno 2] No such file or directory: '{missing}'" in streams.err
     assert "Traceback" not in streams.err
+    assert "containers may still be running" not in streams.err
 
 
 def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
@@ -450,8 +451,11 @@ def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
     """`deploy` exited 2 already, but printed a bare path.
 
     That bare form is the #26 complaint, which was only ever fixed in
-    storage.py. Both commands now raise the three-argument FileNotFoundError,
-    so both print why the path failed.
+    storage.py. The two render functions now raise the three-argument
+    FileNotFoundError, so both commands print why the path failed. Other
+    raise sites still use a message string (load_bundle) or a bare path
+    (testing.py, storage.py:344); this pins the two that `up` and `deploy`
+    reach, not a repo-wide convention.
     """
     missing = tmp_path / "no-such-pipeline.py"
 
@@ -470,7 +474,38 @@ def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
     assert exit_code == 2
     streams = capsys.readouterr()
     assert f"deploy: [Errno 2] No such file or directory: '{missing}'" in streams.err
-    assert streams.err.strip() != f"deploy: {missing}"
+
+
+def test_deploy_missing_requirements_names_the_reason_too(
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The other raise site render_deploy_bundle owns.
+
+    Without this, reverting the requirements raise in _deploy.py alone leaves
+    the whole suite green while `deploy --requirements <missing>` goes back to
+    printing a bare path.
+    """
+    missing = tmp_path / "no-such-requirements.txt"
+
+    exit_code = main(
+        [
+            "deploy",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root-uri",
+            "s3://bucket/data",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--requirements",
+            str(missing),
+        ]
+    )
+
+    assert exit_code == 2
+    streams = capsys.readouterr()
+    assert f"deploy: [Errno 2] No such file or directory: '{missing}'" in streams.err
 
 
 def test_up_from_published_install_uses_matching_distribution(

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -371,6 +371,108 @@ def test_up_rejects_an_out_of_range_api_port_on_an_existing_bundle(
     assert len(compose_calls) == calls_after_first_up
 
 
+def test_up_reports_a_missing_pipeline_file_as_bad_input(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A path that does not exist is an argument error, not a runtime failure.
+
+    `up` used to let FileNotFoundError escape to the interpreter: a traceback
+    and exit 1. 1 means the runtime started and then failed, so the caller is
+    told containers may still be running and to tear them down. Nothing has
+    started here -- render_bundle refuses before it makes the directory -- so
+    the honest answer is 2, the same code every sibling command already returns
+    for the same input.
+    """
+    missing = tmp_path / "no-such-pipeline.py"
+    bundle_dir = tmp_path / "runtime"
+
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(missing),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+        ]
+    )
+
+    assert exit_code == 2
+    assert not bundle_dir.exists()
+    assert compose_calls == []
+    streams = capsys.readouterr()
+    assert streams.out == ""
+    # The reason, not just the path: a bare path was the complaint in #26.
+    assert f"up: [Errno 2] No such file or directory: '{missing}'" in streams.err
+    assert "Traceback" not in streams.err
+    assert "containers may still be running" not in streams.err
+
+
+def test_up_reports_a_missing_requirements_file_the_same_way(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--requirements takes the same path through render_bundle as --pipeline."""
+    missing = tmp_path / "no-such-requirements.txt"
+
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(tmp_path / "runtime"),
+            "--requirements",
+            str(missing),
+        ]
+    )
+
+    assert exit_code == 2
+    assert compose_calls == []
+    streams = capsys.readouterr()
+    assert f"up: [Errno 2] No such file or directory: '{missing}'" in streams.err
+    assert "Traceback" not in streams.err
+
+
+def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`deploy` exited 2 already, but printed a bare path.
+
+    That bare form is the #26 complaint, which was only ever fixed in
+    storage.py. Both commands now raise the three-argument FileNotFoundError,
+    so both print why the path failed.
+    """
+    missing = tmp_path / "no-such-pipeline.py"
+
+    exit_code = main(
+        [
+            "deploy",
+            "--pipeline",
+            str(missing),
+            "--data-root-uri",
+            "s3://bucket/data",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert exit_code == 2
+    streams = capsys.readouterr()
+    assert f"deploy: [Errno 2] No such file or directory: '{missing}'" in streams.err
+    assert streams.err.strip() != f"deploy: {missing}"
+
+
 def test_up_from_published_install_uses_matching_distribution(
     compose_calls: list[list[str]],
     healthy_client: None,


### PR DESCRIPTION
## Summary

`hflow up --pipeline <missing>` printed a traceback and exited 1. It now prints one line and exits 2.

```
up: [Errno 2] No such file or directory: '/tmp/definitely-missing.py'
```

Closes #90.

## Why

1 and 2 are not interchangeable here. 1 means the runtime started and then failed, so the handler that owns it prints teardown advice and the caller is told containers may still be running. A missing pipeline file fails inside `render_bundle`, before any container exists, so 1 sent a script after containers that were never created. That is why the new handler is its own `except` block rather than an addition to the `(ComposeError, TimeoutError)` tuple.

The raise sites moved to the three-argument `FileNotFoundError`, matching `storage.py:656`, so `str(error)` carries the errno text instead of a bare path. That is four sites: the pipeline and requirements checks in `_bundle.py` and the same pair in `_deploy.py`.

`deploy` needed no CLI change. `_command_deploy` already caught `FileNotFoundError` and returned 2, so fixing the raise site fixed its message too. Its old output was `deploy: /tmp/x.py`, which is the bare-path form #26 was closed for and which only `storage.py` was ever fixed for.

Two questions a reviewer would reasonably ask, answered up front.

**Can the new handler swallow a genuine runtime failure?** No. The one plausible source after containers start is a missing `docker` binary, and `_compose.py:49` already converts that into `ComposeError`. Nothing between `compose_up_detached` and the return raises `FileNotFoundError`, so the new handler only ever sees `render_bundle`.

**Does it lie about a path that exists?** Yes, in one case, and I left it. `is_file()` is False for a directory, so `hflow up --pipeline <a-directory>` now says "No such file or directory" about something that is present. The old bare-path message was not wrong so much as useless, so this is a small regression in accuracy for an input this issue does not cover. Fixing it properly means raising `IsADirectoryError`, which changes the exception type on a public API and breaks every `except FileNotFoundError` that currently catches it. That is a design call, and it belongs with the bare-versus-errno question already headed for Discussions rather than in this PR.

## Validation

```
uv run pytest -q                386 passed, 5 failed, 6 skipped
uv run ruff check .             All checks passed!
uv run ruff format --check .    97 files already formatted
uv run ty check                 All checks passed!
```

The 5 failures are `test_ffmpeg.py` and `test_run_profiles.py` on macOS. They reproduce on unmodified `ca17730` with no changes applied, so they are the local ffmpeg build and not this change.

Reverting all three source files to `origin/main` and rerunning the CLI suite:

```
FAILED test_up_reports_a_missing_pipeline_file_as_bad_input
FAILED test_up_reports_a_missing_requirements_file_the_same_way
FAILED test_deploy_missing_pipeline_names_the_reason_not_just_the_path
FAILED test_deploy_missing_requirements_names_the_reason_too
4 failed, 25 passed
```

All 29 pass with the change restored. Each of the four raise sites is pinned on its own: reverting any single one of them fails exactly one test.

Behaviour before and after, same command:

```
before:  traceback, exit 1
after:   up: [Errno 2] No such file or directory: '/tmp/definitely-missing.py'
         exit 2
```

stderr carries two lines, not one: `up: rendering the runtime bundle at <dir>` prints first, from the existing progress callback. The definition of done said one line, so flagging the difference. The error itself is one line and the narration is pre-existing behaviour on every `up`.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements. No doc change: no documented flag, format or requirement changes, and no doc states the old exit code.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.