### PR TITLE
feat(resample): add quaternion slerp policy

### DIFF
--- a/src/hflow/format.py
+++ b/src/hflow/format.py
@@ -51,7 +51,7 @@ NANOSECONDS_PER_SECOND = 1_000_000_000
 # versioned: bump this when the grid or selection semantics change.
 # Annotated as ``str`` rather than inferred as a literal, for the same reason
 # TRANSFORM_BEHAVIOR_VERSION is: the whole point is that it changes.
-RESAMPLE_POLICY_VERSION: str = "1"
+RESAMPLE_POLICY_VERSION: str = "2"
 
 # ``provenance/v1`` keys written when derived channels are present:
 # ``derived/<topic>`` holds each derived channel's content-hash version, and

--- a/src/hflow/resample.py
+++ b/src/hflow/resample.py
@@ -6,7 +6,7 @@ versioned: ``hflow.format.RESAMPLE_POLICY_VERSION`` names the semantics
 below and is stamped into ``provenance/v1`` whenever derived channels are
 written.
 
-Resample policy version "1":
+Resample policy version "2":
 
 - The grid steps by ``1e9 / rate_hz`` nanoseconds and is anchored to integer
   multiples of the step (epoch-anchored): it runs from the first multiple at
@@ -17,6 +17,8 @@ Resample policy version "1":
 - ``interpolate``: linear interpolation per column (``numpy.interp``).
 - ``nearest``: the value of the source sample nearest in time to each grid
   point; the earlier sample wins an exact tie.
+- ``slerp``: shortest-arc spherical interpolation of four-component rotation
+  fields after source normalization and sequential hemisphere alignment.
 """
 
 import math
@@ -31,7 +33,9 @@ from hflow.format import NANOSECONDS_PER_SECOND
 if TYPE_CHECKING:
     from hflow.episode import ChannelData
 
-ResamplePolicy = Literal["interpolate", "nearest"]
+ResamplePolicy = Literal["interpolate", "nearest", "slerp"]
+
+_SLERP_NEAR_PARALLEL_DOT = 1.0 - 1e-7
 
 
 @dataclass(frozen=True)
@@ -120,10 +124,9 @@ def _source_columns(channel: "ChannelData", field: str | None) -> dict[str, np.n
 
 
 # Componentwise interpolation of quaternions produces unnormalized rotations
-# and is wrong across antipodal sign flips; refuse the obvious cases until a
-# proper slerp alignment policy lands (tracked follow-up). Name-based
-# detection is best-effort: it cannot catch every quaternion field, but it
-# catches the conventional ones (orientation/quaternion/rotation, 4 columns).
+# and is wrong across antipodal sign flips. Name-based detection is best-effort:
+# it cannot catch every quaternion field, but it catches the conventional ones
+# (orientation/quaternion/rotation, 4 columns).
 _QUATERNION_NAME_HINTS = ("quat", "orientation", "rotation")
 
 
@@ -152,6 +155,72 @@ def _nearest_source_indices(
     return np.where(distance_to_earlier <= distance_to_later, earlier, later)
 
 
+def _slerp_quaternions(
+    source_timestamps_ns: np.ndarray,
+    source_quaternions: np.ndarray,
+    grid_timestamps_ns: np.ndarray,
+) -> np.ndarray:
+    """Shortest-arc interpolation of four-component rotations.
+
+    Component order is deliberately opaque: dot products, normalization, and
+    scalar multiplication work identically for ``xyzw`` and ``wxyz`` input.
+    """
+    source_norms = np.linalg.norm(source_quaternions, axis=1)
+    if np.any(~np.isfinite(source_quaternions)) or np.any(~np.isfinite(source_norms)):
+        raise ValueError("slerp source quaternions must contain only finite values")
+    if np.any(source_norms == 0.0):
+        raise ValueError("slerp source quaternions must have nonzero norm")
+
+    aligned = source_quaternions / source_norms[:, np.newaxis]
+    aligned = aligned.copy()
+    for source_index in range(1, len(aligned)):
+        if np.dot(aligned[source_index - 1], aligned[source_index]) < 0.0:
+            aligned[source_index] *= -1.0
+
+    later_indices = np.searchsorted(source_timestamps_ns, grid_timestamps_ns, side="left")
+    later_indices = np.clip(later_indices, 0, len(source_timestamps_ns) - 1)
+    earlier_indices = np.maximum(later_indices - 1, 0)
+    earlier_timestamps = source_timestamps_ns[earlier_indices]
+    later_timestamps = source_timestamps_ns[later_indices]
+    intervals = later_timestamps - earlier_timestamps
+    interpolation_fractions = np.divide(
+        grid_timestamps_ns - earlier_timestamps,
+        intervals,
+        out=np.zeros(len(grid_timestamps_ns), dtype=np.float64),
+        where=intervals != 0,
+    )
+
+    earlier_quaternions = aligned[earlier_indices]
+    later_quaternions = aligned[later_indices]
+    pair_dots = np.clip(np.einsum("ij,ij->i", earlier_quaternions, later_quaternions), -1.0, 1.0)
+    interpolated = np.empty_like(earlier_quaternions)
+
+    # Below this angle, sin(theta) is small enough that the textbook slerp
+    # quotient loses precision. 1e-7 follows the issue's requested scale and
+    # keeps the normalized-lerp approximation far below float64 data noise.
+    near_parallel = pair_dots > _SLERP_NEAR_PARALLEL_DOT
+    if np.any(near_parallel):
+        fractions = interpolation_fractions[near_parallel, np.newaxis]
+        interpolated[near_parallel] = earlier_quaternions[near_parallel] + fractions * (
+            later_quaternions[near_parallel] - earlier_quaternions[near_parallel]
+        )
+
+    spherical = ~near_parallel
+    if np.any(spherical):
+        theta = np.arccos(pair_dots[spherical])
+        sin_theta = np.sin(theta)
+        fractions = interpolation_fractions[spherical]
+        earlier_weights = np.sin((1.0 - fractions) * theta) / sin_theta
+        later_weights = np.sin(fractions * theta) / sin_theta
+        interpolated[spherical] = (
+            earlier_weights[:, np.newaxis] * earlier_quaternions[spherical]
+            + later_weights[:, np.newaxis] * later_quaternions[spherical]
+        )
+
+    output_norms = np.linalg.norm(interpolated, axis=1)
+    return interpolated / output_norms[:, np.newaxis]
+
+
 def to_grid(
     channel: "ChannelData",
     rate_hz: float,
@@ -164,8 +233,10 @@ def to_grid(
     Numeric fields only (reuses :meth:`ChannelData.to_numpy`, including its
     automatic field selection when ``field`` is None). A 2-D field of shape
     (n_messages, m) becomes m columns named ``<field>_0 .. <field>_{m-1}``.
-    Semantics are pinned by ``hflow.format.RESAMPLE_POLICY_VERSION`` (see
-    the module docstring).
+    ``policy="slerp"`` requires exactly four columns but deliberately does not
+    assume whether their source order is ``xyzw`` or ``wxyz``. Semantics are
+    pinned by ``hflow.format.RESAMPLE_POLICY_VERSION`` (see the module
+    docstring).
     """
     if rate_hz <= 0.0:
         raise ValueError(f"rate_hz must be positive, got {rate_hz}")
