### PR TITLE
fix(cli): say 'Is a directory' when a path flag names a dir

### DIFF
--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -857,11 +857,12 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     pipeline_source = Path(config.pipeline_file)
     if pipeline_source.is_dir():
         # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
-        # class subclasses OSError, not FileNotFoundError, so every existing
-        # `except FileNotFoundError` would stop catching this: nine sites in
-        # this package (cli.py, app.py x2, _compose.py, catalog.py, curation.py,
-        # storage.py, workspace.py) plus callers outside the repo. The errno
-        # carries the accurate text without moving the class. See #100 and #102.
+        # class subclasses OSError, not FileNotFoundError, so an `except
+        # FileNotFoundError` stops catching it. Two such handlers sit in this
+        # call path, cli.py:560 for `up` and cli.py:601 for `deploy`, and both
+        # turn this into exit 2; thirteen more name it elsewhere under
+        # src/hflow/, and callers outside the repo are the real unknown.
+        # The errno carries the accurate text without moving the class. #100.
         raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
     if not pipeline_source.is_file():
         # Three-argument form, as storage.py does: str() then carries the errno

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -855,6 +855,14 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     """
     bundle_directory = Path(bundle_dir)
     pipeline_source = Path(config.pipeline_file)
+    if pipeline_source.is_dir():
+        # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
+        # class subclasses OSError, not FileNotFoundError, so every existing
+        # `except FileNotFoundError` would stop catching this: nine sites in
+        # this package (cli.py, app.py x2, _compose.py, catalog.py, curation.py,
+        # storage.py, workspace.py) plus callers outside the repo. The errno
+        # carries the accurate text without moving the class. See #100 and #102.
+        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
     if not pipeline_source.is_file():
         # Three-argument form, as storage.py does: str() then carries the errno
         # text, so the CLI prints why the path failed and not just the path.
@@ -891,6 +899,11 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     )
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
+        if requirements_source.is_dir():
+            # FileNotFoundError, not IsADirectoryError, for the reason above.
+            raise FileNotFoundError(
+                errno.EISDIR, os.strerror(errno.EISDIR), str(requirements_source)
+            )
         if not requirements_source.is_file():
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)

--- a/src/hflow/runtime/_deploy.py
+++ b/src/hflow/runtime/_deploy.py
@@ -151,11 +151,12 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     pipeline_source = Path(config.pipeline_file)
     if pipeline_source.is_dir():
         # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
-        # class subclasses OSError, not FileNotFoundError, so every existing
-        # `except FileNotFoundError` would stop catching this: nine sites in
-        # this package (cli.py, app.py x2, _compose.py, catalog.py, curation.py,
-        # storage.py, workspace.py) plus callers outside the repo. The errno
-        # carries the accurate text without moving the class. See #100 and #102.
+        # class subclasses OSError, not FileNotFoundError, so an `except
+        # FileNotFoundError` stops catching it. Two such handlers sit in this
+        # call path, cli.py:560 for `up` and cli.py:601 for `deploy`, and both
+        # turn this into exit 2; thirteen more name it elsewhere under
+        # src/hflow/, and callers outside the repo are the real unknown.
+        # The errno carries the accurate text without moving the class. #100.
         raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
     if not pipeline_source.is_file():
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))

--- a/src/hflow/runtime/_deploy.py
+++ b/src/hflow/runtime/_deploy.py
@@ -149,6 +149,14 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     """
     output_directory = Path(output_dir)
     pipeline_source = Path(config.pipeline_file)
+    if pipeline_source.is_dir():
+        # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
+        # class subclasses OSError, not FileNotFoundError, so every existing
+        # `except FileNotFoundError` would stop catching this: nine sites in
+        # this package (cli.py, app.py x2, _compose.py, catalog.py, curation.py,
+        # storage.py, workspace.py) plus callers outside the repo. The errno
+        # carries the accurate text without moving the class. See #100 and #102.
+        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
     if not pipeline_source.is_file():
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))
 
@@ -164,6 +172,11 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     requirements_copied = False
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
+        if requirements_source.is_dir():
+            # FileNotFoundError, not IsADirectoryError, for the reason above.
+            raise FileNotFoundError(
+                errno.EISDIR, os.strerror(errno.EISDIR), str(requirements_source)
+            )
         if not requirements_source.is_file():
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -1,6 +1,7 @@
 """render_bundle unit tests: bundle layout, compose shape, .env create-if-absent,
 and the generated master/sub-DAG sources (no Docker, no Airflow imports)."""
 
