### PR TITLE
fix(catalog): refuse measurement keys that shadow episodes columns

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -344,12 +344,13 @@ itself. A catalog root contains the `format_version` marker.
   0/1). Text-valued measurements stay in the long `measurements` table;
   query them there.
 - A measurement key that collides with an episode column name (`task`,
-  `uri`, `pipeline_version`, ...) is **silently renamed** in the wide view, not
-  refused: the episode column keeps the name and the measurement is reachable
-  only as `task_1`, which no query would think to ask for. `SELECT task` then
-  returns the metadata and never the measurement. Follow the
-  [naming rules](#naming-measurement-keys) and it cannot arise; query the long
-  `measurements` table if you hit it in an existing corpus.
+  `uri`, `pipeline_version`, ...) or with the derived `status` column is
+  **refused at append time**. Pivoted beside the real column, DuckDB would
+  rename it to `task_1`, so `SELECT task` would silently return the metadata
+  instead of the measurement. Follow the
+  [naming rules](#naming-measurement-keys) and the collision cannot arise;
+  appends written before this check keep their renamed ghost columns -- query
+  such values in the long `measurements` table.
 - The wide view binds its measurement columns to the keys present when the
   connection was opened. `curate()` reopens per call, so this only matters
   if you hold a long-lived connection from `open_catalog_connection()` while

--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -103,6 +103,23 @@ _reconciled_append_stems: set[tuple[str, str]] = set()
 
 _FORMAT_MARKER_NAME = "format_version"
 
+# The quarantine state rendered as a queryable column by the curation
+# views (curation.py builds both episodes views with it). Declared here
+# because measurement keys are validated against the episodes view's full
+# column list -- the table's columns plus this derived one.
+EPISODES_VIEW_STATUS_COLUMN = "status"
+
+# Lowercased name -> canonical spelling of every column a measurement key
+# must not claim. Derived from the episodes DDL plus the derived column
+# above, so a new episode column is guarded without touching the check.
+_EPISODES_VIEW_RESERVED_COLUMNS: dict[str, str] = {
+    **{
+        column.split()[0].lower(): column.split()[0]
+        for column in TABLE_COLUMN_DDL["episodes"].split(",")
+    },
+    EPISODES_VIEW_STATUS_COLUMN.lower(): EPISODES_VIEW_STATUS_COLUMN,
+}
+
 
 @dataclass(frozen=True)
 class CheckRunRow:
@@ -279,6 +296,34 @@ def _normalized_measurements(
             )
         normalized[key] = value
     return normalized
+
+
+def _raise_if_measurement_keys_shadow_episode_columns(
+    check_rows: Sequence[CheckRunRow],
+) -> None:
+    """Refuse a run whose measurement key claims an ``episodes`` column.
+
+    The wide ``episodes`` view pivots each numeric key into a column beside
+    the promoted episode columns; DuckDB resolves such a collision by
+    silently renaming the pivoted column to ``<key>_1``, so queries reading
+    the episode column get the episode value and never the measurement.
+    Keys compare case-insensitively -- DuckDB identifiers are, so ``Task``
+    shadows ``task`` all the same.
+    """
+    shadowed = [
+        f"{key!r} from {row.check_name!r} shadows {_EPISODES_VIEW_RESERVED_COLUMNS[key.lower()]!r}"
+        for row in check_rows
+        for key in row.measurements
+        if key.lower() in _EPISODES_VIEW_RESERVED_COLUMNS
+    ]
+    if not shadowed:
+        return
+    raise ValueError(
+        f"measurement keys collide with episodes columns: {'; '.join(shadowed)}. The wide "
+        "episodes view pivots keys into columns beside those names, so DuckDB renames the "
+        "measurement to <column>_1 and SELECT <column> returns the episode value instead. "
+        "Rename the measurement key."
+    )
 
 
 def _run_fingerprint(
@@ -481,6 +526,7 @@ class Catalog:
             replace(row, measurements=_normalized_measurements(row.check_name, row.measurements))
             for row in check_rows
         ]
+        _raise_if_measurement_keys_shadow_episode_columns(check_rows)
         run_fingerprint = _run_fingerprint(
             episode_id,
             stamps.pipeline_version,

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -18,11 +18,11 @@ Views registered on the connection:
 - ``episodes`` -- the wide view for everyday queries: latest episode rows,
   a ``status`` column (``'quarantined'``/``'ok'``), and one numeric column
   per measurement key (booleans as 0/1; text-valued measurements stay in the
-  long table). A measurement key that collides with an episode column name is
-  silently renamed rather than refused: the episode column keeps the name and
-  the measurement becomes ``<key>_1``, so ``SELECT task`` returns the metadata
-  and never the measurement. Name keys ``<topic>/<metric>`` and it cannot
-  arise.
+  long table). A measurement key claiming an episode column -- or this
+  derived ``status`` -- is refused at append time: pivoted beside the real
+  column, DuckDB would silently rename it to ``<key>_1``, and ``SELECT task``
+  would return the metadata where the measurement was meant. Name keys
+  ``<topic>/<metric>`` and the collision cannot arise.
 
 Dataset-level reporting always includes coverage denominators: which checks
 ran on what fraction of episodes, because a statistic over half a delivery
@@ -37,7 +37,7 @@ from pathlib import Path
 
 import duckdb
 
-from hflow.catalog import TABLE_COLUMN_DDL
+from hflow.catalog import EPISODES_VIEW_STATUS_COLUMN, TABLE_COLUMN_DDL
 from hflow.format import CATALOG_FORMAT_VERSION
 from hflow.steps import CheckStatus
 from hflow.storage import (
@@ -312,7 +312,7 @@ def _open_connection_over_root(
             CREATE VIEW episodes AS
             SELECT
                 e.* EXCLUDE (quarantined),
-                CASE WHEN e.quarantined THEN 'quarantined' ELSE 'ok' END AS status,
+                CASE WHEN e.quarantined THEN 'quarantined' ELSE 'ok' END AS {EPISODES_VIEW_STATUS_COLUMN},
                 m.* EXCLUDE (episode_id)
             FROM episodes_latest e
             LEFT JOIN (
@@ -334,11 +334,11 @@ def _open_connection_over_root(
         )
     else:
         connection.execute(
-            """
+            f"""
             CREATE VIEW episodes AS
             SELECT
                 * EXCLUDE (quarantined),
-                CASE WHEN quarantined THEN 'quarantined' ELSE 'ok' END AS status
+                CASE WHEN quarantined THEN 'quarantined' ELSE 'ok' END AS {EPISODES_VIEW_STATUS_COLUMN}
             FROM episodes_latest
             """
         )

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -678,6 +678,49 @@ def test_non_scalar_measurement_is_refused_naming_the_check_and_key(
         )
 
 
+def test_measurement_key_claiming_an_episode_column_is_refused(tmp_path: Path) -> None:
+    """A key named like an episodes column would pivot into <key>_1 beside it."""
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="claims_task",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"task": 99.0},
+    )
+    with pytest.raises(ValueError, match=r"'claims_task'.*'task'"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+    assert list((tmp_path / "catalog" / "episodes").glob("*.parquet")) == []
+
+
+def test_measurement_key_shadowing_is_case_insensitive(tmp_path: Path) -> None:
+    """DuckDB identifiers are case-insensitive, so 'Task' shadows 'task' too."""
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="claims_task",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"Task": 1.0},
+    )
+    with pytest.raises(ValueError, match=r"'Task'.*shadows 'task'"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+
 def test_crash_repaired_append_keeps_one_recorded_at_across_tables(tmp_path: Path) -> None:
     """A retry after a crashed append must not mix timestamps across tables.
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -319,3 +319,19 @@ def test_colliding_endpoint_alias_names_are_refused(
 
     with pytest.raises(ValueError, match="HFLOW_ENDPOINT_JUDGE_V1"):
         app.test(state_only_source_episode, verbose=False)
+
+
+def test_check_claiming_an_episode_column_refuses_the_append(
+    state_only_source_episode: Path, tmp_path: Path
+) -> None:
+    """The #130 repro: a check measuring ``task`` used to land as ``task_1``
+    beside the real column, so SELECT task returned the metadata (here
+    'fold_napkin') and never the measurement. The append now refuses."""
+    app = hflow.App("reserved-key", data_root=tmp_path / "data")
+
+    @app.check()
+    def claims_task(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"task": 99.0})
+
+    with pytest.raises(ValueError, match=r"'claims_task'.*shadows 'task'"):
+        app.test(state_only_source_episode, verbose=False, record=True)


### PR DESCRIPTION
Closes #130

A measurement key named like an episodes column (`task`, `uri`,
`pipeline_version`, ...) pivoted beside the real thing, and DuckDB resolved
the collision by silently renaming the measurement to `<key>_1`. Nothing
errored; `SELECT task` just returned the metadata forever while the
measurement sat behind a name no query would ask for. A wrong answer rather
than a loud one.

The append now refuses the run before anything is written, naming the
check, the key, and the column it shadows -- the same boundary treatment
measurement values got in #127. Keys compare case-insensitively, since
DuckDB identifiers do.

The reserved set is derived, not listed: it comes from the episodes table
DDL plus the wide view's one derived column (`status`), whose name now
lives in one place (`EPISODES_VIEW_STATUS_COLUMN`) and is interpolated into
both view definitions in curation.py. A future episode column is guarded
the moment it enters the DDL.

Docs updated to match the new behavior (curation.py module docstring,
CATALOG.md current-limits): appends written before this check keep their
renamed ghost columns -- append-only -- and such values remain queryable in
the long `measurements` table.

Validation:

    uv run ruff check src tests
    uv run ruff format --check src tests
    uv run ty check src tests
    uv run pytest -q          # 720 passed, 3 skipped

The issue's repro now raises at append time instead of printing
`['task', 'task_1']`.
