### PR TITLE
fix(server): warn on stderr when --pipeline file cannot be imported.

### DIFF
--- a/packages/hflow-server/src/hflow_server/_pipeline.py
+++ b/packages/hflow-server/src/hflow_server/_pipeline.py
@@ -11,6 +11,7 @@ remembered, the config capability reports false, and /api/v1/pipeline answers
 409 with the stored reason.
 """
 
+import sys
 from dataclasses import dataclass
 
 from fastapi import APIRouter, HTTPException
@@ -52,7 +53,16 @@ PipelineState = PipelineLoaded | PipelineUnavailable
 
 
 def load_pipeline_state(pipeline_spec: str | None) -> PipelineState:
-    """Run the one startup import and remember its outcome, whatever it is."""
+    """Run the one startup import and remember its outcome, whatever it is.
+
+    A configured import that failed also reports itself on stderr, once,
+    here where the outcome is computed: the degrade stays deliberate -- one
+    unimportable file must not stop the catalog, episodes, and curation
+    pages from serving -- but an operator who asked for a pipeline should
+    not have to open the pipeline page and find a 409 to learn this launch
+    does not include one. A missing ``--pipeline`` is the ordinary case and
+    stays silent.
+    """
     if pipeline_spec is None:
         return PipelineUnavailable(
             detail=(
@@ -63,6 +73,11 @@ def load_pipeline_state(pipeline_spec: str | None) -> PipelineState:
     try:
         return PipelineLoaded(application=import_pipeline_application(pipeline_spec))
     except ValueError as error:
+        print(
+            f"hflow serve: --pipeline {pipeline_spec} could not be imported: {error}",
+            file=sys.stderr,
+            flush=True,
+        )
         return PipelineUnavailable(detail=str(error))
 
 

--- a/packages/hflow-server/tests/test_server_pipeline.py
+++ b/packages/hflow-server/tests/test_server_pipeline.py
@@ -7,6 +7,7 @@ startup import is side-effect-free.
 
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 from hflow_server import ServerSettings, create_app
 from ui_test_fixtures import PopulatedWorkspace
@@ -135,3 +136,39 @@ def test_pipeline_unconfigured_is_a_409_naming_the_flag(api: TestClient) -> None
     response = api.get("/api/v1/pipeline")
     assert response.status_code == 409
     assert "--pipeline" in response.json()["detail"]
+
+
+def test_failed_startup_import_warns_on_stderr_naming_path_and_reason(
+    tmp_path: Path, unbuilt_assets_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The operator asked for a pipeline and did not get one: the launch says
+    so on stderr, naming the path and the reason, while still serving."""
+    pipeline_file = _written_pipeline_file(tmp_path, RAISING_PIPELINE_SOURCE)
+    data_root = tmp_path / "root"
+    data_root.mkdir()
+    client = _client_over(data_root, unbuilt_assets_dir, pipeline=str(pipeline_file))
+    assert client.get("/api/v1/config").json()["capabilities"]["pipeline"] is False
+    stderr_text = capsys.readouterr().err
+    assert str(pipeline_file) in stderr_text
+    assert "boom at import" in stderr_text
+    assert "--pipeline" in stderr_text
+
+
+def test_no_import_warning_for_a_working_or_unconfigured_launch(
+    populated_workspace: PopulatedWorkspace,
+    unbuilt_assets_dir: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Only a configured-and-failed import warns: a working pipeline and the
+    ordinary no---pipeline launch are both silent."""
+    working_file = _written_pipeline_file(tmp_path, WORKING_PIPELINE_SOURCE)
+    client = _client_over(
+        populated_workspace.data_root, unbuilt_assets_dir, pipeline=str(working_file)
+    )
+    assert client.get("/api/v1/pipeline").status_code == 200
+    assert "could not be imported" not in capsys.readouterr().err
+
+    unconfigured = _client_over(populated_workspace.data_root, unbuilt_assets_dir, pipeline=None)
+    assert unconfigured.get("/api/v1/pipeline").status_code == 409
+    assert "could not be imported" not in capsys.readouterr().err


### PR DESCRIPTION
Closes #125

An operator who passes `--pipeline` and gets an unimportable file used to see a
completely normal launch: the degrade stayed deliberate (and still does -- one bad
file must not take down catalog/episodes/curation serving), but the failure never
reached the terminal, so a typo was indistinguishable from a working launch until
someone opened the pipeline page and found a 409.

Now the startup reports itself once on stderr, naming the path and the reason:

    hflow serve: --pipeline /tmp/nope.py could not be imported: importing
    /tmp/nope.py failed: [Errno 2] No such file or directory

Everything else is unchanged: the process still starts, exit code is unaffected,
/api/v1/pipeline still answers 409 with the same detail, /api/v1/config still
reports the capability false, and
test_pipeline_import_failure_is_remembered_not_fatal passes untouched.

The report lives where the outcome is computed (`load_pipeline_state`'s failure
branch), so it fires exactly once at startup -- never per request -- and cannot
fire when no `--pipeline` was given: the unconfigured case returns before the try.
The line goes to stderr with flush=True, matching how `serve` already guarantees
its notices reach piped output.

Validation:

    uv run ruff check src tests packages
    uv run ruff format --check src tests packages
    uv run ty check src tests packages/hflow-server/src packages/hflow-server/tests
    uv run pytest -q          # 753 passed, 3 skipped

The issue's own repro now prints the report as the first line before uvicorn's
startup banner.
