### PR TITLE
fix(transform): reject pass-through video starting mid-GOP

### DIFF
--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -9,8 +9,9 @@ v1 behavior:
 - Channels already carrying ``foxglove.CompressedVideo`` pass through
   byte-for-byte, but only after every message is validated against the
   canonical video constraints (``format="h264"``, one AUD-delimited access
-  unit per message, SPS+PPS on keyframes) -- the provenance stamp asserts
-  conformance, so nonconforming video must fail loudly, never pass silently.
+  unit per message, SPS+PPS on keyframes, each channel starts on a keyframe) --
+  the provenance stamp asserts conformance, so nonconforming video must fail
+  loudly, never pass silently.
   Raw ``sensor_msgs/msg/Image``/``foxglove.RawImage`` is not supported in v1
   (explicit error).
 - Every other channel passes through byte-for-byte with its original schema.
@@ -226,7 +227,9 @@ def _resolve_decoder(topic: str, info: TopicInfo) -> Callable[[bytes], Any]:
     )
 
 
-def _validate_passthrough_video_payload(topic: str, decoded_message: Any) -> None:
+def _validate_passthrough_video_payload(
+    topic: str, decoded_message: Any, *, is_first_message: bool
+) -> None:
     """Enforce the canonical video constraints on a pass-through message.
 
     The provenance stamp asserts the whole file conforms (FORMAT.md), so a
@@ -252,10 +255,16 @@ def _validate_passthrough_video_payload(topic: str, decoded_message: Any) -> Non
             f"{len(access_units)} access units; the canonical convention requires "
             "exactly one decodable frame per message"
         )
-    if access_units[0].is_keyframe and not access_units[0].has_parameter_sets:
+    access_unit = access_units[0]
+    if access_unit.is_keyframe and not access_unit.has_parameter_sets:
         raise ValueError(
             f"pass-through video topic {topic!r} has a keyframe without SPS/PPS; "
             "the canonical convention requires parameter sets on every keyframe"
+        )
+    if is_first_message and not access_unit.is_keyframe:
+        raise ValueError(
+            f"pass-through video topic {topic!r} starts mid-GOP: its first message "
+            "is not a keyframe, so the stream is not decodable from the start"
         )
 
 
@@ -362,6 +371,7 @@ def write_canonical_episode(
             if info.schema_name in _PASSTHROUGH_VIDEO_SCHEMAS
         }
         passthrough_video_decoders: dict[int, Callable[[bytes], Any]] = {}
+        passthrough_video_channels_with_messages: set[int] = set()
         for batch in reader.iter_batches():
             if batch.channel_id in camera_payloads:
                 camera_log_times[batch.channel_id].extend(int(t) for t in batch.log_times)
@@ -375,7 +385,15 @@ def write_canonical_episode(
                         )
                     decode = passthrough_video_decoders[batch.channel_id]
                     for payload in batch.data:
-                        _validate_passthrough_video_payload(batch.topic, decode(payload))
+                        is_first_message = (
+                            batch.channel_id not in passthrough_video_channels_with_messages
+                        )
+                        _validate_passthrough_video_payload(
+                            batch.topic,
+                            decode(payload),
+                            is_first_message=is_first_message,
+                        )
+                        passthrough_video_channels_with_messages.add(batch.channel_id)
                 outgoing.extend(
                     _OutgoingMessage(
                         log_time=int(batch.log_times[index]),

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -14,12 +14,21 @@ from mcap.writer import Writer as StockWriter
 from mcap_protobuf.schema import build_file_descriptor_set
 
 import hflow
+from hflow.doctor import diagnose
 from hflow.format import METADATA_RECORD_EPISODE
 from hflow.mcap_writer import CanonicalMcapWriter
 from hflow.steps import compute_check_version
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import write_canonical_episode
 from hflow.video import estimate_fps_from_log_times
+
+ANNEX_B_START_CODE = b"\x00\x00\x00\x01"
+KEYFRAME_ACCESS_UNIT = b"".join(
+    ANNEX_B_START_CODE + bytes([nal_type]) + b"payload" for nal_type in (0x09, 0x67, 0x68, 0x65)
+)
+NON_KEYFRAME_ACCESS_UNIT = b"".join(
+    ANNEX_B_START_CODE + bytes([nal_type]) + b"payload" for nal_type in (0x09, 0x41)
+)
 
 
 def test_estimate_fps_normal_stream() -> None:
@@ -93,6 +102,83 @@ def test_transform_rejects_nonconforming_passthrough_video(tmp_path: Path) -> No
         writer.finish()
     with pytest.raises(ValueError, match="requires 'h264'"):
         write_canonical_episode(source, tmp_path / "out.mcap")
+
+
+def _write_passthrough_video_source(
+    path: Path, messages: list[tuple[str, int, bytes]]
+) -> dict[str, list[bytes]]:
+    payloads_by_topic: dict[str, list[bytes]] = {}
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        channel_ids = {
+            topic: writer.register_channel(
+                topic=topic, message_encoding="protobuf", schema_id=schema_id
+            )
+            for topic in dict.fromkeys(topic for topic, _log_time, _data in messages)
+        }
+        for topic, log_time, access_unit_data in messages:
+            message = CompressedVideo()
+            message.timestamp.FromNanoseconds(log_time)
+            message.frame_id = topic.strip("/")
+            message.data = access_unit_data
+            message.format = "h264"
+            payload = message.SerializeToString()
+            writer.add_message(
+                channel_ids[topic], log_time=log_time, data=payload, publish_time=log_time
+            )
+            payloads_by_topic.setdefault(topic, []).append(payload)
+        writer.finish()
+    return payloads_by_topic
+
+
+def test_transform_rejects_each_passthrough_video_channel_starting_mid_gop(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "interleaved-mid-gop.mcap"
+    _write_passthrough_video_source(
+        source,
+        [
+            ("/cam/left", 1, KEYFRAME_ACCESS_UNIT),
+            ("/cam/right", 2, NON_KEYFRAME_ACCESS_UNIT),
+            ("/cam/left", 3, NON_KEYFRAME_ACCESS_UNIT),
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"/cam/right.*starts mid-GOP"):
+        write_canonical_episode(source, tmp_path / "out.mcap")
+
+
+def test_transform_accepts_independent_interleaved_passthrough_video_channels(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "interleaved-keyframes.mcap"
+    expected_payloads = _write_passthrough_video_source(
+        source,
+        [
+            ("/cam/left", 1, KEYFRAME_ACCESS_UNIT),
+            ("/cam/right", 2, KEYFRAME_ACCESS_UNIT),
+            ("/cam/left", 3, NON_KEYFRAME_ACCESS_UNIT),
+            ("/cam/right", 4, NON_KEYFRAME_ACCESS_UNIT),
+        ],
+    )
+    output = tmp_path / "out.mcap"
+
+    write_canonical_episode(source, output)
+
+    with output.open("rb") as stream:
+        reader = make_reader(stream)
+        actual_payloads: dict[str, list[bytes]] = {}
+        for _schema, channel, message in reader.iter_messages(log_time_order=True):
+            actual_payloads.setdefault(channel.topic, []).append(message.data)
+    assert actual_payloads == expected_payloads
+    report = diagnose(output)
+    assert report.conforming, report.summary()
 
 
 def test_aborted_writer_does_not_publish_partial_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #96.

## Outcome

- Tracks the first successfully validated pass-through video message independently for each MCAP channel.
- Rejects a channel whose first H.264 access unit is not a keyframe, so the transform can no longer stamp a mid-GOP stream as canonical.
- Keeps accepted pass-through payloads byte-for-byte unchanged.

## Regression coverage

- Interleaves two camera channels and proves the second channel is rejected when its own first message starts mid-GOP, even after the first channel has already passed validation.
- Interleaves two valid channels that each start on a keyframe, then verifies their serialized payloads are unchanged and `diagnose()` reports the output conforming.

`TRANSFORM_BEHAVIOR_VERSION` is intentionally unchanged: this closes acceptance of an input that already violates the documented canonical format. Inputs that were valid before still produce identical canonical bytes.

## Validation

- `/Users/William/.local/bin/uv run ruff check --fix`
- `/Users/William/.local/bin/uv run ruff format`
- `/Users/William/.local/bin/uv run ty check`
- `/Users/William/.local/bin/uv run pytest -q` — 654 passed, 6 skipped
- `git diff --check`

AI assistance disclosure: I used OpenAI Codex to help inspect the existing transform/doctor invariants, implement the change, and run validation. I reviewed the final diff and test evidence.