### PR TITLE
refactor(server): make a refusal its own HTTP response

### DIFF
--- a/packages/hflow-server/src/hflow_server/_curation.py
+++ b/packages/hflow-server/src/hflow_server/_curation.py
@@ -173,10 +173,6 @@ def _reject_non_single_select(user_sql: str) -> None:
         )
 
 
-def _sidecar_refusal(error: _sidecar.SidecarError) -> HTTPException:
-    return HTTPException(status_code=error.status_code, detail=error.detail)
-
-
 def _browsable_relations(
     connection: duckdb.DuckDBPyConnection,
 ) -> dict[str, CatalogTableKind]:
@@ -310,23 +306,17 @@ def create_curation_router(settings: ServerSettings) -> APIRouter:
     # mutating route -- sufficient for the single-server design.
     sidecar_write_lock = threading.Lock()
 
+    # A SidecarError is already an HTTPException, so these three only bind the
+    # data root -- nothing catches and re-raises, and a refusal raised inside
+    # them reaches the client with the status and detail _sidecar chose.
     def loaded_sidecar_state() -> _sidecar.SidecarState:
-        try:
-            return _sidecar.load_sidecar_state(settings.data_root)
-        except _sidecar.SidecarError as error:
-            raise _sidecar_refusal(error) from error
+        return _sidecar.load_sidecar_state(settings.data_root)
 
     def stored_sidecar_state(state: _sidecar.SidecarState) -> None:
-        try:
-            _sidecar.store_sidecar_state(settings.data_root, state)
-        except _sidecar.SidecarError as error:
-            raise _sidecar_refusal(error) from error
+        _sidecar.store_sidecar_state(settings.data_root, state)
 
     def local_data_root_or_refuse() -> Path:
-        try:
-            return _sidecar.local_data_root(settings.data_root)
-        except _sidecar.SidecarError as error:
-            raise _sidecar_refusal(error) from error
+        return _sidecar.local_data_root(settings.data_root)
 
     @router.post("/curation/preview")
     def run_curation_preview(request: PreviewRequest) -> CurationPreviewResponse:
@@ -420,14 +410,10 @@ def create_curation_router(settings: ServerSettings) -> APIRouter:
                 status_code=404, detail=f"no pinned manifest with id {manifest_id!r}"
             )
         manifest_file = local_data_root_or_refuse() / entry.manifest_path
-        try:
-            # The same strict-resolve + containment check media serving uses:
-            # even a hand-edited registry path can only serve workspace files.
-            resolved_file = _media.resolve_served_file(
-                str(manifest_file), data_root=settings.data_root
-            )
-        except _media.MediaResolutionError as error:
-            raise _media.media_refusal(error) from error
+        # The same strict-resolve + containment check media serving uses: even
+        # a hand-edited registry path can only serve workspace files. Its
+        # refusal is already an HTTPException, so it needs no rewrapping here.
+        resolved_file = _media.resolve_served_file(str(manifest_file), data_root=settings.data_root)
         return _media.served_file_response(
             resolved_file, attachment_filename=Path(entry.manifest_path).name
         )

--- a/packages/hflow-server/src/hflow_server/_media.py
+++ b/packages/hflow-server/src/hflow_server/_media.py
@@ -68,24 +68,15 @@ _HARDENING_HEADERS = {
 }
 
 
