### PR TITLE
tests: make ffmpeg override path portable

### DIFF
--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -63,9 +63,13 @@ def cleared_binary_caches() -> Iterator[None]:
     _clear_all_binary_caches()
 
 
-def test_env_override_wins(monkeypatch: pytest.MonkeyPatch, cleared_binary_caches: None) -> None:
-    monkeypatch.setenv(FFMPEG_ENV_VAR, "/usr/bin/ffmpeg")
-    assert ffmpeg_path() == Path("/usr/bin/ffmpeg")
+def test_env_override_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cleared_binary_caches: None
+) -> None:
+    override_ffmpeg = tmp_path / "ffmpeg"
+    override_ffmpeg.touch()
+    monkeypatch.setenv(FFMPEG_ENV_VAR, str(override_ffmpeg))
+    assert ffmpeg_path() == override_ffmpeg
 
 
 def test_env_override_to_missing_file_raises(


### PR DESCRIPTION
## Summary

- replace the Linux-specific `/usr/bin/ffmpeg` fixture with a real temporary file
- keep the test focused on the observable override-precedence contract
- make the regression hermetic across supported Linux and macOS development hosts

Closes #108.

## Validation

- `uv run pytest -q tests/test_ffmpeg.py::test_env_override_wins` — 1 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 99 files already formatted
- `uv run ty check` — passed
- `uv run pytest -q -k 'not test_contact_sheet_grid_geometry and not test_contact_sheet_max_tiles_sampling and not test_contact_sheet_accepts_apostrophes_in_external_paths and not test_media_stage_records_a_contact_sheet_artifact'` — 398 passed, 6 skipped, 4 deselected

The unfiltered local suite reached 398 passed and 6 skipped, with four unrelated contact-sheet failures because the installed Homebrew FFmpeg build does not provide the `drawtext` filter. The focused regression and all code-quality gates pass on macOS.

AI assistance disclosure: I used OpenAI Codex to inspect, implement, and validate this change, and reviewed the final diff and evidence.