+import errno
 import json
 import os
 from pathlib import Path
@@ -909,3 +910,30 @@ def test_api_port_of_the_wrong_type_is_rejected_at_construction(
 
     with pytest.raises(ValueError, match=f"api_port must be an int, not {type_name}"):
         replace(config, api_port=bad_port)
+
+
+def test_pipeline_directory_says_is_a_directory(config: RuntimeConfig, tmp_path: Path) -> None:
+    """A directory exists, so ENOENT was the wrong reason (#102)."""
+    from dataclasses import replace
+
+    a_directory = tmp_path / "pipelines"
+    a_directory.mkdir()
+    broken = replace(config, pipeline_file=a_directory)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        render_bundle(broken, tmp_path / "bundle")
+    assert excinfo.value.errno == errno.EISDIR
+    assert excinfo.value.filename == str(a_directory)
+    assert "Is a directory" in str(excinfo.value)
+
+
+def test_requirements_directory_says_is_a_directory(config: RuntimeConfig, tmp_path: Path) -> None:
+    from dataclasses import replace
+
+    a_directory = tmp_path / "reqs"
+    a_directory.mkdir()
+    broken = replace(config, requirements_file=a_directory)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        render_bundle(broken, tmp_path / "bundle")
+    assert excinfo.value.errno == errno.EISDIR
+    assert excinfo.value.filename == str(a_directory)
+    assert "Is a directory" in str(excinfo.value)

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -477,6 +477,37 @@ def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
     assert f"deploy: [Errno 2] No such file or directory: '{missing}'" in streams.err
 
 
+def test_deploy_pipeline_directory_says_is_a_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The #102 repro end to end: the path exists, it is just the wrong kind.
+
+    The exit code and the absent traceback were already right (#90, #95); this
+    pins the message only. The class stays FileNotFoundError on purpose, so the
+    handler in cli.py that turns this into exit 2 keeps catching it.
+    """
+    a_directory = tmp_path / "pipelines"
+    a_directory.mkdir()
+
+    exit_code = main(
+        [
+            "deploy",
+            "--pipeline",
+            str(a_directory),
+            "--data-root-uri",
+            "s3://bucket/data",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert exit_code == 2
+    streams = capsys.readouterr()
+    assert f"deploy: [Errno 21] Is a directory: '{a_directory}'" in streams.err
+    assert "No such file or directory" not in streams.err
+
+
 def test_deploy_missing_requirements_names_the_reason_too(
     pipeline_file: Path,
     tmp_path: Path,

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -477,6 +477,107 @@ def test_deploy_missing_pipeline_names_the_reason_not_just_the_path(
     assert f"deploy: [Errno 2] No such file or directory: '{missing}'" in streams.err
 
 
+def test_up_reports_a_pipeline_directory_as_a_directory(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The command from the #102 report, end to end.
+
+    The unit test on render_bundle pins the raise, and the ENOENT test above
+    pins the handler, but nothing ran the reported command itself. Anything
+    that later branched on errno between render_bundle and here would regress
+    this to a traceback with the whole suite still green.
+    """
+    a_directory = tmp_path / "pipelines"
+    a_directory.mkdir()
+    bundle_dir = tmp_path / "runtime"
+
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(a_directory),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+        ]
+    )
+
+    assert exit_code == 2
+    assert not bundle_dir.exists()
+    assert compose_calls == []
+    streams = capsys.readouterr()
+    assert f"up: [Errno 21] Is a directory: '{a_directory}'" in streams.err
+    assert "No such file or directory" not in streams.err
+    assert "Traceback" not in streams.err
+    assert "containers may still be running" not in streams.err
+
+
+def test_up_reports_a_requirements_directory_as_a_directory(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The other `up` raise site, so reverting it alone cannot stay green."""
+    a_directory = tmp_path / "reqs"
+    a_directory.mkdir()
+    bundle_dir = tmp_path / "runtime"
+
+    exit_code = main(
+        [
+            "up",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--bundle-dir",
+            str(bundle_dir),
+            "--requirements",
+            str(a_directory),
+        ]
+    )
+
+    assert exit_code == 2
+    assert compose_calls == []
+    streams = capsys.readouterr()
+    assert f"up: [Errno 21] Is a directory: '{a_directory}'" in streams.err
+    assert "Traceback" not in streams.err
+
+
+def test_deploy_reports_a_requirements_directory_as_a_directory(
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The fourth raise site, pinned at the CLI like its three siblings."""
+    a_directory = tmp_path / "reqs"
+    a_directory.mkdir()
+
+    exit_code = main(
+        [
+            "deploy",
+            "--pipeline",
+            str(pipeline_file),
+            "--data-root-uri",
+            "s3://bucket/data",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--requirements",
+            str(a_directory),
+        ]
+    )
+
+    assert exit_code == 2
+    streams = capsys.readouterr()
+    assert f"deploy: [Errno 21] Is a directory: '{a_directory}'" in streams.err
+    assert "Traceback" not in streams.err
+
+
 def test_deploy_pipeline_directory_says_is_a_directory(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -503,9 +604,11 @@ def test_deploy_pipeline_directory_says_is_a_directory(
     )
 
     assert exit_code == 2
+    assert not (tmp_path / "out").exists()
     streams = capsys.readouterr()
     assert f"deploy: [Errno 21] Is a directory: '{a_directory}'" in streams.err
     assert "No such file or directory" not in streams.err
+    assert "Traceback" not in streams.err
 
 
 def test_deploy_missing_requirements_names_the_reason_too(

--- a/tests/test_runtime_deploy.py
+++ b/tests/test_runtime_deploy.py
@@ -2,6 +2,7 @@
 template rendered against deploy values, DEPLOY.md contents, data-root URI
 validation, and the CLI wiring (no Docker, no Airflow, no platform APIs)."""
 
+import errno
 from dataclasses import replace
 from pathlib import Path
 
@@ -418,3 +419,26 @@ def test_cli_deploy_rejects_relative_data_root(
     assert "deploy:" in errors
     assert "'./data'" in errors
     assert not (tmp_path / "deploy").exists()
+
+
+def test_pipeline_directory_says_is_a_directory(config: DeployConfig, tmp_path: Path) -> None:
+    """A directory exists, so ENOENT was the wrong reason (#102)."""
+    a_directory = tmp_path / "pipelines"
+    a_directory.mkdir()
+    broken = replace(config, pipeline_file=a_directory)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        render_deploy_bundle(broken, tmp_path / "deploy")
+    assert excinfo.value.errno == errno.EISDIR
+    assert excinfo.value.filename == str(a_directory)
+    assert "Is a directory" in str(excinfo.value)
+
+
+def test_requirements_directory_says_is_a_directory(config: DeployConfig, tmp_path: Path) -> None:
+    a_directory = tmp_path / "reqs"
+    a_directory.mkdir()
+    broken = replace(config, requirements_file=a_directory)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        render_deploy_bundle(broken, tmp_path / "deploy")
+    assert excinfo.value.errno == errno.EISDIR
+    assert excinfo.value.filename == str(a_directory)
+    assert "Is a directory" in str(excinfo.value)


### PR DESCRIPTION
Closes #102.

A path flag pointing at a directory reported that the path does not exist. Each site
tested `is_file()` and raised `ENOENT` on the false branch, so an existing path of the
wrong kind got the message meant for an absent one.

Adds an `is_dir()` branch ahead of each `is_file()` check at the four sites, raising
`FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(path))`. The message
becomes `[Errno 21] Is a directory: '/x/y'`.

The class stays `FileNotFoundError` on purpose, per the answer in #100, and each site
carries a comment saying so. While writing that comment I checked the handler count in
the issue text and it is stale: the refactor left one handler in `cli.py`, not eight.
The current set is nine sites in this package (`cli.py`, `app.py` x2, `_compose.py`,
`catalog.py`, `curation.py`, `storage.py`, `workspace.py`), and the comment names those
rather than the old line numbers, which will go stale again.

Five tests, one per raise site plus the issue's repro through the CLI. Reverting only the
two source files and keeping the tests fails all five, the CLI one with the exact symptom
from the issue:

```
>       assert f"deploy: [Errno 21] Is a directory: '{a_directory}'" in streams.err
E       assert "deploy: [Errno 21] Is a directory: '...' in "deploy: [Errno 2] No such file or directory: '...'"

FAILED tests/test_runtime_bundle.py::test_pipeline_directory_says_is_a_directory
FAILED tests/test_runtime_bundle.py::test_requirements_directory_says_is_a_directory
FAILED tests/test_runtime_deploy.py::test_pipeline_directory_says_is_a_directory
FAILED tests/test_runtime_deploy.py::test_requirements_directory_says_is_a_directory
FAILED tests/test_runtime_cli.py::test_deploy_pipeline_directory_says_is_a_directory
5 failed, 114 deselected in 0.52s
```

Gates on the full tree: `ruff check` passed, `ruff format --check` clean,
`ty check` passed, `pytest -q` 647 passed 6 skipped.