### PR TITLE
fix(doctor): report every file and continue past unreadable ones; document exit codes

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -143,8 +143,26 @@ A file claiming this convention must satisfy, in increasing strictness:
 5. **Stamps**: `provenance/v1` present with `schema_version` and `pipeline_version`.
 
 `hflow doctor <file.mcap> [more.mcap ...]` executes these checks against every
-file given, printing one report each, and exits with status 0 when all files
-conform or 1 when any reports violations.
+file given, printing one report each in argument order, and exits with status 0
+when all files conform or 1 when any reports violations. An unreadable or
+unparseable path is reported in place, in the same per-file shape (`[error]
+unreadable: ...`), and the run continues with the remaining files.
+
+### Exit codes
+
+Every `hflow` command follows the same three-value convention:
+
+- `0` - success: the command did what it was asked.
+- `1` - ran, and found something to report: `doctor`, a non-conforming file;
+  `stale --exit-code`, stale episodes found; `up`, started then failed, so
+  containers may still be running; `ingest`, episodes failed.
+- `2` - bad input, nothing useful happened: an invalid flag combination, an
+  unreachable endpoint, a missing catalog, or a `doctor` run in which no file
+  could be diagnosed at all.
+
+`doctor` treats an unreadable file as at least as bad as a non-conforming one
+(exit 1), and reserves 2 for runs where nothing was diagnosed, so a batch run
+never both loses its reports and erases the fact that it read anything.
 
 ## References
 

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -34,6 +34,11 @@ before the subcommand:
 - `--version` prints the installed HFlow version and exits.
 - `-v`, `--verbose` enables verbose logging.
 
+Every subcommand follows the same three-value exit-code convention (0 success,
+1 ran and found something to report, 2 bad input and nothing happened), which
+matters when scripting `up` or `ingest`: see
+[Exit codes](./FORMAT.md#exit-codes).
+
 ## What `up` builds: anatomy of the bundle
 
 ```bash

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -163,7 +163,10 @@ def _build_parser() -> argparse.ArgumentParser:
         description=(
             "Validate container integrity, metadata stamps, chunk-group layout, "
             "and in-band video constraints (docs/FORMAT.md, executable form). "
-            "Accepts multiple files; exit code 0 when all conform, 1 when any does not."
+            "Accepts multiple files, each reported in order whatever happens "
+            "to the others. Exit 0 when all conform, 1 when any file is "
+            "non-conforming or could not be read, 2 when no file could be "
+            "diagnosed (nothing useful happened)."
         ),
     )
     doctor_parser.add_argument(
@@ -738,17 +741,25 @@ def _command_curate(arguments: argparse.Namespace) -> int:
 
 
 def _command_doctor(arguments: argparse.Namespace) -> int:
+    # Findings, not exceptions, across files as well: an unreadable path is a
+    # finding about the corpus, reported in place, so a batch run never loses
+    # the reports for the files it could read. Exit precedence (docs/FORMAT.md):
+    # 2 only when nothing could be diagnosed; otherwise 1 when any file was
+    # non-conforming or unreadable; 0 when everything conformed.
+    diagnosed_any = False
     exit_code = 0
     for file in arguments.file:
         try:
             doctor_report = diagnose(file)
         except (ValueError, FileNotFoundError) as error:
-            print(f"doctor: {error}", file=sys.stderr)
-            return 2
+            print(f"doctor: {file}\n  [error] unreadable: {error}\n  verdict: NOT CONFORMING")
+            exit_code = 1
+            continue
+        diagnosed_any = True
         print(doctor_report.summary())
         if not doctor_report.conforming:
             exit_code = 1
-    return exit_code
+    return 2 if not diagnosed_any else exit_code
 
 
 def _command_serve(arguments: argparse.Namespace) -> int:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -126,9 +126,34 @@ def test_cli_doctor_missing_file_prints_one_line(capsys: pytest.CaptureFixture[s
     missing = "C:/definitely/not/here.mcap"
     assert cli_main(["doctor", missing]) == 2
     captured = capsys.readouterr()
-    assert "doctor:" in captured.err
-    assert "No such file or directory" in captured.err
+    assert "doctor:" in captured.out
+    assert "[error] unreadable:" in captured.out
+    assert "No such file or directory" in captured.out
+    assert "Traceback" not in captured.out
     assert "Traceback" not in captured.err
+
+
+def test_cli_doctor_continues_past_unreadable_file(
+    canonical_episode: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = "C:/definitely/not/here.mcap"
+    assert cli_main(["doctor", str(canonical_episode), missing, str(canonical_episode)]) == 1
+    out = capsys.readouterr().out
+    first = out.index(str(canonical_episode))
+    missing_at = out.index(missing)
+    last = out.rindex(str(canonical_episode))
+    assert first < missing_at < last
+    assert out.count("[error] unreadable:") == 1
+    assert "NOT CONFORMING" in out
+    assert "Traceback" not in out
+
+
+def test_cli_doctor_all_unreadable_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    missing = "C:/definitely/not/here.mcap"
+    assert cli_main(["doctor", missing, missing]) == 2
+    captured = capsys.readouterr()
+    assert captured.out.count("[error] unreadable:") == 2
+    assert "Traceback" not in captured.out
 
 
 def test_cli_curate_bad_catalog_prints_one_line(


### PR DESCRIPTION
## What changed

`hflow doctor` now reports on every file it was given, whatever happens to any one of them, and the exit-code convention is written down.

**Loop behavior:** an unreadable or unparseable path is reported in place, in the same per-file shape as the other reports (`[error] unreadable: ...` + `verdict: NOT CONFORMING`), on stdout, so the order of output matches the argument order and a diff between two runs is readable. The loop continues to the next file; `diagnose()` itself still raises (per-file diagnosis is not weakened).

**Exit-code precedence** (per the issue's two requirements resolved together: an unreadable file is at least as bad as a non-conforming one, and a run where some files were read must not silently become 2):
- `0` - everything conformed.
- `1` - any file was non-conforming OR could not be read (an unreadable file is reported at the same severity as a non-conforming one, never milder).
- `2` - nothing useful happened: no file could be diagnosed at all (or CLI misuse).

**Documentation:** the 0/1/2 contract now lives in the CLI reference (docs/FORMAT.md Conformance section, where doctor's status was already documented): the meaning of each code, plus what `1` means per command (`doctor`, `stale --exit-code`, `up`, `ingest`). The doctor help text states the precedence too.

## Validation (run in WSL2)

```
uv run ruff check --fix   # clean
uv run ruff format        # clean
uv run ty check           # All checks passed
uv run pytest -q          # 638 passed, 3 skipped; 2 failed + 7 errors, ALL in test_ffmpeg.py
```

The ffmpeg failures are pre-existing environment gaps (no ffmpeg binaries in this WSL image): I stashed my changes and reproduced the identical 2 failed / 7 errors on clean `main`. New doctor tests (`test_cli_doctor_continues_past_unreadable_file`, `test_cli_doctor_all_unreadable_exits_2`, updated missing-file test) all pass.

```
lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .
# 257 OK, 0 Errors
```

Fixes #99