### PR TITLE
fix: use ffprobe_path() instead of hardcoded /usr/bin/ffprobe in test_video.py

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from hflow.ffmpeg import ffmpeg_path
+from hflow.ffmpeg import ffmpeg_path, ffprobe_path
 from hflow.video import (
     AccessUnit,
     VideoEncodeError,
@@ -151,9 +151,7 @@ def test_png_input_codec_upholds_guarantees(tmp_path: Path) -> None:
 
 def _ffprobe_video_stream_fields(mp4_path: Path) -> dict[str, str]:
     """Read codec/profile/decoded-frame-count fields from the first video stream."""
-    ffprobe_binary = ffmpeg_path().with_name("ffprobe")
-    if not ffprobe_binary.is_file():
-        ffprobe_binary = Path("/usr/bin/ffprobe")
+    ffprobe_binary = ffprobe_path()
     completed = subprocess.run(
         [
             str(ffprobe_binary),


### PR DESCRIPTION
Fixes #115

## Problem
tests/test_video.py reimplements ffprobe resolution with a hardcoded Linux path (/usr/bin/ffprobe) as fallback, missing the HFLOW_FFPROBE override and proper error handling from ffprobe_path().

## Solution
Replaced the manual resolution logic in _ffprobe_video_stream_fields() with a single call to ffprobe_path(), following the pattern established in PR #110.

## Changes
- Added ffprobe_path to imports from hflow.ffmpeg
- Replaced 3 lines of manual resolution with ffprobe_path()

## Verification
- All 9 tests in tests/test_video.py pass
- No hardcoded binary paths remain in tests
- Quality checks pass (ruff check, ruff format)
- Note: ty check has pre-existing errors about missing pyarrow module unrelated to this change