### PR TITLE
fix: reserve the built-in media step name

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -751,11 +751,13 @@ class App:
         self.transform_override: TransformFunction | None = None
 
     def _registered_step_names(self) -> set[str]:
-        # Checks and enrichments share the catalog's check_name column, so
-        # names are unique across both.
-        return {registered.name for registered in self.checks} | {
-            registered.name for registered in self.enrichments
-        }
+        # Checks, enrichments, and the built-in media step share the catalog's
+        # check_name column, so names are unique across all three.
+        return (
+            {MEDIA_CONTACT_SHEET_STEP_NAME}
+            | {registered.name for registered in self.checks}
+            | {registered.name for registered in self.enrichments}
+        )
 
     @property
     def pipeline_version(self) -> str:

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 
 import hflow
+from hflow.app import MEDIA_CONTACT_SHEET_STEP_NAME
 from hflow.curation import open_catalog_connection
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
@@ -138,6 +139,22 @@ def test_step_names_are_unique_across_checks_and_enrichments(tmp_path: Path) -> 
         @app.enrich(name="labeling")
         def another(ep: hflow.Episode) -> hflow.EnrichmentResult:
             return hflow.EnrichmentResult()
+
+
+def test_built_in_media_step_name_is_reserved_for_user_steps(tmp_path: Path) -> None:
+    app = hflow.App("reserved-media-name", data_root=tmp_path)
+
+    def check(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult()
+
+    def enrichment(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        return hflow.EnrichmentResult()
+
+    with pytest.raises(ValueError, match=r"media/contact_sheet.*already registered"):
+        app.check(name=MEDIA_CONTACT_SHEET_STEP_NAME)(check)
+
+    with pytest.raises(ValueError, match=r"media/contact_sheet.*already registered"):
+        app.enrich(name=MEDIA_CONTACT_SHEET_STEP_NAME)(enrichment)
 
 
 def test_enrichment_uses_alias_is_preflighted(source_episode: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- reserve the built-in `media/contact_sheet` step name during user step registration
- reject both checks and enrichments that try to use the reserved name
- cover the public registration behavior with a regression test

## Why

The media stage creates `media/contact_sheet` at processing time. Allowing a user step to register with the same name can therefore write two `check_runs` rows under one `check_name`, which makes coverage reporting ambiguous. Reserving the name at registration prevents that invalid pipeline configuration before any data is processed.

Closes #129

## Validation

- `uv sync --locked --all-extras`
- `uv run pytest tests/test_enrichments.py -q` — 7 passed
- `uv run pytest -q` — 715 passed, 6 skipped
- `uv run ruff check --fix` — passed
- `uv run ruff format` — 145 files left unchanged
- `uv run ty check` — passed

## Checklist

- [x] I added outcome-focused regression coverage for the changed registration behavior.
- [x] Documentation is unchanged because this restores the existing unique-step-name contract without adding a flag, format, or operational requirement.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite and the full default suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is preserved; invalid duplicate names are rejected before processing.

## AI assistance

OpenAI Codex assisted with implementation and PR preparation. The final diff was reviewed and all validation commands above were run locally.
