### PR TITLE
fix(catalog): coerce NumPy scalar measurements at the boundary; refuse the rest

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -35,11 +35,12 @@ import hashlib
 import json
 import tempfile
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
 import duckdb
+import numpy as np
 
 from hflow.format import CATALOG_FORMAT_VERSION
 from hflow.steps import CheckResult, CheckStatus, Interval, MeasurementValue
@@ -255,6 +256,31 @@ def content_episode_id(canonical_path: Path) -> str:
     return digest.hexdigest()[:16]
 
 
+def _normalized_measurements(
+    check_name: str, measurements: dict[str, MeasurementValue]
+) -> dict[str, MeasurementValue]:
+    """Coerce NumPy scalars to Python scalars; refuse anything else loudly.
+
+    Real check code returns NumPy scalars (np.mean(), indexing, np.bool_
+    verdicts), and only np.float64 subclasses a Python type -- the rest used
+    to fall through every storage branch into all-NULL value columns while
+    the key still landed. Coercion happens here, before anything consumes
+    the values, so one np.float32(0.4) and float(0.4) outcome fingerprints
+    and stores identically instead of splitting into two runs.
+    """
+    normalized: dict[str, MeasurementValue] = {}
+    for key, value in measurements.items():
+        if isinstance(value, np.generic):
+            value = value.item()
+        if not isinstance(value, MeasurementValue):
+            raise ValueError(
+                f"check {check_name!r} measured {key!r} as {type(value).__name__}: "
+                "measurements hold one int/float/str/bool per key"
+            )
+        normalized[key] = value
+    return normalized
+
+
 def _run_fingerprint(
     episode_id: str,
     pipeline_version: str,
@@ -283,11 +309,8 @@ def _run_fingerprint(
         }
         for row in check_rows
     ]
-    # default=repr: measurement values are user data and may be non-JSON
-    # scalars (numpy integers/bools reach here untouched); repr keeps the
-    # fingerprint deterministic instead of crashing the whole append.
     check_outcomes.sort(
-        key=lambda outcome: json.dumps(outcome, sort_keys=True, separators=(",", ":"), default=repr)
+        key=lambda outcome: json.dumps(outcome, sort_keys=True, separators=(",", ":"))
     )
     payload = json.dumps(
         {
@@ -298,7 +321,6 @@ def _run_fingerprint(
         },
         sort_keys=True,
         separators=(",", ":"),
-        default=repr,
     )
     return hashlib.sha256(payload.encode()).hexdigest()[:12]
 
@@ -451,6 +473,14 @@ class Catalog:
         address for local roots).
         """
         episode_id = content_episode_id(canonical_path)
+        # One normalized shape feeds every consumer below -- the run
+        # fingerprint, the replay repair pass, and the dependent-table
+        # inserts. Normalizing any later would let np.float32(0.4) and
+        # float(0.4) hash as two outcomes while storing NULL columns.
+        check_rows = [
+            replace(row, measurements=_normalized_measurements(row.check_name, row.measurements))
+            for row in check_rows
+        ]
         run_fingerprint = _run_fingerprint(
             episode_id,
             stamps.pipeline_version,

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -519,8 +519,8 @@ def test_constrained_curate_writes_the_manifest_but_refuses_outside_reads(
         )
 
 
-def test_append_accepts_non_json_measurement_scalars(tmp_path: Path) -> None:
-    """numpy scalars are user data: they must fingerprint, not crash the append."""
+def test_numpy_scalar_measurements_round_trip(tmp_path: Path) -> None:
+    """NumPy scalars from real check code store readable values, not NULLs."""
     import numpy as np
 
     canonical = tmp_path / "e.canonical.mcap"
@@ -532,9 +532,12 @@ def test_append_accepts_non_json_measurement_scalars(tmp_path: Path) -> None:
         critical=False,
         status=hflow.CheckStatus.MEASURED,
         duration_s=0.1,
-        # cast: deliberately smuggling user-supplied non-JSON scalars past the
+        # cast: deliberately passing user-supplied NumPy scalars past the
         # declared MeasurementValue type -- exactly what real check code does.
-        measurements=cast(dict, {"count": np.int64(3), "flag": np.bool_(True)}),
+        measurements=cast(
+            dict,
+            {"ratio": np.float32(0.4), "frames": np.int64(3), "flag": np.bool_(True)},
+        ),
     )
     result = catalog.append_episode(
         canonical_path=canonical,
@@ -543,14 +546,136 @@ def test_append_accepts_non_json_measurement_scalars(tmp_path: Path) -> None:
         check_rows=[row],
     )
     assert result.written is True
-    replay = catalog.append_episode(
-        canonical_path=canonical,
-        stamps=FAKE_STAMPS,
-        episode_metadata={},
-        check_rows=[row],
+    connection = open_catalog_connection(tmp_path / "catalog")
+    try:
+        raw_rows = connection.execute(
+            "SELECT key, value_double, value_text, value_bool FROM measurements"
+        ).fetchall()
+        raw = {
+            key: (value_double, value_text, value_bool)
+            for key, value_double, value_text, value_bool in raw_rows
+        }
+        wide = connection.execute(
+            "SELECT ratio, frames FROM episodes WHERE episode_id = ?",
+            [result.episode_id],
+        ).fetchone()
+    finally:
+        connection.close()
+    # The measurements table holds one typed column per value.
+    assert raw["ratio"] == (np.float32(0.4).item(), None, None)
+    assert raw["frames"] == (3.0, None, None)
+    assert raw["flag"] == (None, None, True)
+    # The wide view exposes them to threshold predicates.
+    assert wide == pytest.approx((np.float32(0.4).item(), 3.0))
+
+
+def test_numpy_measured_episode_survives_a_manifest_filter(tmp_path: Path) -> None:
+    """A NumPy-measured episode must not vanish from a threshold-filtered manifest."""
+    import numpy as np
+
+    catalog_dir = tmp_path / "catalog"
+    for name, black_pct in (("numpy", np.float32(0.4)), ("python", 0.4)):
+        canonical = tmp_path / f"{name}.canonical.mcap"
+        canonical.write_bytes(name.encode())
+        Catalog(catalog_dir).append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[
+                CheckRunRow(
+                    check_name="camera_blackout",
+                    check_version="v1",
+                    critical=False,
+                    status=hflow.CheckStatus.MEASURED,
+                    duration_s=0.1,
+                    measurements=cast(dict, {"black_pct": black_pct}),
+                )
+            ],
+        )
+    connection = open_catalog_connection(catalog_dir)
+    try:
+        kept = connection.execute(
+            "SELECT episode_id FROM episodes WHERE black_pct < 1.0 AND status != 'quarantined'"
+        ).fetchall()
+    finally:
+        connection.close()
+    assert len(kept) == 2
+
+
+def test_same_value_in_a_numpy_or_python_scalar_replays_as_one_run(
+    tmp_path: Path,
+) -> None:
+    """Equal values across scalar flavors fingerprint identically.
+
+    Idempotence must not depend on which scalar flavor a check happened to
+    return that day. (A genuinely different value -- float32 rounding of 0.4
+    versus the float64 literal, say -- stays a distinct outcome by design.)
+    """
+    import numpy as np
+
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    catalog = Catalog(tmp_path / "catalog")
+
+    def measure(value: object) -> CheckRunRow:
+        return CheckRunRow(
+            check_name="camera_blackout",
+            check_version="v1",
+            critical=False,
+            status=hflow.CheckStatus.MEASURED,
+            duration_s=0.1,
+            measurements=cast(dict, {"black_pct": value}),
+        )
+
+    float_attempts = [
+        catalog.append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[measure(value)],
+        )
+        for value in (np.float64(0.5), 0.5, np.float64(0.5))
+    ]
+    assert [attempt.written for attempt in float_attempts] == [True, False, False]
+    assert len({attempt.run_fingerprint for attempt in float_attempts}) == 1
+
+    int_canonical = tmp_path / "int.canonical.mcap"
+    int_canonical.write_bytes(b"int-episode-bytes")
+    int_attempts = [
+        catalog.append_episode(
+            canonical_path=int_canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[measure(value)],
+        )
+        for value in (np.int64(7), 7)
+    ]
+    assert [attempt.written for attempt in int_attempts] == [True, False]
+    assert len({attempt.run_fingerprint for attempt in int_attempts}) == 1
+
+
+def test_non_scalar_measurement_is_refused_naming_the_check_and_key(
+    tmp_path: Path,
+) -> None:
+    """An unstoreable measurement raises loudly instead of writing NULLs."""
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="broken_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        # cast: the misuse this test exists to refuse.
+        measurements=cast(dict, {"bad": {"nested": 1}}),
     )
-    assert replay.written is False
-    assert replay.run_fingerprint == result.run_fingerprint
+    with pytest.raises(ValueError, match=r"broken_check.*'bad'.*dict"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
 
 
 def test_crash_repaired_append_keeps_one_recorded_at_across_tables(tmp_path: Path) -> None:

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -74,6 +74,8 @@ def test_enrichment_wrong_return_type_is_an_error(source_episode: Path, tmp_path
 def test_enrichment_labels_and_artifacts_land_in_the_catalog(
     source_episode: Path, tmp_path: Path
 ) -> None:
+    import numpy as np
+
     data_root = tmp_path / "data"
     artifact_dir = tmp_path / "artifacts"
     artifact_dir.mkdir()
@@ -84,7 +86,14 @@ def test_enrichment_labels_and_artifacts_land_in_the_catalog(
         artifact_path = artifact_dir / "segments.json"
         artifact_path.write_text(json.dumps({"segments": []}))
         return hflow.EnrichmentResult(
-            labels={"caption": "synthetic joints wiggle", "confidence": 0.9},
+            labels=cast(
+                dict,
+                {
+                    "caption": "synthetic joints wiggle",
+                    # real labelers return NumPy scalars; they must store, not NULL out
+                    "confidence": np.float32(0.9),
+                },
+            ),
             artifacts={"segments": artifact_path},
             tags=["labeled"],
         )
@@ -96,6 +105,10 @@ def test_enrichment_labels_and_artifacts_land_in_the_catalog(
             "SELECT value_text FROM measurements WHERE key = 'caption'"
         ).fetchone()
         assert caption_row == ("synthetic joints wiggle",)
+        confidence_row = connection.execute(
+            "SELECT value_double FROM measurements WHERE key = 'confidence'"
+        ).fetchone()
+        assert confidence_row == pytest.approx((np.float32(0.9).item(),))
         artifact_row = connection.execute(
             "SELECT value_text FROM measurements WHERE key = 'artifact/segments'"
         ).fetchone()

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -877,11 +877,11 @@ def test_api_port_accepts_an_int_enum_member(config: RuntimeConfig) -> None:
 def test_api_port_rejects_a_numpy_integer(config: RuntimeConfig) -> None:
     """A numpy integer is not an int, and a config field is not user data.
 
