### PR TITLE
chore: prepare HFlow 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hflow"
-version = "0.2.0"
+version = "0.2.1"
 description = "Open source SDK for building Physical AI data pipelines"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "hflow"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

- bump the core HFlow package version to 0.2.1
- keep the workspace lock metadata aligned

This release makes the current main branch, including portable dataset snapshots, available from PyPI.

## Validation

- `uv lock --check`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run --python 3.11 --locked pytest -q` (946 passed, 6 skipped)
- `uv run --python 3.14 --locked pytest -q` (946 passed, 6 skipped)
- `uv build`
- installed-wheel smoke test on Python 3.11
- installed CLI reports `hflow 0.2.1`
- installed CLI exposes `hflow export snapshot --help`