### PR TITLE
docs: document curate --sql-file and catalog root

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -84,6 +84,17 @@ hflow curate "SELECT episode_id, uri FROM episodes WHERE task = 'fold_napkin'" \
     --catalog data/catalog --output data/manifest.parquet
 ```
 
+For a query stored in a file, pass `--sql-file` instead of the positional SQL
+string:
+
+```bash
+hflow curate --sql-file query.sql \
+    --catalog data/catalog --output data/manifest.parquet
+```
+
+Pass exactly one of the positional SQL string or `--sql-file`; passing both or
+neither is an error.
+
 The manifest is written **manifest-last**: to a temp file, renamed into place
 only after the query completed, so a partial manifest is unreachable.
 
@@ -277,6 +288,12 @@ duckdb.execute(
 the same way. The only reserved file is the `format_version` marker at the
 catalog root (currently `1`); a breaking layout change bumps it, and readers
 refuse loudly on mismatch.
+
+## Troubleshooting
+
+**`<location> is not a catalog root`.** Pass the catalog location created
+beneath the data root, commonly `<data_root>/catalog`, rather than the data root
+itself. A catalog root contains the `format_version` marker.
 
 ## Current limits
 


### PR DESCRIPTION
## Summary

- document using `hflow curate --sql-file` for file-backed queries
- state that callers must provide exactly one of inline SQL or `--sql-file`
- add troubleshooting guidance for passing a data root instead of its catalog root

## Why

The CLI already supports `--sql-file` and reports catalog-root mistakes, but `docs/CATALOG.md` did not explain either path. This keeps the catalog guide aligned with the current command and error behavior.

Closes #71

## Validation

- `git diff --check origin/main...HEAD` — passed
- `lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .` — 262 total, 259 OK, 3 excluded, 0 errors

## Checklist

- [x] Documentation-only change; no business-logic tests are required.
- [x] I updated documentation for existing behavior and flags.
- [x] Python formatting, typing, and pytest gates are not applicable to this Markdown-only change.
- [x] I ran the repository's Markdown link check.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged.