### PR TITLE
test: cover plan_batches lower bounds

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -55,6 +55,10 @@ def test_argument_validation() -> None:
         plan_batches({"a": 1}, batch_count=1, target_batch_bytes=1)
     with pytest.raises(ValueError, match="negative"):
         plan_batches({"a": -1}, batch_count=1)
+    with pytest.raises(ValueError, match="batch_count must be >= 1, got 0"):
+        plan_batches({"a": 1}, batch_count=0)
+    with pytest.raises(ValueError, match="target_batch_bytes must be >= 1, got 0"):
+        plan_batches({"a": 1}, target_batch_bytes=0)
     assert plan_batches({}, batch_count=3) == []
 
 


### PR DESCRIPTION
## Summary

- cover the `batch_count < 1` validation branch with a nonempty input
- cover the `target_batch_bytes < 1` validation branch with a nonempty input
- keep production behavior unchanged

Closes #66.

## Validation

- `uv sync --locked --all-extras`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest tests/test_batching.py -q` (7 passed)
- `uv run pytest -q` (810 passed, 9 skipped)