### PR TITLE
docs: list all opt-in test suites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,13 @@ uv run --python 3.11 --locked --all-extras pytest -q
 uv run --python 3.14 --locked --all-extras pytest -q
 ```
 
-Two integration tests are intentionally opt-in because they need network or
-Docker access:
+Three integration test suites are intentionally opt-in because they need
+network access, Docker, or a writable object-store prefix:
 
 ```bash
 HFLOW_NETWORK_TESTS=1 uv run pytest tests/test_ffmpeg.py -q
 HFLOW_DOCKER_TESTS=1 uv run pytest tests/test_runtime_integration.py -q
+HFLOW_TEST_BUCKET_URL=gs://your-bucket/tmp-prefix uv run pytest tests/test_storage.py -q
 ```
 
 Run the Docker test when changing the runtime bundle, DAG templates, REST


### PR DESCRIPTION
## Context

While reviewing HFlow's contributor setup after cloning the repository, I noticed that `CONTRIBUTING.md` described two opt-in integration suites, while `tests/test_storage.py` contains a third live object-store suite gated by `HFLOW_TEST_BUCKET_URL`.

## Change

- describe all three external dependencies: network access, Docker, and a writable object-store prefix
- add the runnable command for the live bucket suite to the existing opt-in test block

Closes #70.

## Validation

- `git diff --check` — passed
- verified the command and environment-variable gate against `TestLiveBucket` in `tests/test_storage.py`
- `lychee` was not available locally; this change adds no Markdown links

## Checklist

- [ ] I added or updated outcome-focused tests for changed business logic. (Not applicable: documentation only.)
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [ ] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`. (Not applicable to this Markdown-only change; `uv` is not installed locally.)
- [ ] I ran the relevant pytest suite. (Not applicable: no runtime behavior changed.)
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility.