### PR TITLE
fix(cli): answer bad serve launch input with exit 2

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -157,8 +157,9 @@ Every `hflow` command follows the same three-value convention:
   `stale --exit-code`, stale episodes found; `up`, started then failed, so
   containers may still be running; `ingest`, episodes failed.
 - `2` - bad input, nothing useful happened: an invalid flag combination, an
-  unreachable endpoint, a missing catalog, or a `doctor` run in which no file
-  could be diagnosed at all.
+  unreachable endpoint, a missing catalog, a `serve` launch that never started
+  (a port outside 1-65535, a data root that is not a directory, a host with no
+  free port), or a `doctor` run in which no file could be diagnosed at all.
 
 `doctor` treats an unreadable file as at least as bad as a non-conforming one
 (exit 1), and reserves 2 for runs where nothing was diagnosed, so a batch run

--- a/packages/hflow-server/src/hflow_server/__init__.py
+++ b/packages/hflow-server/src/hflow_server/__init__.py
@@ -6,8 +6,8 @@ subcommand is a thin caller of exactly these two names.
 """
 
 from hflow_server._settings import ServerSettings
-from hflow_server.server import create_app, serve
+from hflow_server.server import ServerStartupError, create_app, serve
 
 __version__ = "0.1.0"
 
-__all__ = ["ServerSettings", "__version__", "create_app", "serve"]
+__all__ = ["ServerSettings", "ServerStartupError", "__version__", "create_app", "serve"]

--- a/packages/hflow-server/src/hflow_server/_settings.py
+++ b/packages/hflow-server/src/hflow_server/_settings.py
@@ -59,6 +59,17 @@ class ServerSettings:
         # the command line. Left to bind(2) instead, an out-of-range port
         # surfaces as an OverflowError from inside the port probe, and port 0
         # binds fine while printing a URL nobody can open.
+        # Type first, because the range test cannot do it. bool subclasses int,
+        # so True is 1 to a comparison and would pass the range on its way into
+        # the URL this launch prints and hands to the browser. Ordered first for
+        # a second reason: a str port reaching the range test raises TypeError
+        # from the comparison, and every caller here is catching ValueError.
+        #
+        # `isinstance` and not `type(...) is int`, so an IntEnum member is
+        # accepted; this mirrors RuntimeConfig.api_port in `hflow.runtime`,
+        # message shape included, because the two fields are the same field.
+        if not isinstance(self.port, int) or isinstance(self.port, bool):
+            raise ValueError(f"port must be an int, not {type(self.port).__name__}: {self.port!r}")
         if not MIN_PORT <= self.port <= MAX_PORT:
             raise ValueError(f"port {self.port!r} is not in {MIN_PORT}-{MAX_PORT}")
 

--- a/packages/hflow-server/src/hflow_server/server.py
+++ b/packages/hflow-server/src/hflow_server/server.py
@@ -428,6 +428,17 @@ def _contained_asset_response(assets_directory: Path, requested_path: str) -> Fi
     return FileResponse(resolved_candidate)
 
 
+class ServerStartupError(RuntimeError):
+    """The launch could not be started, and nothing is serving.
+
+    Its own type so ``hflow serve`` can answer a launch that never got off the
+    ground with exit 2 (bad input, nothing happened) without also catching a
+    RuntimeError raised out of ``uvicorn.run`` once the server is up, which is
+    exit 1 (started, then failed). Subclasses RuntimeError so callers that
+    already catch that keep working.
+    """
+
+
 def serve(settings: ServerSettings) -> None:
     """Run the workspace server: free port, printed URL, browser, uvicorn."""
     application = create_app(settings)
@@ -470,4 +481,6 @@ def _first_free_port(host: str, preferred_port: int) -> int:
             except OSError:
                 continue
         return candidate_port
-    raise RuntimeError(f"no free port between {preferred_port} and {last_candidate_port} on {host}")
+    raise ServerStartupError(
+        f"no free port between {preferred_port} and {last_candidate_port} on {host}"
+    )

--- a/packages/hflow-server/tests/test_server_settings.py
+++ b/packages/hflow-server/tests/test_server_settings.py
@@ -1,5 +1,7 @@
 """ServerSettings: the launch values parsed where they are set."""
 
+from enum import IntEnum
+
 import pytest
 from hflow_server import ServerSettings
 
@@ -22,3 +24,35 @@ def test_the_default_launch_is_loopback_and_servable() -> None:
     settings = ServerSettings(data_root="/tmp/does-not-need-to-exist")
     assert settings.host == "127.0.0.1"
     assert 1 <= settings.port <= 65535
+
+
+def test_a_port_that_is_not_an_int_is_refused_with_runtimeconfig_s_message() -> None:
+    """The type check `hflow.runtime` grew for the same field, in this package too.
+
+    `bool` subclasses int, so ``True`` satisfies ``1 <= port <= 65535`` and
+    reaches the URL the launch prints as ``http://127.0.0.1:True``. A ``str``
+    is worse than useless: it raises TypeError out of the range comparison,
+    which the CLI's ``except ValueError`` does not catch, so a bad ``--port``
+    escapes as a traceback. Both are why the type test is ordered first.
+    """
+    wrong_type_ports: tuple[object, ...] = (True, 8080.0, "4356", None)
+    for wrong_type_port in wrong_type_ports:
+        with pytest.raises(ValueError, match="port must be an int"):
+            # The wrong type is the point: this guards the callers that are not
+            # type checked, which is every command line there has ever been.
+            ServerSettings(data_root="/tmp/does-not-need-to-exist", port=wrong_type_port)  # ty: ignore
+
+
+def test_an_intenum_port_is_still_a_port() -> None:
+    """`isinstance` and not `type(...) is int`, matching RuntimeConfig.api_port.
+
+    An IntEnum member is an int by every test Python has, and CONTRIBUTING asks
+    for typed variants over bare literals, so refusing one would punish the
+    style the repo asks for.
+    """
+
+    class WorkspacePort(IntEnum):
+        DEFAULT = 4356
+
+    settings = ServerSettings(data_root="/tmp/does-not-need-to-exist", port=WorkspacePort.DEFAULT)
+    assert settings.port == 4356

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -20,6 +20,7 @@ environment credentials) -- the same commands drive a hosted workspace.
 """
 
 import argparse
