### PR TITLE
docs: stop counting the built-ins in prose that dates instantly

### DIFF
--- a/docs/how-to/enable-built-in-checks.md
+++ b/docs/how-to/enable-built-in-checks.md
@@ -182,7 +182,7 @@ FROM episodes WHERE status != 'quarantined' AND black_pct < 5.0
 ## One packaged check that is not in this list
 
 `hflow.mediapipe_hands.mediapipe_hand_detection` also ships with HFlow, and is
-deliberately not one of the fifteen: it runs a model rather than computing a
+deliberately not one of them: it runs a model rather than computing a
 signal statistic. Everything above -- evidence-only results, content-hash
 versions, gates you attach -- works the same way for it, but it needs an opt-in
 extra and a downloaded model asset, and what it records is what MediaPipe

--- a/docs/how-to/measure-hand-presence-with-mediapipe.md
+++ b/docs/how-to/measure-hand-presence-with-mediapipe.md
@@ -203,7 +203,7 @@ things.
 ## See also
 
 - [Enable the built-in quality checks](./enable-built-in-checks.md) -- the
-  fifteen deterministic checks, which this is not one of.
+  deterministic checks, none of which this is.
 - [Call an OpenAI vision endpoint from a step](./call-openai-vision.md) -- the
   other way to ask about hands, and the one that can answer questions a
   landmark detector cannot (whose hands, gloved or bare, holding what).


### PR DESCRIPTION
Follow-up to #138. It said "not one of the fifteen" while #136 was landing a sixteenth built-in (`required_topics`); both merges were textually clean, so the contradiction slipped through.

Neither sentence needs the number — removed rather than incremented, so the next built-in cannot stale it again. The one place that does state a count sits immediately above the table a reader can count for themselves.