### PR TITLE
refuse measurement keys that claim the artifact/ namespace

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -467,12 +467,18 @@ def _check_run_rows(report: "TestReport") -> list[CheckRunRow]:
         )
         for run in report.checks
     ]
+    _raise_if_measurement_keys_claim_artifact_namespace(
+        (row.check_name, key) for row in check_rows for key in row.measurements
+    )
     for enrichment_run in report.enrichments:
         enrichment_result = enrichment_run.result
         labels: dict[str, float | int | str | bool] = (
             dict(enrichment_result.labels) if enrichment_result is not None else {}
         )
         if enrichment_result is not None:
+            _raise_if_measurement_keys_claim_artifact_namespace(
+                (enrichment_run.enrichment.name, key) for key in labels
+            )
             labels.update(
                 {
                     f"{ARTIFACT_MEASUREMENT_KEY_PREFIX}{artifact_name}": artifact_uri
@@ -492,6 +498,37 @@ def _check_run_rows(report: "TestReport") -> list[CheckRunRow]:
             )
         )
     return check_rows
+
+
+def _raise_if_measurement_keys_claim_artifact_namespace(
+    claimed: Iterable[tuple[str, str]],
+) -> None:
+    """Refuse a key that claims the framework's ``artifact/`` namespace.
+
+    ``ARTIFACT_MEASUREMENT_KEY_PREFIX`` is reserved for URIs the framework
+    itself publishes: this module packs them into the same measurements dict
+    under that prefix, and snapshot.py exports every key under it as media.
+    A user label reaching that dict under the prefix is indistinguishable
+    from a real published artifact, and the ``labels.update`` merge below
+    would let a real artifact of the same name silently overwrite the label.
+    The enrichment call site runs before that merge, while the two are still
+    told apart; the check call site runs on rows whose measurements never
+    carry framework keys at all.
+    """
+    claimed_names = [
+        f"{key!r} from {check_name!r}"
+        for check_name, key in claimed
+        if key.startswith(ARTIFACT_MEASUREMENT_KEY_PREFIX)
+    ]
+    if not claimed_names:
+        return
+    raise ValueError(
+        f"measurement keys claim the framework's artifact/ namespace: "
+        f"{'; '.join(claimed_names)}. Keys under artifact/ are reserved for the "
+        "URIs the framework publishes (snapshot.py exports every such key as "
+        "media), so a real artifact of the same name would silently overwrite "
+        "the label. Rename the key."
+    )
 
 
 def _raise_if_measurement_keys_collide(check_rows: Sequence[CheckRunRow]) -> None:

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -166,3 +166,75 @@ def test_enrichment_uses_alias_is_preflighted(source_episode: Path, tmp_path: Pa
 
     with pytest.raises(ValueError, match="captioner"):
         app.test(source_episode, verbose=False)
+
+
+def test_enrichment_label_claiming_the_artifact_namespace_is_refused(
+    source_episode: Path, tmp_path: Path
+) -> None:
+    """A user label under `artifact/` is indistinguishable from a published
+    artifact in the catalog, and snapshot.py ships every such key as media."""
+    data_root = tmp_path / "data"
+    app = hflow.App("artifact-claim", data_root=data_root)
+
+    @app.enrich()
+    def labeling(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        return hflow.EnrichmentResult(
+            labels=cast(
+                dict,
+                {"artifact/notes": "s3://bucket/notes", "caption": "legit label"},
+            )
+        )
+
+    with pytest.raises(ValueError, match=r"'artifact/notes'.*'labeling'"):
+        app.test(source_episode, verbose=False, record=True)
+    assert list((data_root / "catalog" / "episodes").glob("*.parquet")) == []
+
+
+def test_check_measurement_claiming_the_artifact_namespace_is_refused(
+    source_episode: Path, tmp_path: Path
+) -> None:
+    """A check measurement key under `artifact/` is refused the same way."""
+    data_root = tmp_path / "data"
+    app = hflow.App("artifact-claim-check", data_root=data_root)
+
+    @app.check()
+    def labeled(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"artifact/frames": 1.0})
+
+    with pytest.raises(ValueError, match=r"'artifact/frames'.*'labeled'"):
+        app.test(source_episode, verbose=False, record=True)
+    assert list((data_root / "catalog" / "episodes").glob("*.parquet")) == []
+
+
+def test_labels_near_the_artifact_namespace_still_land_with_real_artifacts(
+    source_episode: Path, tmp_path: Path
+) -> None:
+    """Only the exact `artifact/` prefix is reserved; real artifacts land unchanged."""
+    data_root = tmp_path / "data"
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    app = hflow.App("artifact-boundary", data_root=data_root)
+
+    @app.enrich()
+    def labeling(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        artifact_path = artifact_dir / "segments.json"
+        artifact_path.write_text(json.dumps({"segments": []}))
+        return hflow.EnrichmentResult(
+            labels=cast(dict, {"artifact_notes": "s3://bucket/notes"}),
+            artifacts={"segments": artifact_path},
+        )
+
+    app.test(source_episode, verbose=False, record=True)
+    connection = open_catalog_connection(data_root / "catalog")
+    try:
+        label_row = connection.execute(
+            "SELECT value_text FROM measurements WHERE key = 'artifact_notes'"
+        ).fetchone()
+        assert label_row == ("s3://bucket/notes",)
+        artifact_row = connection.execute(
+            "SELECT value_text FROM measurements WHERE key = 'artifact/segments'"
+        ).fetchone()
+        assert artifact_row is not None
+        assert str(artifact_row[0]).endswith("segments.json")
+    finally:
+        connection.close()


### PR DESCRIPTION
Fixes #151

## What changed

`_check_run_rows` now refuses, before anything is written, any enrichment label or check measurement key that claims the framework's `artifact/` prefix:

- **Enrichments**: guarded on the user labels **before** `labels.update` merges published artifact URIs into the same dict — the one layer that can still tell the two apart (the merge erases the distinction, which is why the catalog layer cannot do this).
- **Checks**: guarded on the row's measurements (those never carry framework keys, but the guard keeps the message shape uniform).
- Message shape mirrors `_raise_if_measurement_keys_shadow_episode_columns`: names the check and the key, states the collision, says what to do instead.

## Why

A user label like `artifact/notes` lands a row indistinguishable from a real published artifact, `snapshot.py:357` exports every measurement key under the prefix as media, and `labels.update` means a real artifact of the same name silently overwrites the label. Same defect family as #129/#130, third instance, settled fix shape per #133.

## Tests

Three new tests in `tests/test_enrichments.py`, in the same file as the existing artifact-landing test so the two behaviors are proven side by side:

- `test_enrichment_label_claiming_the_artifact_namespace_is_refused` — refused with a message naming check + key; nothing written (no episode parquet).
- `test_check_measurement_claiming_the_artifact_namespace_is_refused` — same gate on the check path.
- `test_labels_near_the_artifact_namespace_still_land_with_real_artifacts` — `artifact_notes` (close, not claiming) and a real `artifact/segments` URI both land unchanged.

## Validation

```bash
uv run pytest tests/test_enrichments.py -q      # 10 passed
uv run pytest -q                                # 813 passed, 6 skipped
uv run ruff check --fix                         # clean
uv run ruff format                              # clean
uv run ty check                                 # clean
```

The 2 failed + 13 errors in the full run are all in `tests/test_ffmpeg.py` and are the known environment gap (no ffmpeg binary in this WSL; `HFLOW_FFMPEG` unset), same as noted on #141 — zero overlap with changed files.