### PR TITLE
refactor: remove dead quarantine state helper

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -204,18 +204,6 @@ def latest_quarantine(
     )
 
 
-def latest_quarantine_state(
-    catalog_root: "Path | str | StorageRoot", episode_id: str
-) -> bool | None:
-    """Whether ``episode_id``'s most recent cataloged run left it quarantined.
-
-    ``None`` when the catalog or the episode is unknown -- no catalog means
-    no known quarantine, and callers proceed.
-    """
-    latest = latest_quarantine(catalog_root, episode_id)
-    return None if latest is None else latest.quarantined
-
-
 def content_episode_id(canonical_path: Path) -> str:
     """Content-address an episode: sha256 of the canonical file, 16 hex chars."""
     digest = hashlib.sha256()


### PR DESCRIPTION
## Summary

While reviewing the catalog implementation for issue #64, I found that `latest_quarantine_state()` is a private wrapper with no callers, exports, tests, or documentation. This removes that dead helper and changes nothing else.

Closes #64

## Why

The richer `latest_quarantine()` result is already used by the real consumer. Keeping the unused wrapper adds an extra maintenance surface without providing an API or behavior.

## Validation

- `rg -n "latest_quarantine_state" src tests docs examples README.md` — no matches after the change
- `uv run ruff check` — passed
- `uv run ruff format --check` — passed (97 files already formatted)
- `uv run ty check` — passed
- `uv run pytest -q` — 391 passed, 6 skipped; 7 environment-dependent failures unrelated to this deletion (this macOS environment lacks `/usr/bin/ffmpeg`, Python `lzma`, and FFmpeg's `drawtext` filter)
- `git diff --check` — passed

## Checklist

- [x] No business logic changed, so no outcome-focused test is needed.
- [x] No behavior, flag, format, or requirement changed, so documentation is unchanged.
- [x] I ran Ruff formatting/lint and `ty check`.
- [x] I ran the relevant pytest suite and documented its environment-only failures above.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged.