### PR TITLE
Expose ChannelData.publish_times

### DIFF
--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -113,6 +113,18 @@ class ChannelData:
         return self._log_times
 
     @property
+    def publish_times(self) -> np.ndarray:
+        """Publish times in nanoseconds, shape (n,). Does not decode.
+
+        These are when the publisher stamped each message, not when the
+        recorder wrote it -- unlike :attr:`timestamps`, they are **not**
+        guaranteed to be ascending, since messages can be logged out of
+        publish order. Compare against :attr:`timestamps` to measure
+        recording latency.
+        """
+        return self._publish_times
+
+    @property
     def raw(self) -> list[bytes]:
         """Raw encoded message payloads. Does not decode."""
         return self._raw

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -162,6 +162,20 @@ def test_arrow_export(report_and_app: tuple[hflow.TestReport, hflow.App]) -> Non
     assert "position" in table.column_names
 
 
+def test_channel_exposes_publish_times(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+) -> None:
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        channel = episode.channel("/joint_states")
+        publish_times = channel.publish_times
+
+    assert publish_times.shape == (len(channel),)
+    # Same length as the log times they pair with, so the two can be
+    # subtracted to get per-message recording latency.
+    assert publish_times.shape == channel.timestamps.shape
+
+
 def test_failed_critical_verdict_quarantines_and_skips_downstream(
     source_episode: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #4.

Adds the property directly below `timestamps`, following that pattern as the issue suggests.

```python
@property
def publish_times(self) -> np.ndarray:
    """Publish times in nanoseconds, shape (n,). Does not decode.

    These are when the publisher stamped each message, not when the
    recorder wrote it -- unlike :attr:`timestamps`, they are **not**
    guaranteed to be ascending, since messages can be logged out of
    publish order. Compare against :attr:`timestamps` to measure
    recording latency.
    """
    return self._publish_times
```

I spelled out the "compare against `timestamps`" use in the docstring because that is the reason to reach for publish times over log times at all, and it makes the missing ascending guarantee land as a consequence rather than a footnote.

### Test

Added to `tests/test_end_to_end.py`, using the existing `report_and_app` fixture next to `test_arrow_export`. It asserts the shape matches `len(channel)` per the definition of done, plus that it matches `timestamps.shape` — the pairing is what makes the latency subtraction valid, and a future change that returned a differently-sized array would still satisfy the first assertion alone.

### One caveat, stated plainly

**I could not run the suite locally.** `hflow` imports `fcntl`, which does not exist on Windows, so `import hflow` fails before any test runs on my machine:

```
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```

`ruff check` and `ruff format --check` are clean on both changed files, and the property mirrors the adjacent `timestamps` exactly, but I am relying on your CI rather than claiming a green local run I did not have. If the test needs adjusting to the fixture I will turn it around quickly.