@@ -180,8 +251,13 @@ def to_grid(
         raise ValueError(
             f"field {field!r} of topic {channel.topic!r} looks like a quaternion; "
             "componentwise interpolation corrupts rotations (unnormalized, wrong "
-            "across sign flips). Use policy='nearest' for now -- slerp-based "
-            "quaternion alignment is a tracked follow-up."
+            "across sign flips). Use policy='slerp' for rotation-aware interpolation "
+            "or policy='nearest' to copy source samples."
+        )
+    if policy == "slerp" and len(source_columns) != 4:
+        raise ValueError(
+            f"policy='slerp' requires a field with exactly 4 columns, got "
+            f"{len(source_columns)} for field {field!r} of topic {channel.topic!r}"
         )
     match policy:
         case "interpolate":
@@ -201,6 +277,15 @@ def to_grid(
             resampled_columns = {
                 column_name: column_values[nearest_indices]
                 for column_name, column_values in source_columns.items()
+            }
+        case "slerp":
+            source_quaternions = np.column_stack(list(source_columns.values())).astype(np.float64)
+            resampled_quaternions = _slerp_quaternions(
+                source_timestamps_ns, source_quaternions, grid_timestamps_ns
+            )
+            resampled_columns = {
+                column_name: resampled_quaternions[:, component_index]
+                for component_index, column_name in enumerate(source_columns)
             }
         case _:
             assert_never(policy)

--- a/tests/test_resample_derive.py
+++ b/tests/test_resample_derive.py
@@ -132,6 +132,75 @@ def test_to_grid_vector_field_becomes_named_columns() -> None:
     np.testing.assert_allclose(series.values["position_1"], [0.0, 50.0, 100.0, 150.0, 200.0])
 
 
+def quaternion_channel(timestamps_ns: list[int], quaternions: list[list[float]]) -> ChannelData:
+    return make_json_channel(
+        timestamps_ns,
+        [{"orientation": quaternion} for quaternion in quaternions],
+    )
+
+
+def quaternion_values(series: DerivedSeries) -> np.ndarray:
+    return np.column_stack(
+        [series.values[f"orientation_{component_index}"] for component_index in range(4)]
+    )
+
+
+def test_to_grid_slerp_interpolates_180_degree_rotation() -> None:
+    assert RESAMPLE_POLICY_VERSION == "2"
+    source = quaternion_channel(
+        [0, 2_000_000_000],
+        [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0]],
+    )
+
+    series = to_grid(source, 1.0, policy="slerp", field="orientation")
+    quaternions = quaternion_values(series)
+
+    np.testing.assert_allclose(np.linalg.norm(quaternions, axis=1), 1.0)
+    np.testing.assert_allclose(quaternions[1], [0.0, 0.0, np.sqrt(0.5), np.sqrt(0.5)], atol=1e-12)
+    assert abs(np.dot(quaternions[-1], np.array([0.0, 0.0, 1.0, 0.0]))) == pytest.approx(1.0)
+
+
+def test_to_grid_slerp_aligns_antipodal_sign_flip() -> None:
+    rotation = np.array([0.0, 0.0, np.sqrt(0.5), np.sqrt(0.5)])
+    source = quaternion_channel(
+        [0, 1_000_000_000, 2_000_000_000],
+        [[0.0, 0.0, 0.0, 1.0], rotation.tolist(), (-rotation).tolist()],
+    )
+
+    series = to_grid(source, 2.0, policy="slerp", field="orientation")
+    quaternions = quaternion_values(series)
+
+    np.testing.assert_allclose(np.linalg.norm(quaternions, axis=1), 1.0)
+    assert abs(np.dot(quaternions[-1], -rotation)) == pytest.approx(1.0)
+    assert abs(np.dot(quaternions[-2], rotation)) == pytest.approx(1.0)
+
+
+def test_to_grid_slerp_near_parallel_fallback_stays_normalized() -> None:
+    tiny_angle = 1e-5
+    nearly_identical = [0.0, 0.0, np.sin(tiny_angle / 2.0), np.cos(tiny_angle / 2.0)]
+    source = quaternion_channel(
+        [0, 2_000_000_000],
+        [[0.0, 0.0, 0.0, 2.0], nearly_identical],
+    )
+
+    series = to_grid(source, 1.0, policy="slerp", field="orientation")
+    quaternions = quaternion_values(series)
+
+    np.testing.assert_allclose(np.linalg.norm(quaternions, axis=1), 1.0)
+    expected_midpoint = np.array([0.0, 0.0, np.sin(tiny_angle / 4.0), np.cos(tiny_angle / 4.0)])
+    assert abs(np.dot(quaternions[1], expected_midpoint)) == pytest.approx(1.0)
+
+
+def test_to_grid_slerp_rejects_non_quaternion_width() -> None:
+    channel = make_json_channel(
+        [0, 1_000_000_000],
+        [{"rotation": [1.0, 0.0, 0.0]}, {"rotation": [0.0, 1.0, 0.0]}],
+    )
+
+    with pytest.raises(ValueError, match="exactly 4 columns, got 3"):
+        to_grid(channel, 1.0, policy="slerp", field="rotation")
+
+
 def test_to_grid_rejects_span_shorter_than_one_step() -> None:
     with pytest.raises(ValueError, match="shorter than one grid step"):
         to_grid(ramp_channel(), 0.01, policy="interpolate")
@@ -318,8 +387,7 @@ def test_second_transform_override_errors(tmp_path: Path) -> None:
 
 
 def test_interpolate_refuses_quaternion_shaped_fields() -> None:
-    """Componentwise lerp corrupts rotations; the guard fails loudly until
-    slerp-based alignment lands (dependency-assessment follow-up)."""
+    """Componentwise lerp corrupts rotations; the guard points to slerp."""
     from typing import cast
 
     import numpy as np
@@ -346,7 +414,7 @@ def test_interpolate_refuses_quaternion_shaped_fields() -> None:
 
     # Duck-typed test double smuggled past the checker, like untyped user code.
     channel = cast(ChannelData, _FakeQuaternionChannel())
-    with pytest.raises(ValueError, match="quaternion"):
+    with pytest.raises(ValueError, match="policy='slerp'"):
         to_grid(channel, 10.0, policy="interpolate", field="orientation")
     # nearest copies whole samples and stays quaternion-safe.
     series = to_grid(channel, 10.0, policy="nearest", field="orientation")


### PR DESCRIPTION
## Summary

- add public `policy="slerp"` support for exactly four-component rotation fields
- normalize source samples, reject non-finite/zero-norm inputs, and apply sequential hemisphere alignment before shortest-arc interpolation
- use normalized linear interpolation when `dot > 1 - 1e-7` to avoid the near-parallel slerp precision loss
- preserve component-order agnosticism (`xyzw` and `wxyz` both work) and normalize every output sample
- update quaternion-shaped `interpolate` errors to recommend `slerp`, and reject non-4-column fields explicitly
- bump `RESAMPLE_POLICY_VERSION` to `"2"`

## Regression coverage

- 180-degree midpoint and unit norm
- antipodal sign flip with exact-source rotational equality (`abs(dot) ≈ 1`)
- near-parallel normalized-lerp fallback
- explicit non-4-column rejection
- updated quaternion interpolation guidance

## Validation

- `ruff check .`
- `ruff format --check .`
- `ty check`
- full test suite: 817 passed, 9 skipped
- randomized 200-path smoke check: finite/unit outputs and exact-source rotational equivalence

Closes #97

Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>