### PR TITLE
feat(steps): derive stable identity for functools.partial steps

### DIFF
--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -8,6 +8,7 @@ on a check registered with ``critical=True``, a False verdict quarantines the
 episode (a tag, never a deletion) and skips its downstream steps.
 """
 
+import functools
 import hashlib
 import inspect
 import json
@@ -248,6 +249,12 @@ def _callable_implementation_identity(
     *,
     allow_opaque: bool = False,
 ) -> VersionIdentityValue:
+    if isinstance(function, functools.partial):
+        return {
+            "partial_func": _callable_implementation_identity(function.func),
+            "partial_args": _stable_version_identity_value(function.args),
+            "partial_keywords": _stable_version_identity_value(function.keywords),
+        }
     source_target: object = function
     if not inspect.isfunction(function) and not inspect.ismethod(function):
         source_target = type(function).__call__
@@ -288,7 +295,10 @@ def _callable_behavior_configuration(
     function: Callable[..., object],
 ) -> VersionIdentityValue:
     configuration: dict[str, VersionIdentityValue] = {}
-    if inspect.isfunction(function) or inspect.ismethod(function):
+    if isinstance(function, functools.partial):
+        configuration["partial_args"] = _stable_version_identity_value(function.args)
+        configuration["partial_keywords"] = _stable_version_identity_value(function.keywords)
+    elif inspect.isfunction(function) or inspect.ismethod(function):
         closure_variables = inspect.getclosurevars(function)
         configuration["nonlocals"] = _stable_version_identity_value(closure_variables.nonlocals)
         configuration["globals"] = _stable_version_identity_value(closure_variables.globals)

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -362,7 +362,10 @@ def test_step_version_still_refuses_a_partial_bound_to_an_opaque_value() -> None
     class OpaqueClient:
         pass
 
-    bound = functools.partial(hflow.checks.action_rate, topics=OpaqueClient())
+    def scored_by_client(episode: hflow.Episode, *, client: object) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"ok": client is not None})
+
+    bound = functools.partial(scored_by_client, client=OpaqueClient())
     with pytest.raises(ValueError, match="cannot derive a stable version identity"):
         compute_check_version("opaque", bound, False, frozenset(), None)
 

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -1,5 +1,6 @@
 """Processing, publication, and user-step boundary regressions."""
 
+import functools
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -324,6 +325,56 @@ def test_wrapper_example_binds_every_missing_parameter() -> None:
     message = str(raised.value)
     assert "threshold=..." in message
     assert "topics=..." in message
+
+
+def test_step_version_accepts_functools_partial_with_bound_args() -> None:
+    bound = functools.partial(hflow.checks.action_rate, topics=["/joint_states"])
+    version = compute_check_version("bound", bound, False, frozenset(), None)
+
+    assert version
+
+
+def test_step_version_differs_when_partial_bindings_change() -> None:
+    """Hold the name fixed, so only the binding can move the version.
+
+    The step name is part of the identity, so naming these differently would
+    pass whether or not the bound arguments were read at all.
+    """
+    topics_a = functools.partial(hflow.checks.action_rate, topics=["/joint_states"])
+    topics_b = functools.partial(hflow.checks.action_rate, topics=["/other_stream"])
+    version_a = compute_check_version("same_name", topics_a, False, frozenset(), None)
+    version_b = compute_check_version("same_name", topics_b, False, frozenset(), None)
+
+    assert version_a != version_b
+    # Stable across construction, so the identity cannot be address-derived.
+    rebuilt_a = functools.partial(hflow.checks.action_rate, topics=["/joint_states"])
+    assert compute_check_version("same_name", rebuilt_a, False, frozenset(), None) == version_a
+
+
+def test_step_version_still_refuses_a_partial_bound_to_an_opaque_value() -> None:
+    """Transparency of the wrapper does not make its contents transparent.
+
+    A partial is identifiable only because its bound values are. Bind
+    something the identity machinery cannot describe and it must keep
+    refusing, or the version silently stops tracking that value.
+    """
+
+    class OpaqueClient:
+        pass
+
+    bound = functools.partial(hflow.checks.action_rate, topics=OpaqueClient())
+    with pytest.raises(ValueError, match="cannot derive a stable version identity"):
+        compute_check_version("opaque", bound, False, frozenset(), None)
+
+
+def test_check_registration_accepts_functools_partial() -> None:
+    app = hflow.App("partial-registration", data_root=Path("/tmp"))
+    bound = functools.partial(hflow.checks.action_rate, topics=["/joint_states"])
+
+    app.check(name="bound")(bound)
+
+    assert {check.name for check in app.checks} == {"bound"}
+    assert app.checks[0].version
 
 
 _STEP_VERSION_GLOBAL_THRESHOLD = 0.1


### PR DESCRIPTION
Fixes #98

A `functools.partial` was refused as an unidentifiable opaque callable, pushing users to hand-write `version='...'` — which silently stops tracking bound-argument changes (two differently-parameterized checks share a version). A partial is fully inspectable: `func`, `args`, `keywords`.

**Change (src/hflow/steps.py):**
- `_callable_implementation_identity`: partial branch composing the wrapped callable's identity with stable values of `args` and `keywords` (dict path already sorts keys)
- `_callable_behavior_configuration`: partial branch carrying the same bound values, so binding changes alter the version
- registration guard from #86/#93 already works: `inspect.signature` resolves partials (verified: `([], True)` + registers)

**Verified:**
- the issue's exact repro (register `functools.partial(action_rate, topics=[...])`) now registers with a version
- versions differ when `topics` changes; stable across repeated calls
- tests: 3 added (partial registers, versions differ on rebinding, registration accepts partial)

**Validation:**
- ruff check: clean; ruff format --check: clean; ty check: clean
- pytest -q: 392 passed, 3 skipped; only pre-existing `test_ffmpeg.py` env failures (identical on clean main)