### PR TITLE
feat(cli): add `hflow curate --dry-run` and render the no-output report clearly

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -107,7 +107,8 @@ def _build_parser() -> argparse.ArgumentParser:
             f"(default: $HFLOW_DATA_ROOT/catalog, else {DEFAULT_DATA_ROOT}/catalog)"
         ),
     )
-    curate_parser.add_argument(
+    curate_output_group = curate_parser.add_mutually_exclusive_group()
+    curate_output_group.add_argument(
         "--output",
         "-o",
         default=f"{_environment_data_root().rstrip('/')}/manifest.parquet",
@@ -116,6 +117,11 @@ def _build_parser() -> argparse.ArgumentParser:
             f"(default: $HFLOW_DATA_ROOT/manifest.parquet, else "
             f"{DEFAULT_DATA_ROOT}/manifest.parquet)"
         ),
+    )
+    curate_output_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run the query and report row count and coverage without writing a manifest",
     )
 
     export_parser = subparsers.add_parser(
@@ -784,7 +790,11 @@ def _command_curate(arguments: argparse.Namespace) -> int:
         return 2
     try:
         sql = arguments.sql if arguments.sql is not None else arguments.sql_file.read_text()
-        report = curate(arguments.catalog, sql, output=arguments.output)
+        report = curate(
+            arguments.catalog,
+            sql,
+            output=None if arguments.dry_run else arguments.output,
+        )
     except (ValueError, FileNotFoundError) as error:
         print(f"curate: {error}", file=sys.stderr)
         return 2

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -82,9 +82,12 @@ class CurationReport:
     coverage: list[CheckCoverage]
 
     def summary(self) -> str:
+        if self.manifest_path is None:
+            manifest = "manifest: (not written; dry run)"
+        else:
+            manifest = f"manifest: {self.manifest_path}"
         lines = [
-            f"manifest: {self.manifest_path} ({self.row_count} rows, "
-            f"from {self.total_episodes} cataloged episodes)"
+            f"{manifest} ({self.row_count} rows, from {self.total_episodes} cataloged episodes)"
         ]
         lines.append("coverage (episodes each check ran on):")
         for entry in sorted(self.coverage, key=lambda item: item.check_name):

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -10,7 +10,7 @@ import pytest
 import hflow
 from hflow.catalog import TABLE_COLUMN_DDL, Catalog, CheckRunRow, content_episode_id
 from hflow.cli import main as cli_main
-from hflow.curation import curate, open_catalog_connection
+from hflow.curation import CurationReport, curate, open_catalog_connection
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import EpisodeStamps
 
@@ -436,6 +436,59 @@ def test_cli_curate(
 
 def test_cli_curate_requires_exactly_one_sql_source(tmp_path: Path) -> None:
     assert cli_main(["curate", "--catalog", str(tmp_path)]) == 2
+
+
+def test_cli_curate_dry_run_reports_without_writing_a_manifest(
+    recorded_data_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_root = tmp_path / "data-root"
+    monkeypatch.setenv("HFLOW_DATA_ROOT", str(data_root))
+    exit_code = cli_main(
+        [
+            "curate",
+            "SELECT episode_id, task FROM episodes WHERE status != 'quarantined'",
+            "--catalog",
+            str(recorded_data_root / "catalog"),
+            "--dry-run",
+        ]
+    )
+    assert exit_code == 0
+    printed = capsys.readouterr().out
+    assert "1 rows" in printed
+    assert "manifest: (not written; dry run)" in printed
+    assert "manifest: None" not in printed
+    assert not (data_root / "manifest.parquet").exists()
+
+
+def test_cli_curate_rejects_dry_run_with_an_explicit_output(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(
+            [
+                "curate",
+                "SELECT 1",
+                "--catalog",
+                str(tmp_path),
+                "--dry-run",
+                "--output",
+                str(tmp_path / "manifest.parquet"),
+            ]
+        )
+    assert exc_info.value.code == 2
+
+
+def test_curation_report_summary_renders_the_no_output_case() -> None:
+    report = CurationReport(
+        manifest_path=None,
+        row_count=3,
+        total_episodes=10,
+        coverage=[],
+    )
+    summary = report.summary()
+    assert "manifest: (not written; dry run)" in summary
+    assert "manifest: None" not in summary
 
 
 def test_stale_episodes_lists_only_episodes_behind_the_current_versions(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Adds `hflow curate --dry-run` and fixes the report's no-output rendering.

- `--dry-run` is mutually exclusive with an explicit `--output` (argparse group, per the issue's pattern-to-copy). When set, the CLI passes `output=None` to the library so the query still runs and reports row count + check coverage without writing a manifest. The library (`curate(..., output=None)`, documented at `src/hflow/curation.py:438-454`) remains the single owner of dry-run execution.
- Omitting both flags preserves the existing environment-aware default output (`$HFLOW_DATA_ROOT/manifest.parquet`).
- `CurationReport.summary()` now renders the no-output case as `manifest: (not written; dry run)` instead of the literal `None`.

## Validation

```bash
uv sync --locked --all-extras
uv run ruff check --fix      # clean
uv run ruff format           # clean (1 file reformatted by the gate)
uv run ty check              # 1 pre-existing diagnostic only: unresolved import cv2 in
                             # src/hflow/motion.py:71 (optional opencv dep absent in this env;
                             # file untouched by this PR)
uv run pytest -q             # 781 passed, 7 skipped
```

The 4 failures + 13 errors are all pre-existing environment issues on this machine, proven against a clean-main worktree: `test_ffmpeg.py` needs ffmpeg/ffprobe on PATH, and the two `test_checks.py` failures come from the new `motion.py` module needing `cv2` (both reproduce identically with all my changes stashed). Targeted tests for this change: `pytest tests/test_catalog_curation.py -k "curate or report or manifest"` → 10 passed (3 new: dry-run CLI behavior, dry-run + `--output` mutual exclusion, no-output report rendering).

## Tests added

- `test_cli_curate_dry_run_reports_without_writing_a_manifest` — exit 0, report shows `(not written; dry run)`, no manifest created under `HFLOW_DATA_ROOT`.
- `test_cli_curate_rejects_dry_run_with_an_explicit_output` — argparse exits 2.
- `test_curation_report_summary_renders_the_no_output_case` — no `manifest: None`.

Closes #8