### PR TITLE
fix(storage): say 'Is a directory' at the two remaining sites

### DIFF
--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -343,9 +343,9 @@ class LocalStorageRoot:
         if local_file.is_dir():
             # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
             # class subclasses OSError, not FileNotFoundError, so an `except
-            # FileNotFoundError` stops catching it. cli.py:835 is one such handler,
-            # reached from `hflow doctor` through fetch_uri below, and it turns this
-            # into a finding rather than a traceback; sixteen more name the class
+            # FileNotFoundError` stops catching it. `_command_doctor` is one such
+            # handler, reached through fetch_uri below, and it turns this into a
+            # finding rather than a traceback; sixteen more name the class
             # elsewhere under src/hflow/, and callers outside the repo are the real
             # unknown. The errno carries the accurate text without moving the class.
             # Same decision as the four sites #102 covered. #144.

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -340,6 +340,16 @@ class LocalStorageRoot:
     def fetch(self, relative: str) -> Path:
         """The local file at ``relative`` (it already lives here)."""
         local_file = self.path / _validated_relative_key(relative)
+        if local_file.is_dir():
+            # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
+            # class subclasses OSError, not FileNotFoundError, so an `except
+            # FileNotFoundError` stops catching it. cli.py:835 is one such handler,
+            # reached from `hflow doctor` through fetch_uri below, and it turns this
+            # into a finding rather than a traceback; sixteen more name the class
+            # elsewhere under src/hflow/, and callers outside the repo are the real
+            # unknown. The errno carries the accurate text without moving the class.
+            # Same decision as the four sites #102 covered. #144.
+            raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(local_file))
         if not local_file.is_file():
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
         return local_file
@@ -652,6 +662,9 @@ def fetch_uri(uri: "str | Path") -> Path:
             raise ValueError(f"bucket URI {uri!r} names no object")
         return BucketStorageRoot(parent_url).fetch(name)
     local_file = Path(uri)
+    if local_file.is_dir():
+        # FileNotFoundError, not IsADirectoryError, for the reason above.
+        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(local_file))
     if not local_file.is_file():
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
     return local_file

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -120,6 +120,17 @@ class TestLocalStorageRoot:
         assert "No such file or directory" in str(excinfo.value)
         assert str(missing) in str(excinfo.value)
 
+    def test_fetch_directory_says_is_a_directory(self, tmp_path: Path) -> None:
+        """A directory exists, so ENOENT was the wrong reason (#144)."""
+        root = LocalStorageRoot(tmp_path)
+        a_directory = tmp_path / "landing"
+        a_directory.mkdir()
+        with pytest.raises(FileNotFoundError) as excinfo:
+            root.fetch("landing")
+        assert excinfo.value.errno == errno.EISDIR
+        assert excinfo.value.filename == str(a_directory)
+        assert "Is a directory" in str(excinfo.value)
+
     def test_publish_copies_only_when_needed(self, tmp_path: Path) -> None:
         root = LocalStorageRoot(tmp_path / "root")
         outside_file = tmp_path / "made-elsewhere.bin"
@@ -202,6 +213,16 @@ class TestBucketStorageRoot:
         assert excinfo.value.errno == 2
         assert "No such file or directory" in str(excinfo.value)
         assert str(missing) in str(excinfo.value)
+
+    def test_fetch_local_directory_says_is_a_directory(self, tmp_path: Path) -> None:
+        """`hflow doctor <a directory>` reaches this and reported ENOENT (#144)."""
+        a_directory = tmp_path / "adir"
+        a_directory.mkdir()
+        with pytest.raises(FileNotFoundError) as excinfo:
+            fetch_uri(a_directory)
+        assert excinfo.value.errno == errno.EISDIR
+        assert excinfo.value.filename == str(a_directory)
+        assert "Is a directory" in str(excinfo.value)
 
     def test_publish_uploads_and_warms_mirror(self, tmp_path: Path) -> None:
         root, remote_dir = bucket_over_tmp(tmp_path)


### PR DESCRIPTION
Closes #144.

`storage.py` had two sites testing `is_file()` and raising `ENOENT` on the false
branch, so a path that exists but is a directory got the message for a path that
is absent. `hflow doctor <a directory>` is the one that surfaces on the command
line:

    $ hflow doctor /tmp/probe/adir
      [error] unreadable: [Errno 2] No such file or directory: '/tmp/probe/adir'

Now:

    $ hflow doctor /tmp/probe/adir
      [error] unreadable: [Errno 21] Is a directory: '/tmp/probe/adir'

Exit code is unchanged at 2.

Both sites keep `FileNotFoundError`. `IsADirectoryError` subclasses `OSError`
and not `FileNotFoundError`, so the accurate class would slip past every
existing handler. `cli.py:835` is one of them, and it is what turns this into a
doctor finding rather than a traceback. Sixteen more name the class under
`src/hflow/`. That is the decision #102 settled and #120 carried into the four
sites it covered; these two were never in that list.

`ENOENT` is unchanged for a path that is absent, and there is no caller in the
repo that branches on `errno`, so nothing beyond the message moves.

Two tests, one per site, placed beside the `ENOENT` tests they mirror. Both fail
on the unfixed code with `21 != 2` and pass on the fix. Full suite 593 passed,
9 skipped. `ruff check`, `ruff format --check` and `ty check` clean.