### PR TITLE
fix(cli): answer bad curate and up path input with exit 2

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -603,6 +603,23 @@ def _command_up(arguments: argparse.Namespace) -> int:
         # be false.
         print(f"up: {error}", file=sys.stderr)
         return 2
+    # A bucket data root has no local directory to check, the same distinction
+    # drawn for the bundle dir below. Only a root that exists and is not a
+    # directory is refused here: every one of the three `mkdir` calls in
+    # render_bundle raises NotADirectoryError against it, and nothing has been
+    # rendered or started when that happens, so it is bad input (2).
+    # A *missing* local root is deliberately left alone. `serve` refuses that
+    # case too, but whether it should is open on #143, and until that lands the
+    # two commands agreeing on the wrong answer is worse than only this one
+    # answering the case that is bad input under any reading.
+    if not is_bucket_url(arguments.data_root):
+        local_data_root = Path(arguments.data_root)
+        if local_data_root.exists() and not local_data_root.is_dir():
+            print(
+                f"up: {os.strerror(errno.ENOTDIR)}: {local_data_root}",
+                file=sys.stderr,
+            )
+            return 2
     # A bucket data root has no local directory to host the bundle: ./runtime.
     default_bundle_dir = (
         Path(RUNTIME_BUNDLE_DIRECTORY_NAME)
@@ -789,8 +806,22 @@ def _command_curate(arguments: argparse.Namespace) -> int:
     if (arguments.sql is None) == (arguments.sql_file is None):
         print("curate: pass exactly one of a SQL string or --sql-file", file=sys.stderr)
         return 2
+    if arguments.sql_file is not None:
+        try:
+            sql = arguments.sql_file.read_text()
+        except OSError as error:
+            # Its own block around the read alone, rather than widening the
+            # handler below. `read_text` on a directory raises
+            # IsADirectoryError, which subclasses OSError and not
+            # FileNotFoundError, so it walked past that handler. Catching
+            # OSError here is safe precisely because this block spans one
+            # read of one caller-named path: nothing curate does can reach it,
+            # so a mid-run filesystem failure is still an unhandled crash.
+            print(f"curate: {error}", file=sys.stderr)
+            return 2
+    else:
+        sql = arguments.sql
     try:
-        sql = arguments.sql if arguments.sql is not None else arguments.sql_file.read_text()
         report = curate(
             arguments.catalog,
             sql,

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -516,6 +516,64 @@ def test_up_reports_a_pipeline_directory_as_a_directory(
     assert "containers may still be running" not in streams.err
 
 
+def test_up_reports_a_data_root_that_is_a_file(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """#145. Every mkdir under <data-root>/runtime raised NotADirectoryError."""
+    a_file = tmp_path / "afile"
+    a_file.write_text("not a directory")
+
+    exit_code = main(["up", "--pipeline", str(pipeline_file), "--data-root", str(a_file)])
+
+    assert exit_code == 2
+    assert compose_calls == []
+    streams = capsys.readouterr()
+    assert f"up: Not a directory: {a_file}" in streams.err
+    assert "Traceback" not in streams.err
+    assert "containers may still be running" not in streams.err
+
+
+def test_up_still_accepts_a_data_root_that_is_not_there_yet(
+    compose_calls: list[list[str]],
+    healthy_client: None,
+    pipeline_file: Path,
+    tmp_path: Path,
+) -> None:
+    """The carve-out in #145: only a root that exists and is not a directory is
+    refused. Whether a missing root should be refused is open on #143, and until
+    that lands `up` must not answer it differently from how it always has.
+    """
+    missing_root = tmp_path / "not_there_yet"
+
+    exit_code = main(["up", "--pipeline", str(pipeline_file), "--data-root", str(missing_root)])
+
+    assert exit_code == 0
+    assert compose_calls != []
+
+
+def test_curate_reports_a_sql_file_that_is_a_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """#145. read_text on a directory raises IsADirectoryError, which subclasses
+    OSError and not FileNotFoundError, so it walked past the handler.
+    """
+    a_directory = tmp_path / "sql"
+    a_directory.mkdir()
+
+    exit_code = main(["curate", "--catalog", str(tmp_path), "--sql-file", str(a_directory)])
+
+    assert exit_code == 2
+    streams = capsys.readouterr()
+    assert f"curate: [Errno 21] Is a directory: '{a_directory}'" in streams.err
+    assert "No such file or directory" not in streams.err
+    assert "Traceback" not in streams.err
+
+
 def test_up_reports_a_requirements_directory_as_a_directory(
     compose_calls: list[list[str]],
     healthy_client: None,


### PR DESCRIPTION
Closes #145.

Two commands answered bad path input with a traceback and exit 1. Both now print
one line and exit 2, like every other path flag on those commands.

    curate --sql-file <a directory>    was IsADirectoryError, exit 1
    up --data-root <a regular file>    was NotADirectoryError, exit 1

### curate

The read moves into its own block around the read alone, rather than widening
the handler below it. `read_text` on a directory raises `IsADirectoryError`,
which subclasses `OSError` and not `FileNotFoundError`, so it walked past the
existing handler.

That block catches `OSError`, which is only safe because of how narrow it is: it
spans one read of one path the caller named, and nothing `curate` itself does can
reach it. A mid-run filesystem failure is still an unhandled crash.

### up

The data root is checked before anything renders, not by catching the `mkdir`.
Catching the `mkdir` cannot tell a bad `--data-root` apart from a bundle dir that
is genuinely unwritable, and only the first of those is exit 2.

Only a root that exists and is not a directory is refused. A missing root is
deliberately left alone, per your note on the issue: `serve` refuses that case,
but whether it should is open on #143, and until that lands it is better to have
one command answering the case that is bad input under any reading than two
commands agreeing on an answer that may be withdrawn.

### Tests

Three, in `tests/test_runtime_cli.py` beside the existing exit-code cases.

The two defect tests fail on the unfixed code with the original traceback and
pass on the fix. The third, `test_up_still_accepts_a_data_root_that_is_not_there_yet`,
passes either way by design: it is a regression guard on the carve-out above, so
that a later change extending the check to a missing root has to fail a test
rather than pass quietly.

Full suite 596 passed, 9 skipped. `ruff check`, `ruff format --check` and
`ty check` clean.