### PR TITLE
fix(storage): raise errno FileNotFoundError at two bare sites

### DIFF
--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -341,7 +341,7 @@ class LocalStorageRoot:
         """The local file at ``relative`` (it already lives here)."""
         local_file = self.path / _validated_relative_key(relative)
         if not local_file.is_file():
-            raise FileNotFoundError(local_file)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
         return local_file
 
     def uri_for(self, relative: str) -> str:

--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -33,8 +33,10 @@ Implementation notes:
   wall-clock reads.
 """
 
+import errno
 import json
 import math
+import os
 import random
 import struct
 import subprocess
@@ -511,7 +513,7 @@ def write_video_episode(
     _validate_video_episode_spec(resolved_spec)
     source_video_path = Path(source_video)
     if not source_video_path.is_file():
-        raise FileNotFoundError(source_video_path)
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(source_video_path))
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,6 +10,7 @@ A live object-store integration test runs only when
 ``HFLOW_TEST_BUCKET_URL`` is set (e.g. ``gs://bucket/tmp-prefix``).
 """
 
+import errno
 import os
 from pathlib import Path
 
@@ -108,6 +109,16 @@ class TestLocalStorageRoot:
         assert root.fetch("landing/e.mcap") == tmp_path / "landing" / "e.mcap"
         with pytest.raises(FileNotFoundError):
             root.fetch("landing/missing.mcap")
+
+    def test_fetch_missing_has_oserror_filename(self, tmp_path: Path) -> None:
+        root = LocalStorageRoot(tmp_path)
+        missing = tmp_path / "landing" / "missing.mcap"
+        with pytest.raises(FileNotFoundError) as excinfo:
+            root.fetch("landing/missing.mcap")
+        assert excinfo.value.errno == errno.ENOENT
+        assert excinfo.value.filename == str(missing)
+        assert "No such file or directory" in str(excinfo.value)
+        assert str(missing) in str(excinfo.value)
 
     def test_publish_copies_only_when_needed(self, tmp_path: Path) -> None:
         root = LocalStorageRoot(tmp_path / "root")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,6 +5,7 @@ these tests referee the hand-encoded CDR, the ros2msg schema texts, and the
 deterministic content formulas.
 """
 
+import errno
 import hashlib
 import json
 import math
@@ -269,3 +270,13 @@ def test_video_episode_adapter_round_trip_and_faults(tmp_path: Path) -> None:
     assert decoded_frame_jpegs[1] != decoded_frame_jpegs[2]
     assert decoded_frame_jpegs[3] == decoded_frame_jpegs[4]
     assert metadata_records["episode/v1"]["source_dataset"] == "test-video"
+
+
+def test_video_episode_missing_source_names_the_path_with_errno(tmp_path: Path) -> None:
+    missing_source = tmp_path / "absent.mp4"
+    with pytest.raises(FileNotFoundError) as excinfo:
+        write_video_episode(missing_source, tmp_path / "adapted.mcap")
+    assert excinfo.value.errno == errno.ENOENT
+    assert excinfo.value.filename == str(missing_source)
+    assert "No such file or directory" in str(excinfo.value)
+    assert str(missing_source) in str(excinfo.value)


### PR DESCRIPTION
Closes #101.

Two sites still built `FileNotFoundError` with a bare path, so `str(error)` was the
path alone and `error.errno` / `error.filename` were `None`. Per the rule settled in
#100, both are cases where the path is the whole story, so both move to the
three-argument errno form.

- `LocalStorageRoot.fetch` (`storage.py:344`) now matches `fetch_uri` at
  `storage.py:656`, which already raised the errno form. Same missing object, same
  message, whichever entry point the caller used.
- `write_video_episode` (`testing.py:514`), same change.

`BucketStorageRoot.fetch` is untouched, as agreed on the issue. obstore raises there
and its text is not ours to wrap.

A test per site pins the errno text rather than just the path:
`errno == ENOENT`, `filename` set to the full path, and
`No such file or directory` present in the message. Both fail on the unfixed code
with `assert None == 2`.

Local run: `399 passed, 6 skipped`, plus 5 pre-existing failures in `test_ffmpeg.py`
and `test_run_profiles.py` that reproduce identically on unmodified main here. They
are a local ffmpeg build problem, not this change. `ruff check`, `ruff format --check`
and `ty check` are clean.

I will open #102 separately once this lands.