### PR TITLE
test(cli): cover ingest URI root guard

### DIFF
--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -891,6 +891,22 @@ def test_ingest_rejects_unknown_profile(pipeline_file: Path, tmp_path: Path) -> 
     assert exit_info.value.code == 2
 
 
+@pytest.mark.parametrize("uri", ["/abs/x.mcap", "../x.mcap"])
+def test_ingest_rejects_uris_outside_data_root(
+    uri: str,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runtime URIs cannot be absolute or escape the configured data root."""
+    bundle_dir = _rendered_bundle(tmp_path, pipeline_file)
+
+    exit_code = main(["ingest", uri, "--bundle-dir", str(bundle_dir)])
+
+    assert exit_code == 2
+    assert "is not relative to the data root" in capsys.readouterr().err
+
+
 def test_start_runtime_waits_for_all_five_dags(
     compose_calls: list[list[str]],
     pipeline_file: Path,


### PR DESCRIPTION
Closes #67.

## Outcome

- Covers rejection of an absolute runtime URI (`/abs/x.mcap`).
- Covers rejection of a parent-directory escape (`../x.mcap`).
- Exercises the real CLI boundary and asserts exit code 2 plus the user-facing data-root error.
- Uses no HTTP mock, so the guard must return before any request path is reached.

This is regression coverage only; production behavior is unchanged.

## Validation

- focused regression: 2 passed
- `tests/test_runtime_cli.py`: 35 passed
- `ruff check --fix tests/test_runtime_cli.py`
- `ruff format --check tests/test_runtime_cli.py`
- `ty check`
- `pytest -q`: 654 passed, 6 skipped
- `git diff --check`

AI assistance disclosure: I used OpenAI Codex to help inspect the existing CLI boundary, implement the test, and run validation. I reviewed the final diff and evidence.