### PR TITLE
Update CATALOG.md

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -161,13 +161,12 @@ episode-scoped, prefix it with the check instead.
 
 **Name keys `<topic>/<metric>_<unit>`.** The topic prefix is what keeps two
 cameras (or two checks) from colliding, and it also keeps a key from clashing
-with an episode column like `task` or `uri`. If a measurement key shadows an
-episode column, the append is refused, naming the check, the key, and the
-column (`catalog.py:301`). Additionally, a measurement key or enrichment label
-must not start with `artifact/`; that prefix is reserved for URIs published by
-the framework, and user keys in that namespace would be treated as fake media
-– such keys are refused at `app.py`
-(`_raise_if_measurement_keys_claim_artifact_namespace`).
+with an episode column like `task` or `uri`. Two namespaces are not yours to
+take, and both are refused at append time rather than resolved silently: an
+episode column name, refused naming the check, the key, and the column it
+shadows; and anything starting with `artifact/`, which is reserved for the URIs
+the framework publishes -- a snapshot export treats every key under that prefix
+as media, so a user key there would ship as media the pipeline never produced.
 Keys containing `/` need double quotes in SQL:
 
 ```sql

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -161,7 +161,13 @@ episode-scoped, prefix it with the check instead.
 
 **Name keys `<topic>/<metric>_<unit>`.** The topic prefix is what keeps two
 cameras (or two checks) from colliding, and it also keeps a key from clashing
-with an episode column like `task` or `uri`, which makes the wide view error.
+with an episode column like `task` or `uri`. If a measurement key shadows an
+episode column, the append is refused, naming the check, the key, and the
+column (`catalog.py:301`). Additionally, a measurement key or enrichment label
+must not start with `artifact/`; that prefix is reserved for URIs published by
+the framework, and user keys in that namespace would be treated as fake media
+– such keys are refused at `app.py`
+(`_raise_if_measurement_keys_claim_artifact_namespace`).
 Keys containing `/` need double quotes in SQL:
 
 ```sql


### PR DESCRIPTION
Clarify naming conventions for measurement keys and their restrictions.

## Summary

- Corrects the outdated claim that a key clashing with an episode column "makes the wide view error" to the actual behavior: the append is refused, naming the check, the key, and the column.
- Adds the missing reserved namespace `artifact/` (measurement keys and enrichment labels may not start with this prefix) as a third restriction, consistent with the code in `app.py`.
- The section now accurately reflects the two refusal checks in `catalog.py:301` and `app.py`, and keeps the "Three rules" structure intact.

## Why

The docs were out of sync with #133 (refusal instead of error) and #151 (new artifact/ reserved name). This fixes the mismatch so check authors have accurate, up‑to‑date rules.

## Validation

- Since this is a documentation-only change and I don't have the local toolchain set up, I relied on manual review of the changes.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [ ] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [ ] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [ ] I preserved stored-data compatibility or documented an explicit version change.