-class MediaResolutionError(Exception):
-    """One refusal to serve a catalog URI, carrying its HTTP mapping."""
+class MediaResolutionError(HTTPException):
+    """One refusal to serve a catalog URI.
 
-    def __init__(self, status_code: int, detail: str) -> None:
-        super().__init__(detail)
-        self.status_code = status_code
-        self.detail = detail
-
-
-def media_refusal(error: MediaResolutionError) -> HTTPException:
-    """The HTTP refusal one unservable URI maps to.
-
-    Lives beside the error it converts (as ``_connections`` and ``_runtime``
-    do for theirs), so the two routes that serve catalog bytes -- episode
-    media and manifest downloads -- share one mapping instead of each copying
-    the two field reads.
+    It IS the HTTP refusal rather than something a caller converts into one:
+    raised from anywhere under a route, FastAPI renders it with the status and
+    detail given here. It stays its own type so
+    :func:`is_uri_servable` can catch media refusals specifically, without also
+    swallowing an unrelated refusal raised nearby.
     """
-    return HTTPException(status_code=error.status_code, detail=error.detail)
 
 
 def _resolved_local_data_root(data_root: str) -> Path:

--- a/packages/hflow-server/src/hflow_server/_sidecar.py
+++ b/packages/hflow-server/src/hflow_server/_sidecar.py
@@ -35,6 +35,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from fastapi import HTTPException
+
 from hflow_server._contract import CheckCoverageEntry, PinnedManifestEntry, SavedQueryEntry
 from hflow_server._settings import local_data_root_or_none
 
@@ -43,13 +45,13 @@ SIDECAR_DIRECTORY_NAME = "curation"
 SIDECAR_FILE_NAME = "state.json"
 
 
-class SidecarError(Exception):
-    """One refusal to read or write the sidecar, carrying its HTTP mapping."""
+class SidecarError(HTTPException):
+    """One refusal to read or write the sidecar.
 
-    def __init__(self, status_code: int, detail: str) -> None:
-        super().__init__(detail)
-        self.status_code = status_code
-        self.detail = detail
+    It IS the HTTP refusal rather than something the router converts into one:
+    raised from anywhere under a route, FastAPI renders it with the status and
+    detail given here.
+    """
 
 
 @dataclass(frozen=True)

--- a/packages/hflow-server/src/hflow_server/server.py
+++ b/packages/hflow-server/src/hflow_server/server.py
@@ -374,11 +374,10 @@ def _catalog_marker_readable(workspace: Workspace) -> bool:
 
 
 def _served_file_response_or_refuse(uri: str, data_root: str) -> FileResponse:
-    try:
-        resolved_file = _media.resolve_served_file(uri, data_root=data_root)
-    except _media.MediaResolutionError as error:
-        raise _media.media_refusal(error) from error
-    return _media.served_file_response(resolved_file)
+    """Bytes for one catalog URI. An unservable URI raises its own refusal
+    (a ``MediaResolutionError`` IS an ``HTTPException``), so there is nothing
+    to catch and convert here."""
+    return _media.served_file_response(_media.resolve_served_file(uri, data_root=data_root))
 
 
 def _assets_directory(settings: ServerSettings) -> Path | None:


### PR DESCRIPTION
`MediaResolutionError` and `SidecarError` subclassed plain `Exception` and carried a status and detail that something else had to convert into an `HTTPException` — two converter functions, plus a catch-and-re-raise at all six call sites that did nothing but copy two fields.

Subclassing `HTTPException` instead makes the refusal *be* the response. Raised from anywhere under a route, FastAPI renders it with the status and detail the raising module chose, so both converters and every rewrap go.

**52 deletions, 30 insertions** — 2,708 → 2,679 code lines.

They stay two types rather than collapsing into one shared refusal, because `_media.is_uri_servable` catches media refusals specifically; a single shared type would let it swallow an unrelated refusal raised nearby.

## Verification

Behaviour is unchanged and checked rather than assumed:

- The OpenAPI schema dumps **byte-identical** before and after.
- Every status assertion in the media, sidecar and pin suites still passes — 645 tests, `ruff` and `ty` clean.

## Provenance

This came out of an audit asking whether `hflow-server` earns its lines, after the question "why do we need so many files for the server". The honest answer was mostly that it does: across three independent deletion theses, each adversarially attacked with claims re-verified on a clean copy, **~1% of the code was signed off as safely deletable**, and the file count was explicitly not the problem. This is that 1%.

Two of the rejected items are worth recording, since both reviewers that proposed them had them wrong: the claim that these classes already subclassed `HTTPException` (they did not — hence the `__init__`s were load-bearing), and a claim that a committed React bundle sat in the wheel (a real bug at the time, fixed separately in #116 before this ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)