+import errno
 import logging
 import os
 import sys
@@ -844,7 +845,7 @@ def _command_doctor(arguments: argparse.Namespace) -> int:
 
 def _command_serve(arguments: argparse.Namespace) -> int:
     try:
-        from hflow_server import ServerSettings, serve
+        from hflow_server import ServerSettings, ServerStartupError, serve
     except ImportError:
         print(
             "serve: the workspace server ships as a separate package so pipeline "
@@ -853,15 +854,38 @@ def _command_serve(arguments: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    settings = ServerSettings(
-        data_root=arguments.data_root,
-        host=arguments.host,
-        port=arguments.port,
-        open_browser=not arguments.no_browser,
-        read_only=arguments.read_only,
-        pipeline=arguments.pipeline,
-    )
-    serve(settings)
+    try:
+        settings = ServerSettings(
+            data_root=arguments.data_root,
+            host=arguments.host,
+            port=arguments.port,
+            open_browser=not arguments.no_browser,
+            read_only=arguments.read_only,
+            pipeline=arguments.pipeline,
+        )
+    except ValueError as error:
+        # Its own block, before anything is built: nothing is serving, so this
+        # is bad input (2) and not a launch that started and then died (1).
+        print(f"serve: {error}", file=sys.stderr)
+        return 2
+    # A bucket data root has no local directory to check, the same distinction
+    # `up` draws for its bundle dir. A local root that is a file, or is not
+    # there at all, otherwise serves an empty workspace at a printed URL and
+    # says nothing about why it is empty.
+    if not is_bucket_url(settings.data_root):
+        local_data_root = Path(settings.data_root)
+        if not local_data_root.is_dir():
+            reason = errno.ENOTDIR if local_data_root.exists() else errno.ENOENT
+            print(f"serve: {os.strerror(reason)}: {local_data_root}", file=sys.stderr)
+            return 2
+    try:
+        serve(settings)
+    except ServerStartupError as error:
+        # Only the startup failure, not RuntimeError at large: the free-port
+        # probe runs before uvicorn binds, so this is still "nothing started".
+        # A RuntimeError out of a running server stays an unhandled crash.
+        print(f"serve: {error}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -1025,3 +1025,80 @@ def test_app_run_errors_helpfully_without_a_script_file(
     monkeypatch.setitem(sys.modules, "__main__", types.ModuleType("__main__"))
     with pytest.raises(RuntimeError, match="notebook"):
         app.run()
+
+
+def test_serve_refuses_a_port_it_cannot_serve(capsys: pytest.CaptureFixture[str]) -> None:
+    """Bad launch input is exit 2 and one line, the answer every other command gives.
+
+    Exit 1 would say the server started and then failed. Nothing started: the
+    port never got as far as the free-port probe.
+    """
+    for unusable_port in ("99999", "0"):
+        exit_code = main(["serve", "--data-root", "/tmp", "--port", unusable_port, "--no-browser"])
+        assert exit_code == 2
+        stderr = capsys.readouterr().err
+        assert stderr.startswith("serve: ")
+        assert "1-65535" in stderr
+        assert "Traceback" not in stderr
+
+
+def test_serve_refuses_a_data_root_that_is_not_a_directory(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """A file, or nothing at all, used to serve an empty workspace and say nothing.
+
+    Both answer with the stock errno sentence the rest of the CLI uses, so the
+    message names which of the two it is rather than leaving the caller to
+    guess why their workspace looks empty.
+    """
+    data_root_file = tmp_path / "not-a-directory"
+    data_root_file.write_text("")
+    missing_data_root = tmp_path / "never-created"
+
+    for data_root, expected in (
+        (data_root_file, "Not a directory"),
+        (missing_data_root, "No such file or directory"),
+    ):
+        exit_code = main(["serve", "--data-root", str(data_root), "--no-browser"])
+        assert exit_code == 2
+        stderr = capsys.readouterr().err
+        assert stderr.startswith("serve: ")
+        assert expected in stderr
+        assert str(data_root) in stderr
+
+
+def test_serve_refuses_a_host_it_cannot_bind(capsys: pytest.CaptureFixture[str]) -> None:
+    """The probe's failure is a launch failure, so it exits 2 like the rest.
+
+    This one arrives as ServerStartupError rather than ValueError, which is why
+    it gets its own handler around ``serve`` instead of being folded into the
+    construction handler above.
+    """
+    exit_code = main(
+        ["serve", "--data-root", "/tmp", "--host", "not-a-host", "--port", "4512", "--no-browser"]
+    )
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("serve: ")
+    assert "no free port" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_serve_does_not_turn_a_running_server_crash_into_bad_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handler catches the startup failure only, not RuntimeError at large.
+
+    A RuntimeError out of a server that is already up means it started and then
+    died, which is exit 1. Widening the handler to RuntimeError would report
+    that as bad launch input and exit 2, which is the bug this issue is about
+    in reverse.
+    """
+    import hflow_server
+
+    def crash_once_running(_settings: object) -> None:
+        raise RuntimeError("uvicorn fell over mid-run")
+
+    monkeypatch.setattr(hflow_server, "serve", crash_once_running)
+    with pytest.raises(RuntimeError, match="mid-run"):
+        main(["serve", "--data-root", "/tmp", "--no-browser"])

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -30,11 +30,15 @@ def served_settings(monkeypatch: pytest.MonkeyPatch) -> list[ServerSettings]:
 def test_ui_flags_land_in_the_launch_settings(
     served_settings: list[ServerSettings], tmp_path: Path
 ) -> None:
+    # A real directory: `serve` refuses a data root that is not one before it
+    # builds the launch, and this test is about the flags reaching it.
+    workspace_directory = tmp_path / "workspace"
+    workspace_directory.mkdir()
     exit_code = main(
         [
             "serve",
             "--data-root",
-            str(tmp_path / "workspace"),
+            str(workspace_directory),
             "--host",
             "0.0.0.0",
             "--port",
@@ -47,7 +51,7 @@ def test_ui_flags_land_in_the_launch_settings(
     )
     assert exit_code == 0
     (settings,) = served_settings
-    assert settings.data_root == str(tmp_path / "workspace")
+    assert settings.data_root == str(workspace_directory)
     assert settings.host == "0.0.0.0"
     assert settings.port == 9999
     assert settings.open_browser is False


### PR DESCRIPTION
Closes #124.

## What changed

`serve` was the only command answering bad launch input with a traceback and exit 1. All three
reported inputs now print one line to stderr and exit 2, and so does a fourth I hit while
reproducing.

```
serve --port 99999                      exit=2  serve: port 99999 is not in 1-65535
serve --port 0                          exit=2  serve: port 0 is not in 1-65535
serve --host not-a-host --port 4512     exit=2  serve: no free port between 4512 and 4521 on not-a-host
serve --data-root <a file>              exit=2  serve: Not a directory: /tmp/ws124file
serve --data-root <missing>             exit=2  serve: No such file or directory: /tmp/nope
```

The last two are the data-root half you mentioned. Before this, a data root that was a regular file
or was not there at all started the server, printed a URL, and served an empty workspace with
nothing said about why it was empty.

## The three pieces

**`ServerSettings.port` type check.** Mirrors `RuntimeConfig.api_port` from #89, message shape
included, and ordered before the range test for two reasons. `bool` subclasses `int`, so `True`
passes the range and reaches the URL as `http://127.0.0.1:True`. A `str` is worse: it raises
`TypeError` out of the comparison, and the handler I added catches `ValueError`, so a bad `--port`
would still escape as a traceback. `isinstance` rather than `type(...) is int` keeps `IntEnum`
working, same as #89.

**`_command_serve` guards.** Two separate blocks, following `_command_up`. `ValueError` around the
`ServerSettings(...)` construction, and the data-root check after it.

**`ServerStartupError`.** The issue warns against widening the handler until a mid-run server crash
also reads as bad input, and a bare `except RuntimeError` around `serve(settings)` does exactly
that. So the free-port probe now raises `ServerStartupError(RuntimeError)` instead. The probe runs
before `uvicorn.run` binds, so that type means "never got off the ground" and nothing else does. It
subclasses `RuntimeError` so anything already catching that is unaffected. There is a test asserting
a `RuntimeError` from a running server still propagates rather than becoming exit 2.

## One thing to check me on

I treated a **missing** data root as bad input alongside a file, since neither is a directory. That
made me change one line of an existing test: `test_ui_flags_land_in_the_launch_settings` passed
`tmp_path / "workspace"` without creating it. That test is about flags reaching the launch and its
sibling on the next case already passes a real `tmp_path`, so I created the directory rather than
weakening the check. If you would rather a missing root still serve, say so and I will narrow it to
`ENOTDIR` only and revert that line.

`docs/FORMAT.md` now names `serve` in the exit-code section.

## Validation

```
uv sync --locked --all-extras
uv run ruff check          All checks passed!
uv run ruff format --check 152 files already formatted
uv run ty check            All checks passed!
uv run pytest -q           808 passed, 9 skipped
```

Also ran each of the five commands above by hand against a real workspace to confirm the exit codes
and that no traceback reaches stderr.