-    catalog.py accommodates numpy scalars in measurements because those are user
-    data mid-append and a crash would cost the whole episode. api_port is set
-    once by the caller, rendered into a .env that is never rewritten, and
-    interpolated into api_base_url, so refusing it costs one line at the call
-    site and nothing downstream.
+    catalog.py coerces numpy scalar measurements at its boundary because
+    those are user data mid-append and refusing would cost the whole episode.
+    api_port is set once by the caller, rendered into a .env that is never
+    rewritten, and interpolated into api_base_url, so refusing it costs one
+    line at the call site and nothing downstream.
     """
     from dataclasses import replace
 


### PR DESCRIPTION
Closes #126

## Summary

Fixes silent data loss in the catalog: NumPy scalar measurements (`np.float32`, `np.int64`, `np.bool_`) were stored as NULL while their keys still landed, causing curation predicates like `WHERE black_pct < 1.0` to silently drop those episodes and splitting replay idempotence by scalar flavor. Now every scalar round-trips, replays converge on value equality, and exotic non-JSON types refuse loudly at the boundary.

## Why

Checks return NumPy scalars constantly (`np.mean()`, indexing, `np.bool_` verdicts), but measurement storage branched on exactly Python int/float/str/bool -- which only np.float64 subclasses. Every other flavor fell through to NULL columns while its key still landed, so the README's own `WHERE black_pct < 1.0` example silently dropped those episodes. The same logical outcome could also split into two runs depending on which scalar flavor a check happened to return that day (np.float32(0.4) vs float(0.4) fingerprinted differently; np.float64 survived by accident).

The fix is one choke point: `append_episode` normalizes measurements before anything consumes them -- both `_run_fingerprint` and `_insert_dependent_rows` now receive one normalized `check_rows`. `np.generic` coerces via `.item()`; anything else raises naming the check, key, and received type (#93/#86 tone), replacing silent NULLs. With values guaranteed JSON-native, `default=repr` is gone from the run fingerprint along with the comment describing the leak it papered over. Nothing but measurements ever fed the non-JSON path, and those were exactly the values being destroyed; exotic types now refuse loudly at the boundary instead of hashing successfully and storing NULLs.

One deliberate scope line: equal values across scalar flavors now replay as one run regardless of flavor, but a genuinely different value stays a distinct outcome -- float32 rounding of 0.4 differs from the float64 literal in the 8th decimal, and coercing cannot (and should not) fuse them. #126's replay example therefore converges on value equality, not flavor equality; happy to take a different ruling if you want float32-quantized identity.

Existing catalogs keep their old NULL rows: append-only, nothing migrates.

Enrichment labels reach the same path (`app.py` packs them into `CheckRunRow.measurements`), so they are covered for free -- with a test.

## Validation

```bash
uv run ruff check --fix src tests       # clean
uv run ruff format src tests            # clean
uv run ty check src tests               # clean
uv run pytest -q                        # 662 passed, 3 skipped
```

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.