### PR TITLE
feat(steps): let version= own a step's identity outright

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -26,7 +26,7 @@ def my_check(ep: hflow.Episode) -> hflow.CheckResult:
     return hflow.CheckResult(measurements=result)  # our line: record
 ```
 
-`@app.check()` takes `name=` (defaults to the function name), `critical=`, `requires={...}` (capability set, e.g. `{"gpu"}`), `uses="alias"` (a named endpoint; see the VLM section), `gate=` (a declarative accept policy the runner evaluates over what the check returned), and optional `version=`. Step identity automatically includes source, defaults, and captured stable configuration such as numeric thresholds. Pass an explicit `version=` for opaque client objects or external model configuration the SDK cannot inspect deterministically. Checks that declare no resources run before checks that do, so cheap integrity checks gate expensive model calls. Today `requires`/`uses` record intent, order steps, and let preflight verify named endpoints are configured; they do **not** route the step to a particular worker or GPU pool (per-step compute routing is [deferred](./ARCHITECTURE.md#implementation-status)) -- a bring-your-own Airflow deployment arranges those resources itself.
+`@app.check()` takes `name=` (defaults to the function name), `critical=`, `requires={...}` (capability set, e.g. `{"gpu"}`), `uses="alias"` (a named endpoint; see the VLM section), `gate=` (a declarative accept policy the runner evaluates over what the check returned), and optional `version=`. By default a step's identity is derived: its source, its defaults and captured stable configuration such as numeric thresholds, and then transitively the helpers it calls and the constants those read, across your own package and hflow's but never into a dependency. Passing `version=` takes the identity over instead. The function is then not inspected at all, so you can refactor freely and your rows stay comparable, at the cost of remembering to bump the number when behaviour really changes; what you declared beside it (`critical`, `requires`, `uses`, `gate`) still counts. Use it for an opaque client object the SDK cannot inspect deterministically, or for a step you would rather promise about than have measured. Checks that declare no resources run before checks that do, so cheap integrity checks gate expensive model calls. Today `requires`/`uses` record intent, order steps, and let preflight verify named endpoints are configured; they do **not** route the step to a particular worker or GPU pool (per-step compute routing is [deferred](./ARCHITECTURE.md#implementation-status)); a bring-your-own Airflow deployment arranges those resources itself.
 
 Every step is called with exactly one argument, an `Episode`, so `@app.check()`, `@app.enrich()`, and `@app.derive()` refuse a function the runtime could never call: one with a required parameter beyond the episode, or with no positional slot to receive it. That refusal happens at registration, not once per episode, and the error shows the wrapper form to use instead. To pass configuration, bind it in a wrapper (`return action_rate(ep, topics=[...])`) rather than adding a parameter.
 
@@ -99,7 +99,7 @@ Import the built-in as a function rather than reaching it as
 `hflow.checks.camera_frame_stats` inside a wrapper. A step's version
 content-hashes the functions it *names*, and transitively the hflow code those
 call, so an import by name means a change to what the check measures shows up
-as a new step version; a module reached by attribute contributes only its name,
+as a new step version. A module reached by attribute contributes only its name,
 and the change would append rows under the old version instead.
 
 To make it *reject* episodes rather than only measure them, attach a gate at
@@ -240,7 +240,7 @@ two steps claim the same one --
 [the naming rules](./CATALOG.md#naming-measurement-keys) explain why a shared
 key is unrecoverable rather than merely untidy.
 
-Every recorded result also carries the check's version (a content hash of its configuration and source, including any gate you attached), so re-running a changed check -- or a retuned threshold -- appends new-version rows instead of silently overwriting old ones.
+Every recorded result also carries the check's version: a content hash of its source and configuration, of the first-party code it calls, and of any gate you attached. Re-running a changed check, or one whose threshold you retuned, appends new-version rows instead of silently overwriting old ones.
 
 ## The dev loop
 

--- a/src/hflow/behavior.py
+++ b/src/hflow/behavior.py
@@ -34,11 +34,11 @@ hash, because a step hash folds in the source of every function the step
 NAMES and then keeps descending through first-party code: the helpers those
 functions call, and the constants they read, down to the leaves (see
 ``_IdentityScope`` in :mod:`hflow.steps`). That is what keeps composition
-honest here, since checks compose by sharing library code -- two built-ins
-reading one ffmpeg pass, the motion checks sharing :mod:`hflow.motion` --
-rather than by depending on each other's results. Without the descent, tuning
-a threshold inside the shared instrument changed what every one of them
-measured while their versions stood still.
+honest here. Checks compose by sharing library code (two built-ins reading one
+ffmpeg pass, the motion checks sharing :mod:`hflow.motion`) rather than by
+depending on each other's results. Without the descent, tuning a threshold
+inside the shared instrument changed what every one of them measured while
+their versions stood still.
 
 What the descent cannot see is a module reached by ATTRIBUTE: a step whose
 body calls ``hflow.checks.timestamp_regularity`` captures the module, and a
@@ -48,9 +48,9 @@ entirely, which is what the docs and examples teach; a wrapper that reaches
 through the module does not, and is the one remaining spelling where a
 built-in's change goes unversioned. The boundary is deliberate in the other
 direction too: the descent stops at hflow's own code and the pipeline's, never
-entering a dependency, because folding numpy's source into a step version
-would re-version a corpus on a release that changed nothing a step observes --
-this module's whole subject.
+entering a dependency. Folding numpy's source into a step version would
+re-version a corpus on a release that changed nothing a step observes, which
+is this module's whole subject.
 
 Two further exceptions live in
 :func:`hflow.transform.compute_pipeline_version`, which folds in
@@ -65,8 +65,8 @@ Identity epochs live here as prose, not as a constant: no build stamps an
 epoch into a corpus, so a module attribute nothing reads would be a comment
 wearing a type annotation. Epoch 1 folded ``hflow.__version__`` into
 ``pipeline_version``, ``episode_id``, and step versions; epoch 2 folded in
-only author-owned facts plus ``TRANSFORM_BEHAVIOR_VERSION``; epoch 3 -- what
-this build produces -- widened a step hash from the functions a step names to
+only author-owned facts plus ``TRANSFORM_BEHAVIOR_VERSION``; epoch 3, what
+this build produces, widened a step hash from the functions a step names to
 the first-party code those transitively call. Written down so a reader can
 explain the one-time re-version between them rather than guess at it.
 
@@ -75,9 +75,9 @@ most of them. Where such a step is a ``@app.derive`` channel the move carries
 further: derived-channel versions reach ``compute_pipeline_version``, which is
 stamped inside the bytes ``episode_id`` hashes, so corpora WITH derived
 channels re-mint episode identities once. That is the honest outcome rather
-than an accident -- those steps really were versioned as though the code they
-call could not change -- but it is a re-ingest, so it belongs in release notes
-and not only here.
+than an accident, because those steps really were versioned as though the code
+they call could not change. It is still a re-ingest, so it belongs in release
+notes and not only here.
 """
 
 # Canonicalization semantics: bump when the transform would write different

--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -385,21 +385,30 @@ def compute_check_version(
     *,
     gate: "Gate | None" = None,
 ) -> str:
-    """Content-hash a step's implementation and behavior configuration.
+    """Content-hash a step, or record the version its author declared.
 
     Used for checks and enrichments alike (enrichments pass
-    ``critical=False``). Closure values, defaults, and callable-instance state
-    are included when they can be represented deterministically. Pass an
-    explicit ``declared_version`` for opaque clients or other configuration
-    that cannot be inspected safely.
+    ``critical=False``). By default the version is DERIVED: the function's
+    source, its closure values and defaults, and -- transitively, across
+    first-party modules only (see :class:`_IdentityScope`) -- the helpers it
+    calls and the constants they read. A parser or a threshold one call below
+    the step still moves the step's version.
+
+    Pass ``declared_version`` to own the version instead. Nothing derived from
+    the function is hashed then, so a refactor the author judges equivalent
+    keeps the identity and its rows stay comparable; the cost is that they
+    must remember to bump it when behavior really does change. Use it for an
+    opaque client the machinery cannot read, and for a step stable enough that
+    its author would rather promise than measure.
+
+    Deriving is the default because the two mistakes are not symmetric. An
+    unnecessary version split is recoverable -- both hashes exist and a query
+    can union them. A missed one is not: two behaviors under one version, with
+    nothing left to say which row came from which.
 
     A ``gate`` arrives from registration rather than from the function, so it
-    is folded in here: tuning a threshold has to move the version, or two
-    policies share one and curation can no longer pin either.
-
-    The walk into referenced code is transitive across first-party modules
-    (see :class:`_IdentityScope`), so a constant or a parser one call deeper
-    than the step still moves the step's version.
+    is folded in under BOTH modes: tuning a threshold has to move the version,
+    or two policies share one and curation can no longer pin either.
     """
     identity = json.dumps(
         step_identity_payload(
@@ -428,28 +437,32 @@ def step_identity_payload(
     "what does this version actually cover", which is what
     ``UNDESCRIBED_CONFIGURATION_KEY`` makes checkable -- a gap in the walk is
     otherwise invisible until someone edits the code it failed to read.
+
+    Two identity modes, and ``declared_version`` chooses between them:
+
+    - **Derived** (the default): the implementation and everything it
+      transitively reaches decide the version. Nothing to remember, and the
+      version cannot claim two behaviors are one.
+    - **Declared**: the author owns the version outright and NOTHING derived
+      from the function reaches the hash, so a refactor they judge equivalent
+      keeps the identity and its rows stay comparable.
+
+    What survives declaring is the REGISTRATION: name, ``critical``,
+    ``requires``, ``uses``, and the gate. Those are not what the function is
+    made of, they are what the author wrote at the decorator -- changing one
+    is a deliberate edit with a visible diff, not a refactor, and a gate in
+    particular must keep moving the version or two threshold policies share
+    one and curation can pin neither (see :class:`Gate`).
     """
     if declared_version is not None and not declared_version:
         raise ValueError(f"declared step version must not be empty for step {name!r}")
 
     scope = _identity_scope_for(function)
-    implementation_identity = _callable_implementation_identity(
-        function,
-        allow_opaque=declared_version is not None,
-    )
-    behavior_configuration: VersionIdentityValue
-    if declared_version is not None:
-        behavior_configuration = {"declared_version": declared_version}
-    else:
-        behavior_configuration = _callable_behavior_configuration(function, scope=scope)
-
-    return {
+    identity: dict[str, VersionIdentityValue] = {
         "name": name,
         "critical": critical,
         "requires": sorted(requires),
         "uses": uses,
-        "implementation": implementation_identity,
-        "configuration": behavior_configuration,
         # Present only when a gate is declared, like transform.py's
         # resample_policy: an unconditional key would re-version every
         # check, enrichment, and derived channel -- and derived-channel
@@ -457,6 +470,17 @@ def step_identity_payload(
         # bytes episode_id hashes. One new key would restamp every corpus.
         **({"gate": _stable_version_identity_value(gate, scope)} if gate is not None else {}),
     }
+    if declared_version is not None:
+        # Not introspected at all, rather than introspected and overridden:
+        # an opaque vendor client has no describable implementation, and an
+        # ordinary function whose author declared a version must not have its
+        # source leak back in -- that would make the declaration advisory and
+        # the refactor it exists to permit would re-version anyway.
+        identity["declared_version"] = declared_version
+        return identity
+    identity["implementation"] = _callable_implementation_identity(function)
+    identity["configuration"] = _callable_behavior_configuration(function, scope=scope)
+    return identity
 
 
 # Marks a point where the identity walk could not describe a transitively
@@ -523,9 +547,14 @@ def _identity_scope_for(function: Callable[..., object]) -> _IdentityScope:
 
 def _callable_implementation_identity(
     function: Callable[..., object],
-    *,
-    allow_opaque: bool = False,
 ) -> VersionIdentityValue:
+    """What a callable IS, or a refusal naming the way out.
+
+    Only reached for a step whose version is derived, so there is no "describe
+    it loosely" mode: a callable this cannot read has no honest derived
+    identity, and the refusal points at ``version='...'`` -- which now means
+    the function is not introspected at all rather than introspected weakly.
+    """
     if isinstance(function, functools.partial):
         return {
             "partial_func": _callable_implementation_identity(function.func),
@@ -541,10 +570,6 @@ def _callable_implementation_identity(
         code = getattr(source_target, "__code__", None)
         if isinstance(code, CodeType):
             return {"code": _code_identity(code)}
-    if allow_opaque:
-        return {
-            "opaque_callable_type": f"{type(function).__module__}.{type(function).__qualname__}"
-        }
     raise ValueError(
         f"cannot derive a stable implementation identity for {function!r}; "
         "register it with version='...'"

--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -389,10 +389,10 @@ def compute_check_version(
 
     Used for checks and enrichments alike (enrichments pass
     ``critical=False``). By default the version is DERIVED: the function's
-    source, its closure values and defaults, and -- transitively, across
-    first-party modules only (see :class:`_IdentityScope`) -- the helpers it
-    calls and the constants they read. A parser or a threshold one call below
-    the step still moves the step's version.
+    source, its closure values and defaults, then transitively the helpers it
+    calls and the constants they read, across first-party modules only (see
+    :class:`_IdentityScope`). A parser or a threshold one call below the step
+    still moves the step's version.
 
     Pass ``declared_version`` to own the version instead. Nothing derived from
     the function is hashed then, so a refactor the author judges equivalent
@@ -402,9 +402,9 @@ def compute_check_version(
     its author would rather promise than measure.
 
     Deriving is the default because the two mistakes are not symmetric. An
-    unnecessary version split is recoverable -- both hashes exist and a query
-    can union them. A missed one is not: two behaviors under one version, with
-    nothing left to say which row came from which.
+    unnecessary version split is recoverable, since both hashes exist and a
+    query can union them. A missed one is not: two behaviors under one version,
+    with nothing left to say which row came from which.
 
     A ``gate`` arrives from registration rather than from the function, so it
     is folded in under BOTH modes: tuning a threshold has to move the version,
@@ -435,7 +435,7 @@ def step_identity_payload(
     Separate from the hash so the description can be inspected rather than
     only compared. A hash answers "did this change"; only the payload answers
     "what does this version actually cover", which is what
-    ``UNDESCRIBED_CONFIGURATION_KEY`` makes checkable -- a gap in the walk is
+    ``UNDESCRIBED_CONFIGURATION_KEY`` makes checkable. A gap in the walk is
     otherwise invisible until someone edits the code it failed to read.
 
     Two identity modes, and ``declared_version`` chooses between them:
@@ -449,8 +449,8 @@ def step_identity_payload(
 
     What survives declaring is the REGISTRATION: name, ``critical``,
     ``requires``, ``uses``, and the gate. Those are not what the function is
-    made of, they are what the author wrote at the decorator -- changing one
-    is a deliberate edit with a visible diff, not a refactor, and a gate in
+    made of; they are what the author wrote at the decorator. Changing one is
+    a deliberate edit with a visible diff rather than a refactor, and a gate in
     particular must keep moving the version or two threshold policies share
     one and curation can pin neither (see :class:`Gate`).
     """
@@ -465,16 +465,16 @@ def step_identity_payload(
         "uses": uses,
         # Present only when a gate is declared, like transform.py's
         # resample_policy: an unconditional key would re-version every
-        # check, enrichment, and derived channel -- and derived-channel
-        # versions reach pipeline_version, which is stamped inside the
-        # bytes episode_id hashes. One new key would restamp every corpus.
+        # check, enrichment, and derived channel. Derived-channel versions
+        # reach pipeline_version, which is stamped inside the bytes
+        # episode_id hashes, so one new key would restamp every corpus.
         **({"gate": _stable_version_identity_value(gate, scope)} if gate is not None else {}),
     }
     if declared_version is not None:
         # Not introspected at all, rather than introspected and overridden:
         # an opaque vendor client has no describable implementation, and an
         # ordinary function whose author declared a version must not have its
-        # source leak back in -- that would make the declaration advisory and
+        # source leak back in. That would make the declaration advisory, and
         # the refactor it exists to permit would re-version anyway.
         identity["declared_version"] = declared_version
         return identity
@@ -498,15 +498,15 @@ class _IdentityScope:
     A step hash covers the source of every function the step NAMES, but until
     this scope existed it stopped there: editing a constant or a parser one
     call deeper changed what the step measured while its version stood still,
-    and the new rows appended under the old version -- two behaviors sharing
-    one identity, which is the failure this whole module exists to prevent.
-    The built-ins made that concrete, ``camera_signal_quality`` naming
-    ``frame_stats`` while the instrument's own parsing sat a level below.
+    and the new rows appended under the old version. Two behaviors sharing one
+    identity is the failure this whole module exists to prevent. The built-ins
+    made it concrete: ``camera_signal_quality`` names ``frame_stats`` while the
+    instrument's own parsing sits a level below that.
 
     ``first_party_roots`` bounds what "deeper" may mean: hflow's own code,
     plus the top-level package the step itself is defined in (so a pipeline's
     private helpers count, wherever the author put them). A DEPENDENCY is
-    deliberately not followed -- folding numpy's source into a step version
+    deliberately not followed. Folding numpy's source into a step version
     would re-version a corpus on an unrelated numpy release, which is exactly
     the release-number coupling :mod:`hflow.behavior` removed.
 
@@ -552,8 +552,8 @@ def _callable_implementation_identity(
 
     Only reached for a step whose version is derived, so there is no "describe
     it loosely" mode: a callable this cannot read has no honest derived
-    identity, and the refusal points at ``version='...'`` -- which now means
-    the function is not introspected at all rather than introspected weakly.
+    identity, and the refusal points at ``version='...'``. That now means the
+    function is not introspected at all rather than introspected weakly.
     """
     if isinstance(function, functools.partial):
         return {
@@ -634,10 +634,11 @@ def _stable_version_identity_value(
     """
     # Unwrap decorators before deciding what a value is. A memoised helper is
     # its wrapped function plus a cache, and the cache changes no behavior a
-    # step can observe -- so hashing the function underneath is both correct
-    # and the difference between versioning a step and refusing to register
-    # it (hflow.ffmpeg._binary memoises the binary probes the instrument
-    # calls). inspect.unwrap raises on a __wrapped__ cycle; keep the wrapper.
+    # step can observe. Hashing the function underneath is therefore both
+    # correct and the difference between versioning a step and refusing to
+    # register it (hflow.ffmpeg._binary memoises the binary probes the
+    # instrument calls). inspect.unwrap raises on a __wrapped__ cycle, so on a
+    # cycle keep the wrapper.
     if not isinstance(value, type) and callable(value) and hasattr(value, "__wrapped__"):
         with suppress(ValueError):
             value = inspect.unwrap(value)
@@ -656,8 +657,8 @@ def _stable_version_identity_value(
         # A compiled pattern IS behavior, and a common way to express it: the
         # ffmpeg instrument parses its output with two module-level patterns,
         # so editing one changes what every camera check measures. Described
-        # by the pattern and its flags -- the compiled object is opaque, but
-        # what it was compiled FROM is exactly the thing that can change.
+        # by the pattern and its flags, because the compiled object is opaque
+        # while what it was compiled FROM is the thing that can change.
         return {"regex": value.pattern, "regex_flags": int(value.flags)}
     if isinstance(value, logging.Logger):
         # A logger is infrastructure a step carries, never behavior a step
@@ -689,11 +690,11 @@ def _stable_version_identity_value(
             # Follow first-party code one call further: this function's own
             # constants, defaults and callees are part of what the step does.
             # A value the walk cannot describe is NAMED here rather than
-            # raised on -- refusing would break registration of a step over
-            # some helper's private state, while the step's OWN captured
-            # state stays strict because that refusal is raised outside this
-            # branch (see compute_check_version). The name still moves the
-            # hash if the helper is swapped for a different one.
+            # raised on, because refusing would break registration of a step
+            # over some helper's private state. The step's OWN captured state
+            # stays strict, since that refusal is raised outside this branch
+            # (see compute_check_version). The name still moves the hash if
+            # the helper is swapped for a different one.
             try:
                 identity["configuration"] = _callable_behavior_configuration(
                     value, scope=scope.entered(referenced_key)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -224,9 +224,14 @@ def test_a_gateless_step_hashes_as_if_gates_did_not_exist() -> None:
     if the identity dict's SHAPE changed. An unconditional new key there would
     re-version every check, every derived channel, and through
     pipeline_version every episode_id in every existing corpus.
+
+    Last moved when a declared version stopped being an override laid over the
+    introspected identity and became the whole of it -- ``implementation`` and
+    ``configuration`` are absent under ``version='...'`` now, which is what
+    lets an author refactor without re-versioning.
     """
     identity = compute_check_version("probe", len, False, frozenset(), None, "v1")
-    assert identity == "59895cb283c3"
+    assert identity == "fec021d42dba"
     assert (
         compute_check_version("probe", len, False, frozenset(), None, "v1", gate=None) == identity
     )

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -226,7 +226,7 @@ def test_a_gateless_step_hashes_as_if_gates_did_not_exist() -> None:
     pipeline_version every episode_id in every existing corpus.
 
     Last moved when a declared version stopped being an override laid over the
-    introspected identity and became the whole of it -- ``implementation`` and
+    introspected identity and became the whole of it. ``implementation`` and
     ``configuration`` are absent under ``version='...'`` now, which is what
     lets an author refactor without re-versioning.
     """

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -594,7 +594,7 @@ def test_step_version_includes_referenced_global_configuration(
 # between checks: two built-ins share one ffmpeg pass by both calling
 # ``frame_stats``, and the motion checks share ``hflow.motion``. That only
 # keeps its integrity if a step version follows the code the step calls, all
-# the way down -- otherwise editing a parser or a constant one level below the
+# the way down. Otherwise editing a parser or a constant one level below the
 # step changes what it measures while its version stands still, and the new
 # rows append under the old version.
 #
@@ -738,7 +738,7 @@ def test_step_version_ignores_a_logger_a_helper_happens_to_hold() -> None:
 
     A logger is reachable from real built-ins (``hflow.ffmpeg._binary`` warns
     about an unpinned binary), so it must be describable or the walk stops
-    there -- but describing its handlers or level would hash the same code
+    there. Describing its handlers or level would instead hash the same code
     differently under different logging setups.
     """
     logger = logging.getLogger("hflow.test.identity")
@@ -774,7 +774,7 @@ def test_no_builtin_check_leaves_part_of_itself_undescribed(builtin_name: str) -
     describe, which is right for a user's pipeline and wrong for hflow's own
     code: a marker here means someone can edit the helper below it and no
     version will move. That gap is invisible in a hash, which is why this
-    asserts over the payload -- it is the regression this whole change is
+    asserts over the payload. It is the regression this whole change is
     about, one level further down.
     """
     builtin = getattr(hflow.checks, builtin_name)
@@ -787,7 +787,7 @@ def test_step_version_degrades_instead_of_refusing_over_a_helpers_private_state(
     """A user's helper may hold anything; registration must still work.
 
     The step's OWN captured state stays strict (see the opaque-partial test
-    below) -- this is only about state one call further down, where refusing
+    below). This is only about state one call further down, where refusing
     would make an unrelated helper's internals fatal to registering a step
     that is perfectly describable itself.
     """
@@ -806,7 +806,7 @@ def test_step_version_does_not_descend_into_a_dependency() -> None:
     internals would restore exactly the coupling ``hflow.behavior`` removed:
     a numpy or scipy upgrade that changed nothing a step observes would still
     invalidate every corpus. The dependency's own source is still read, so
-    swapping which function is called is caught -- only its private internals
+    swapping which function is called is caught. Only its private internals
     are out of scope.
     """
     dependency = ModuleType("vendor_analytics")
@@ -846,7 +846,7 @@ def _declared_check_after_refactor(_episode: hflow.Episode) -> hflow.CheckResult
 def test_a_declared_version_survives_a_refactor_of_the_step() -> None:
     """The point of declaring: the author judges two spellings equivalent.
 
-    Without this the declaration was advisory -- the source hash leaked back
+    Without this the declaration was advisory: the source hash leaked back
     in, so refactoring a step that had opted out of derived versioning still
     split its rows, which is the one thing declaring exists to prevent.
     """

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -654,8 +654,11 @@ def _check_over_mutual_recursion(_episode: hflow.Episode) -> hflow.CheckResult:
     return hflow.CheckResult(verdict=_mutually_recursive_even(2))
 
 
+_NONE: frozenset[str] = frozenset()
+
+
 def _version_of(function: Callable[..., object], name: str = "probe") -> str:
-    return compute_check_version(name, function, False, frozenset(), None)
+    return compute_check_version(name, function, False, _NONE, None)
 
 
 def test_step_version_follows_a_helper_the_step_does_not_name(
@@ -827,6 +830,61 @@ def test_step_version_does_not_descend_into_a_dependency() -> None:
     )
 
     assert _version_of(check_over_a_dependency) == before
+
+
+def _declared_check_before_refactor(_episode: hflow.Episode) -> hflow.CheckResult:
+    total = 0
+    return hflow.CheckResult(measurements={"n": total})
+
+
+def _declared_check_after_refactor(_episode: hflow.Episode) -> hflow.CheckResult:
+    # Renamed local, added comment, reads the shared constant the same way.
+    running_total = 0
+    return hflow.CheckResult(measurements={"n": running_total})
+
+
+def test_a_declared_version_survives_a_refactor_of_the_step() -> None:
+    """The point of declaring: the author judges two spellings equivalent.
+
+    Without this the declaration was advisory -- the source hash leaked back
+    in, so refactoring a step that had opted out of derived versioning still
+    split its rows, which is the one thing declaring exists to prevent.
+    """
+    before = compute_check_version(
+        "owned", _declared_check_before_refactor, False, _NONE, None, "3"
+    )
+    after = compute_check_version("owned", _declared_check_after_refactor, False, _NONE, None, "3")
+
+    assert before == after
+    assert _version_of(_declared_check_before_refactor) != _version_of(
+        _declared_check_after_refactor
+    ), "the same refactor must still move a DERIVED version"
+
+
+def test_a_declared_version_still_tracks_what_was_declared_beside_it() -> None:
+    """Declaring owns the implementation, never the registration.
+
+    ``critical`` and a gate are written at the decorator, not refactored into
+    existence: changing one is a deliberate policy edit with a visible diff,
+    and a gate especially must keep moving the version or two thresholds share
+    one and curation can pin neither.
+    """
+    owned = ("owned", _declared_check_before_refactor, False, _NONE, None, "3")
+    baseline = compute_check_version(*owned)
+    gate = hflow.Gate(accept_when=(hflow.Threshold("n", hflow.Comparison.AT_MOST, 1.0),))
+    looser = hflow.Gate(accept_when=(hflow.Threshold("n", hflow.Comparison.AT_MOST, 9.0),))
+
+    assert compute_check_version(*owned, gate=gate) != baseline
+    assert compute_check_version(*owned, gate=looser) != compute_check_version(*owned, gate=gate)
+    critical_owned = ("owned", _declared_check_before_refactor, True, _NONE, None, "3")
+    assert compute_check_version(*critical_owned) != baseline
+
+
+def test_bumping_a_declared_version_is_what_moves_it() -> None:
+    """The author's promise is the whole identity, so the promise must count."""
+    arguments = ("owned", _declared_check_before_refactor, False, _NONE, None)
+
+    assert compute_check_version(*arguments, "3") != compute_check_version(*arguments, "4")
 
 
 def test_declared_step_version_supports_opaque_callable() -> None:


### PR DESCRIPTION
Follow-up to `f734e34` (on `main`), which widened a step hash to the first-party code a step transitively calls.

## The problem

`version='...'` read as an override laid *over* the introspected identity. It replaced the captured configuration, but `_callable_implementation_identity` still hashed the function's source underneath, so declaring a version bought nothing a refactor could use:

```
automatic:          5ad98987 -> d91aaf64   MOVED
with version='v1':  cf63d4c7 -> 39baf7dd   MOVED   <-- leaks
```

That is a renamed local and an added comment moving the hash of a step whose author had explicitly opted out of derived versioning, which is the one thing declaring exists to prevent. It matters more now that the derived walk reaches shared library code, since a no-op refactor of a shared helper re-versions everything downstream of it.

## The change

Under a declared version the function is not introspected at all. What survives is the **registration**: `name`, `critical`, `requires`, `uses`, and the gate. Those are not what the function is made of, they are what the author wrote at the decorator. Changing one is a deliberate policy edit with a visible diff rather than a refactor, and a gate especially has to keep moving the version or two threshold policies share one and curation can pin neither.

So there are two honest modes instead of one and a half:

| | Derived (default) | Declared (`version=`) |
|---|---|---|
| Hashes | source, captured config, first-party callees | nothing from the function |
| Refactor | re-versions | keeps the identity |
| Forgetting | impossible | your problem |

Derived stays the default because the two mistakes are not symmetric. An unnecessary split is recoverable: both hashes exist and a query can union them. A missed one is not: two behaviours under one version, with nothing left to say which row came from which.

`allow_opaque` goes with it. It existed so a declared step could describe an unreadable callable weakly instead of refusing; nothing reaches that path now, and a *derived* version over a callable the machinery cannot read has no honest answer but the refusal.

## Notes for review

- The golden identity hash in `test_gates.py` moves. That is what it is for: the payload shape changed deliberately.
- Still identity epoch 3, unreleased, so this is the same one-time re-version rather than a second one.
- The last commit drops the ` -- ` construction from the prose these commits added, and fixes two paragraphs in `PORTING.md` that the semantics change had made untrue.

754 passed, 3 skipped; `ruff` and `ty` clean.