### PR TITLE
docs: correct OpenAI vision request count

### DIFF
--- a/docs/how-to/call-openai-vision.md
+++ b/docs/how-to/call-openai-vision.md
@@ -64,7 +64,7 @@ same file can point at a different endpoint without editing it. Inside the
 step, the endpoint remains an ordinary OpenAI SDK option:
 
 ```python
-@app.check(uses="vision")
+@app.check(uses="vision", version="responses-contact-sheet-v1")
 def describe_activity(episode: hflow.Episode) -> hflow.CheckResult:
     client = OpenAI(
         api_key=os.environ["OPENAI_API_KEY"],
@@ -92,10 +92,10 @@ uv run --extra openai python examples/openai_vision/pipeline.py
 ```
 
 Pass an MCAP path to use your own episode. The example samples frames at 0.5
-FPS, caps the request at 12 tiles, and makes one model request per episode. Those
-choices are part of the measurement definition: change them deliberately and
-version the step explicitly when external model configuration cannot be hashed
-from the function.
+FPS, caps each request at 12 tiles, and makes one model request per check: two
+requests per episode for the two checks it ships. Those choices are part of the
+measurement definition: change them deliberately and version the step explicitly
+when external model configuration cannot be hashed from the function.
 
 ## Keep model output as evidence
 


### PR DESCRIPTION
## Summary

While reviewing the current OpenAI vision how-to against its runnable example, I found two documentation mismatches. This change:

- adds the example’s explicit `version="responses-contact-sheet-v1"` to the guide’s decorator;
- clarifies that the shipped example makes one model request per check, or two per episode, while retaining the documented 0.5 FPS sampling and 12-tile cap.

## Why

The runnable example has two checks and each independently calls `client.responses.create`. Describing that as one request per episode understates API usage, while omitting `version=` conflicts with the guide’s advice to version external model configuration.

Fixes #73.

## Validation

- `git diff --check` — passed
- Repository `lychee --no-progress --include-fragments ...` command — 260 total links, 257 OK, 3 expected exclusions, 0 errors

## Checklist

- [x] No business logic changed, so an outcome-focused test is not applicable.
- [x] I updated the affected documentation.
- [x] Python formatting, typing, and pytest gates are not applicable to this Markdown-only change.
- [x] I ran the repository’s prescribed Markdown link check.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged.