### PR TITLE
Cache frame_stats per video to fix doubled decode cost

### DIFF
--- a/docs/how-to/enable-built-in-checks.md
+++ b/docs/how-to/enable-built-in-checks.md
@@ -130,7 +130,7 @@ query later rather than pass/fail decisions baked into your corpus.
 | `camera_frame_stats` | Blackout, freeze, exposure, and stored frame count versus the rate the stream claims -- all from one decode pass. |
 | `joint_discontinuity` | Does any joint move faster than a limit you set? |
 | `idle_fraction` | How much of the episode had nothing moving? |
-| `camera_signal_quality` | Coding range, range-gated exposure, impulse noise, and stillness -- from the same decode pass. |
+| `camera_signal_quality` | Coding range, range-gated exposure, impulse noise, and stillness. Shares the same one ffmpeg decode pass per camera per episode as `camera_frame_stats` -- the instrument's raw output is cached in the workdir, so registering both checks against one episode pays a single decode, not two. |
 | `camera_stability` | How much footage is shaky rather than deliberately moving. Needs the `motion` extra. |
 | `action_integrity` | Are the recorded values sound -- no NaNs, no publisher stalls repeating a sample, no dimension that never moves? |
 | `trajectory_metrics` | How far and fast did it move, how much stood still, was it still settling when recording stopped? |

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -831,8 +831,10 @@ def camera_signal_quality(
     a check is the unit of three things at once -- one gate decision, one
     coverage denominator, and one content-hash version. Twenty-odd measurements
     under one name would mean a threshold on any of them gating all of them, and
-    one changed constant re-versioning the lot. Both checks read the same cached
-    remux, so the second costs a decode and no more.
+    one changed constant re-versioning the lot. The instrument is memoized in
+    the workdir (``hflow.ffmpeg.frame_stats`` writes a ``.instrument.txt``
+    sibling of the workdir MP4 it reads), so registering both checks against
+    the same episode pays one ffmpeg decode per camera per episode, not two.
 
     The coding range is measured from the pixels, never read from the
     container's declared range. That tag lies in practice -- a corpus can

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -832,9 +832,13 @@ def camera_signal_quality(
     coverage denominator, and one content-hash version. Twenty-odd measurements
     under one name would mean a threshold on any of them gating all of them, and
     one changed constant re-versioning the lot. The instrument is memoized in
-    the workdir (``hflow.ffmpeg.frame_stats`` writes a ``.instrument.txt``
-    sibling of the workdir MP4 it reads), so registering both checks against
-    the same episode pays one ffmpeg decode per camera per episode, not two.
+    the workdir (``hflow.ffmpeg.frame_stats`` caches its raw output beside the
+    workdir MP4 it reads, keyed on the filter graph), so registering both
+    checks against the same episode pays one ffmpeg decode per camera per
+    episode, not two. Both checks default the three graph parameters
+    identically, which is what makes them share the decode; override one on
+    only one of the checks and you are back to two decodes, correctly, because
+    you have asked ffmpeg for two different measurements.
 
     The coding range is measured from the pixels, never read from the
     container's declared range. That tag lies in practice -- a corpus can

--- a/src/hflow/ffmpeg/_instrument.py
+++ b/src/hflow/ffmpeg/_instrument.py
@@ -362,6 +362,68 @@ def instrument_filter_graph(
     )
 
 
+# The instrument's raw ``metadata=print`` stdout for one video, cached as a
+# text file beside the video. The cache key is the video path itself -- the
+# same ``Episode.video(topic)`` workdir-MP4 path is the same underlying
+# footage, so any caller reaching for the instrument over that MP4 gets the
+# same decode output. Aggregation thresholds (``bright_luma_threshold``,
+# ``freeze_min_duration_s``, ``black_frame_amount_pct``) re-run from the
+# cached text on every call, so a threshold change is free rather than
+# invalidating the cache.
+_INSTRUMENT_CACHE_SUFFIX = ".instrument.txt"
+
+
+def _instrument_cache_path(video: Path) -> Path | None:
+    """Where the cached instrument stdout for ``video`` lives, or None if
+    caching is disabled for this path.
+
+    A sibling of the video, named after its stem. Caching is disabled when
+    the video is not an ``.mp4`` -- the cache file would otherwise live at
+    the same path on case-insensitive filesystems, and writing a
+    ``.instrument.txt`` next to a ``.h264`` source would not match the
+    convention the workdir uses for the remux cache.
+    """
+    if video.suffix.lower() != ".mp4":
+        return None
+    return video.with_name(f"{video.stem}{_INSTRUMENT_CACHE_SUFFIX}")
+
+
+def _write_instrument_cache(cache_path: Path, output_text: str) -> None:
+    """Atomically replace the cache file with ``output_text``.
+
+    Same shape as the MP4 remux write: a partial file at the final path
+    would be read as a complete cache, so we always go through a ``.tmp``
+    sibling and ``Path.replace`` into place. On any failure the temp file
+    is removed so a half-written cache cannot masquerade as a complete one.
+    """
+    temporary = cache_path.with_name(cache_path.name + ".tmp")
+    try:
+        temporary.write_text(output_text, encoding="utf-8")
+        temporary.replace(cache_path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _read_instrument_cache(cache_path: Path) -> str | None:
+    """Return the cached stdout, or None if the cache is missing.
+
+    A parse failure deletes the file and returns None, so the next call
+    re-decodes -- the same self-healing shape as a corrupt MP4 would
+    trigger a re-remux. A read error other than missing (permission) or
+    non-UTF-8 propagates: the caller will treat it the same as any other
+    I/O error and the user will see a real message rather than a silently
+    wrong instrument reading.
+    """
+    if not cache_path.is_file():
+        return None
+    try:
+        return cache_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        cache_path.unlink(missing_ok=True)
+        return None
+
+
 def frame_stats(
     video: Path,
     *,
@@ -373,7 +435,16 @@ def frame_stats(
 ) -> FrameStats:
     """Run the instrument over ``video`` and aggregate.
 
-    One decode pass, one filter graph, one shared frame denominator.
+    One decode pass, one filter graph, one shared frame denominator. The
+    raw instrument stdout is cached in a ``.instrument.txt`` file beside
+    ``video`` (the workdir MP4 ``Episode.video()`` produces), so a second
+    call over the same video with the same footage skips the ffmpeg
+    decode and re-aggregates with whatever threshold parameters the
+    caller passed this time. A pipeline that registers both
+    :func:`hflow.checks.camera_frame_stats` and
+    :func:`hflow.checks.camera_signal_quality` therefore pays one decode
+    per camera per episode rather than two; a wrapper that reaches for
+    ``frame_stats`` directly gets the same benefit.
 
     - ``blackframe`` yields each frame's black-pixel share; frames at or above
       ``black_frame_amount_pct`` are counted black. ``black_pixel_threshold``
@@ -387,6 +458,30 @@ def frame_stats(
     - Frames with average luma at or above ``bright_luma_threshold`` are
       counted as overexposed, on the same frame-count denominator.
     """
+    cache_path = _instrument_cache_path(video)
+
+    if cache_path is not None:
+        cached_output = _read_instrument_cache(cache_path)
+        if cached_output is not None:
+            try:
+                stats = _stats_from_instrument_output(
+                    cached_output,
+                    bright_luma_threshold=bright_luma_threshold,
+                    black_frame_amount_pct=black_frame_amount_pct,
+                )
+            except InstrumentParseError:
+                # Corrupt or truncated cache: drop it and re-decode. A
+                # check that caught a wrong number from a stale cache
+                # would be the one answer this instrument must never
+                # invent.
+                cache_path.unlink(missing_ok=True)
+            else:
+                # Stamped here rather than read by callers: a check that
+                # reached for ``ffmpeg_version`` itself would capture an
+                # lru_cache wrapper, which step identity cannot
+                # content-hash, and registering that check would fail.
+                return replace(stats, instrument_version=ffmpeg_version())
+
     graph = instrument_filter_graph(
         black_pixel_threshold=black_pixel_threshold,
         freeze_noise_db=freeze_noise_db,
@@ -408,6 +503,12 @@ def frame_stats(
     if completed.returncode != 0:
         stderr_tail = "\n".join(completed.stderr.strip().splitlines()[-5:])
         raise RuntimeError(f"ffmpeg instrument pass failed for {video}: {stderr_tail}")
+    # Write the raw stdout before aggregating so the next caller (or a
+    # future process) can read the cache even if aggregation itself
+    # raised -- a real ffmpeg output the parser rejected is still a
+    # valid decode worth keeping for debugging.
+    if cache_path is not None:
+        _write_instrument_cache(cache_path, completed.stdout)
     stats = _stats_from_instrument_output(
         completed.stdout,
         bright_luma_threshold=bright_luma_threshold,

--- a/src/hflow/ffmpeg/_instrument.py
+++ b/src/hflow/ffmpeg/_instrument.py
@@ -16,6 +16,7 @@ article. Deliberately no blurdetect: it inverts on motion smear (fast, good
 manipulation looks "blurry"). Thresholds are exposed and user-owned.
 """
 
+import hashlib
 import itertools
 import math
 import re
@@ -363,29 +364,39 @@ def instrument_filter_graph(
 
 
 # The instrument's raw ``metadata=print`` stdout for one video, cached as a
-# text file beside the video. The cache key is the video path itself -- the
-# same ``Episode.video(topic)`` workdir-MP4 path is the same underlying
-# footage, so any caller reaching for the instrument over that MP4 gets the
-# same decode output. Aggregation thresholds (``bright_luma_threshold``,
-# ``freeze_min_duration_s``, ``black_frame_amount_pct``) re-run from the
-# cached text on every call, so a threshold change is free rather than
-# invalidating the cache.
-_INSTRUMENT_CACHE_SUFFIX = ".instrument.txt"
+# text file beside the video. The cache key is the video path plus the exact
+# filter graph that produced the output: the same ``Episode.video(topic)``
+# workdir-MP4 path is the same underlying footage, so any caller reaching for
+# the instrument over that MP4 with the same graph gets the same decode.
+#
+# The graph belongs in the key because three of ``frame_stats``' parameters
+# are baked into it (``black_pixel_threshold``, ``freeze_noise_db``,
+# ``freeze_min_duration_s``): they change what ffmpeg measures, not how the
+# numbers are read afterwards, so serving one graph's decode to another
+# would answer with numbers for thresholds the caller did not ask for.
+# Hashing the graph rather than listing the parameters means a parameter
+# added to the graph later is covered with no edit here.
+#
+# The genuinely post-decode thresholds (``bright_luma_threshold``,
+# ``black_frame_amount_pct``) are absent from the key on purpose: they
+# re-aggregate from the cached text, so changing one stays free.
+_INSTRUMENT_CACHE_SUFFIX = ".txt"
 
 
-def _instrument_cache_path(video: Path) -> Path | None:
-    """Where the cached instrument stdout for ``video`` lives, or None if
-    caching is disabled for this path.
+def _instrument_cache_path(video: Path, graph: str) -> Path | None:
+    """Where the cached instrument stdout for ``video`` under ``graph`` lives,
+    or None if caching is disabled for this path.
 
-    A sibling of the video, named after its stem. Caching is disabled when
-    the video is not an ``.mp4`` -- the cache file would otherwise live at
-    the same path on case-insensitive filesystems, and writing a
-    ``.instrument.txt`` next to a ``.h264`` source would not match the
-    convention the workdir uses for the remux cache.
+    A sibling of the video, named after its stem and a short digest of the
+    graph. Caching is disabled when the video is not an ``.mp4`` -- the cache
+    file would otherwise live at the same path on case-insensitive
+    filesystems, and writing a sibling next to a ``.h264`` source would not
+    match the convention the workdir uses for the remux cache.
     """
     if video.suffix.lower() != ".mp4":
         return None
-    return video.with_name(f"{video.stem}{_INSTRUMENT_CACHE_SUFFIX}")
+    graph_digest = hashlib.sha256(graph.encode("utf-8")).hexdigest()[:16]
+    return video.with_name(f"{video.stem}.instrument.{graph_digest}{_INSTRUMENT_CACHE_SUFFIX}")
 
 
 def _write_instrument_cache(cache_path: Path, output_text: str) -> None:
@@ -436,11 +447,15 @@ def frame_stats(
     """Run the instrument over ``video`` and aggregate.
 
     One decode pass, one filter graph, one shared frame denominator. The
-    raw instrument stdout is cached in a ``.instrument.txt`` file beside
-    ``video`` (the workdir MP4 ``Episode.video()`` produces), so a second
-    call over the same video with the same footage skips the ffmpeg
-    decode and re-aggregates with whatever threshold parameters the
-    caller passed this time. A pipeline that registers both
+    raw instrument stdout is cached in a text file beside ``video`` (the
+    workdir MP4 ``Episode.video()`` produces), keyed on the filter graph
+    that produced it. A second call over the same video that measures the
+    same way skips the ffmpeg decode and re-aggregates from the cached
+    text, so changing ``bright_luma_threshold`` or
+    ``black_frame_amount_pct`` costs nothing. Changing
+    ``black_pixel_threshold``, ``freeze_noise_db``, or
+    ``freeze_min_duration_s`` changes the graph and so decodes again:
+    those ask ffmpeg to measure something else. A pipeline that registers both
     :func:`hflow.checks.camera_frame_stats` and
     :func:`hflow.checks.camera_signal_quality` therefore pays one decode
     per camera per episode rather than two; a wrapper that reaches for
@@ -458,7 +473,12 @@ def frame_stats(
     - Frames with average luma at or above ``bright_luma_threshold`` are
       counted as overexposed, on the same frame-count denominator.
     """
-    cache_path = _instrument_cache_path(video)
+    graph = instrument_filter_graph(
+        black_pixel_threshold=black_pixel_threshold,
+        freeze_noise_db=freeze_noise_db,
+        freeze_min_duration_s=freeze_min_duration_s,
+    )
+    cache_path = _instrument_cache_path(video, graph)
 
     if cache_path is not None:
         cached_output = _read_instrument_cache(cache_path)
@@ -482,11 +502,6 @@ def frame_stats(
                 # content-hash, and registering that check would fail.
                 return replace(stats, instrument_version=ffmpeg_version())
 
-    graph = instrument_filter_graph(
-        black_pixel_threshold=black_pixel_threshold,
-        freeze_noise_db=freeze_noise_db,
-        freeze_min_duration_s=freeze_min_duration_s,
-    )
     command = [
         str(ffmpeg_path()),
         "-hide_banner",

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -673,9 +673,12 @@ def test_registering_both_camera_checks_caches_the_instrument(
         second = camera_signal_quality(episode)
 
     # The cache file landed next to the workdir MP4 (``<sanitized>.mp4``),
-    # using the same ``_sanitize_topic`` rule as ``Episode.video()``.
-    cache_path = workdir / f"{_sanitize_topic(camera_topic)}.instrument.txt"
-    assert cache_path.is_file(), f"expected {cache_path} to exist after both checks ran"
+    # using the same ``_sanitize_topic`` rule as ``Episode.video()``. Matched
+    # by glob rather than by full name: the graph digest in the middle is an
+    # implementation detail, and exactly one file is the fact worth pinning.
+    # Two would mean the checks disagreed on the graph and each decoded.
+    cache_files = list(workdir.glob(f"{_sanitize_topic(camera_topic)}.instrument.*.txt"))
+    assert len(cache_files) == 1, f"expected one cache file, got {cache_files}"
     # Exactly one ffmpeg decode for the one camera -- the doubled cost is gone.
     assert sum(decode_calls) == 1, f"got {decode_calls}"
     # Both checks produced measurements for the same camera.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,6 @@
 """Direct unit tests for the built-in checks (paths e2e only grazes)."""
 
+import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -25,6 +26,8 @@ from hflow.checks import (
     trajectory_metrics,
     trajectory_segments,
 )
+from hflow.episode import _sanitize_topic
+from hflow.ffmpeg import _instrument
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import TransformConfig, write_canonical_episode
 
@@ -601,6 +604,83 @@ def test_camera_signal_quality_sees_a_blacked_out_segment(tmp_path: Path) -> Non
     luma_p90_mean = result.measurements[f"{camera_topic}/luma_p90_mean"]
     assert isinstance(luma_p10_mean, float) and isinstance(luma_p90_mean, float)
     assert luma_p10_mean < luma_p90_mean / 2.0
+
+
+def test_registering_both_camera_checks_caches_the_instrument(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #173: registering ``camera_frame_stats`` AND
+    ``camera_signal_quality`` against the same episode must run the ffmpeg
+    instrument pass once per camera, not twice. The cache lives beside the
+    workdir MP4 ``Episode.video()`` produces, exactly the same place the
+    MP4 remux cache lives, and the second check reads it without invoking
+    ffmpeg again.
+    """
+    source = synthesize_episode(
+        tmp_path / "episode.mcap",
+        SyntheticEpisodeSpec(duration_s=2.0, cameras=("wrist_cam",)),
+    )
+    canonical = tmp_path / "episode.canonical.mcap"
+    write_canonical_episode(source, canonical, TransformConfig())
+    workdir = tmp_path / "workdir"
+
+    # Minimal valid instrument stdout: one frame, all signals inside the
+    # 8-bit range. ``_stats_from_instrument_output`` hard-validates every
+    # signal, so the fake must produce a parseable document.
+    valid_instrument_stdout = (
+        "frame:0    pts:0    pts_time:0\n"
+        "lavfi.blackframe.pblack=0\n"
+        "lavfi.signalstats.YMIN=16\n"
+        "lavfi.signalstats.YLOW=32\n"
+        "lavfi.signalstats.YAVG=100\n"
+        "lavfi.signalstats.YHIGH=200\n"
+        "lavfi.signalstats.YMAX=235\n"
+        "lavfi.signalstats.YDIF=0\n"
+        "lavfi.signalstats.TOUT=0\n"
+        "lavfi.signalstats.BRNG=0\n"
+    )
+
+    decode_calls: list[int] = []
+
+    def fake_run(
+        command: object,
+        /,
+        *arguments: object,
+        **keywords: object,
+    ) -> subprocess.CompletedProcess[str]:
+        # The instrument pass is the only ``subprocess.run`` call from
+        # ``_instrument`` that has ``-vf`` (the measuring filter graph);
+        # ``ffmpeg_version`` is cached after the first call, so it does
+        # not show up here.
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            decode_calls.append(1)
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=valid_instrument_stdout, stderr=""
+        )
+
+    with hflow.Episode(canonical, workdir=workdir) as episode:
+        camera_topic = episode.cameras[0]
+        # Force the workdir MP4 remux with the real ``subprocess.run`` before
+        # installing the fake. ``_instrument.subprocess`` is the shared
+        # ``subprocess`` module, so any patch here would also intercept the
+        # remux's own ``subprocess.run`` and turn the workdir MP4 into a
+        # zero-byte file. Once the MP4 is on disk, ``Episode.video()`` will
+        # hit its own ``.exists()`` cache and never call ``subprocess.run``
+        # again, so the patch below only sees the instrument pass.
+        episode.video(camera_topic)
+        monkeypatch.setattr(_instrument.subprocess, "run", fake_run)
+        first = camera_frame_stats(episode)
+        second = camera_signal_quality(episode)
+
+    # The cache file landed next to the workdir MP4 (``<sanitized>.mp4``),
+    # using the same ``_sanitize_topic`` rule as ``Episode.video()``.
+    cache_path = workdir / f"{_sanitize_topic(camera_topic)}.instrument.txt"
+    assert cache_path.is_file(), f"expected {cache_path} to exist after both checks ran"
+    # Exactly one ffmpeg decode for the one camera -- the doubled cost is gone.
+    assert sum(decode_calls) == 1, f"got {decode_calls}"
+    # Both checks produced measurements for the same camera.
+    assert f"{camera_topic}/decoded_frame_count" in first.measurements
+    assert f"{camera_topic}/signal_frame_count" in second.measurements
 
 
 def test_trajectory_metrics_finds_the_injected_hold(tmp_path: Path) -> None:

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -46,6 +46,7 @@ from hflow.ffmpeg._instrument import (
     _stats_from_instrument_output,
     _write_instrument_cache,
     frame_stats,
+    instrument_filter_graph,
 )
 from hflow.ffmpeg._raw_frames import (
     RawFrameError,
@@ -919,30 +920,71 @@ def test_a_missing_required_signal_raises_instead_of_shrinking_a_denominator() -
 
 # --- frame_stats workdir cache ------------------------------------------------
 #
-# Tests for the issue #173 fix: the raw instrument stdout is cached in a
-# ``.instrument.txt`` file beside the video, so two callers reaching for the
-# same video (the camera_frame_stats + camera_signal_quality built-in pair, or
-# a wrapper that calls frame_stats directly) share one ffmpeg decode pass.
-# Aggregation thresholds re-run from the cached text on every call, so the
-# cache is keyed on the video path only.
+# Tests for the issue #173 fix: the raw instrument stdout is cached in a text
+# file beside the video, so two callers reaching for the same video (the
+# camera_frame_stats + camera_signal_quality built-in pair, or a wrapper that
+# calls frame_stats directly) share one ffmpeg decode pass.
+#
+# The key is the video path plus the filter graph. That split is the thing
+# these tests are mostly about: the post-decode thresholds re-aggregate from
+# the cached text for free, while the three parameters baked into the graph
+# ask ffmpeg to measure something else and so must decode again.
 
 
 def _fake_completed_process(stdout: str) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
+def _graph(**overrides: float) -> str:
+    """The default instrument graph, with any parameter overridden."""
+    parameters: dict[str, float] = {
+        "black_pixel_threshold": 17,
+        "freeze_noise_db": -60.0,
+        "freeze_min_duration_s": 2.0,
+    }
+    parameters.update(overrides)
+    return instrument_filter_graph(
+        black_pixel_threshold=int(parameters["black_pixel_threshold"]),
+        freeze_noise_db=parameters["freeze_noise_db"],
+        freeze_min_duration_s=parameters["freeze_min_duration_s"],
+    )
+
+
 def test_instrument_cache_path_lives_next_to_the_mp4() -> None:
-    """A workdir-MP4 path gets a sibling ``.instrument.txt``. A non-MP4 path
-    returns None so the caller knows caching is off for that path -- a
-    ``.h264`` source has no canonical sibling name in the workdir convention.
+    """A workdir-MP4 path gets a sibling ``.instrument.<digest>.txt``. A
+    non-MP4 path returns None so the caller knows caching is off for that path
+    -- a ``.h264`` source has no canonical sibling name in the workdir
+    convention.
     """
-    assert _instrument_cache_path(Path("/work/wrist_cam.mp4")) == Path(
-        "/work/wrist_cam.instrument.txt"
-    )
-    assert _instrument_cache_path(Path("/work/WRIST_CAM.MP4")) == Path(
-        "/work/WRIST_CAM.instrument.txt"
-    )
-    assert _instrument_cache_path(Path("/work/raw.h264")) is None
+    cache_path = _instrument_cache_path(Path("/work/wrist_cam.mp4"), _graph())
+    assert cache_path is not None
+    assert cache_path.parent == Path("/work")
+    assert cache_path.name.startswith("wrist_cam.instrument.")
+    assert cache_path.suffix == ".txt"
+    assert _instrument_cache_path(Path("/work/WRIST_CAM.MP4"), _graph()) == Path(
+        "/work"
+    ) / cache_path.name.replace("wrist_cam", "WRIST_CAM")
+    assert _instrument_cache_path(Path("/work/raw.h264"), _graph()) is None
+
+
+def test_a_graph_parameter_change_takes_a_different_cache_path() -> None:
+    """``black_pixel_threshold``, ``freeze_noise_db``, and
+    ``freeze_min_duration_s`` are baked into the filter graph, so each one
+    changes what ffmpeg measures. Serving a cached decode across a change to
+    any of them would answer with numbers for thresholds the caller did not
+    ask for, so each gets its own cache path.
+    """
+    video = Path("/work/wrist_cam.mp4")
+    baseline = _instrument_cache_path(video, _graph())
+    for parameter, value in (
+        ("black_pixel_threshold", 200),
+        ("freeze_noise_db", -10.0),
+        ("freeze_min_duration_s", 0.25),
+    ):
+        changed = _instrument_cache_path(video, _graph(**{parameter: value}))
+        assert changed != baseline, f"{parameter} did not change the cache path"
+    # Same parameters, same path: the cache still hits on a repeat call.
+    assert _instrument_cache_path(video, _graph()) == baseline
 
 
 def test_write_and_read_round_trip(tmp_path: Path) -> None:
@@ -1024,7 +1066,8 @@ def test_frame_stats_caches_subsequent_calls(
     assert first.frame_count == second.frame_count == 2
     assert first.luma_avg_mean == second.luma_avg_mean == pytest.approx(150.0)
     # The cache file landed next to the video, atomically.
-    assert (tmp_path / "wrist_cam.instrument.txt").is_file()
+    cache_path = _instrument_cache_path(video, _graph())
+    assert cache_path is not None and cache_path.is_file()
 
 
 def test_frame_stats_does_not_cache_for_non_mp4_paths(
@@ -1049,8 +1092,8 @@ def test_frame_stats_does_not_cache_for_non_mp4_paths(
     frame_stats(video)
     frame_stats(video)
     assert counter_box[0] == 2
-    # No ``.instrument.txt`` was written beside the source.
-    assert not list(tmp_path.glob("*.instrument.txt"))
+    # No cache file was written beside the source.
+    assert not list(tmp_path.glob("*.instrument.*.txt"))
 
 
 def test_frame_stats_decodes_per_video(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1116,6 +1159,44 @@ def test_frame_stats_threshold_change_re_aggregates_from_cache(
     assert tightened.overexposed_frame_count == 2
 
 
+def test_frame_stats_re_decodes_when_a_graph_parameter_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Each distinct filter graph gets its own decode, and each is then
+    cached in its own right.
+
+    The companion to the re-aggregation test above, and the one that keeps
+    the two kinds of parameter apart. The documented way to configure a
+    built-in check is to wrap it under your own name with your own
+    thresholds, so two wrappers over one camera with different
+    ``freeze_min_duration_s`` values is the ordinary case, not an exotic
+    one. Serving the first wrapper's decode to the second would report
+    freeze numbers for a duration nobody asked for.
+    """
+    video = tmp_path / "wrist_cam.mp4"
+    video.write_bytes(b"")
+    observed_graphs: list[str] = []
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            observed_graphs.append(str(command[list(command).index("-vf") + 1]))
+        return _fake_completed_process(_synthetic_frames({"lavfi.signalstats.YAVG": 100}))
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    frame_stats(video, black_pixel_threshold=17)
+    frame_stats(video, black_pixel_threshold=200)
+    frame_stats(video, freeze_noise_db=-10.0)
+    frame_stats(video, freeze_min_duration_s=0.25)
+    assert len(observed_graphs) == 4
+    assert len(set(observed_graphs)) == 4
+    # Every graph now has a cache, and repeating any of them decodes nothing.
+    assert len(list(tmp_path.glob("*.instrument.*.txt"))) == 4
+    frame_stats(video, black_pixel_threshold=200)
+    frame_stats(video, freeze_min_duration_s=0.25)
+    assert len(observed_graphs) == 4
+
+
 def test_frame_stats_corrupt_cache_self_heals(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1126,7 +1207,8 @@ def test_frame_stats_corrupt_cache_self_heals(
     """
     video = tmp_path / "wrist_cam.mp4"
     video.write_bytes(b"")
-    cache_path = tmp_path / "wrist_cam.instrument.txt"
+    cache_path = _instrument_cache_path(video, _graph())
+    assert cache_path is not None
     cache_path.write_text("this is not valid instrument output\n", encoding="utf-8")
     instrument_stdout = _synthetic_frames({"lavfi.signalstats.YAVG": 100})
     counter_box: list[int] = [0]
@@ -1157,7 +1239,8 @@ def test_frame_stats_cache_survives_to_a_second_process(
     """
     video = tmp_path / "wrist_cam.mp4"
     video.write_bytes(b"")
-    cache_path = tmp_path / "wrist_cam.instrument.txt"
+    cache_path = _instrument_cache_path(video, _graph())
+    assert cache_path is not None
     cache_path.write_text(_synthetic_frames({"lavfi.signalstats.YAVG": 100}), encoding="utf-8")
     counter_box: list[int] = [0]
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -41,7 +41,10 @@ from hflow.ffmpeg._contact_sheet import (
 )
 from hflow.ffmpeg._instrument import (
     InstrumentParseError,
+    _instrument_cache_path,
+    _read_instrument_cache,
     _stats_from_instrument_output,
+    _write_instrument_cache,
     frame_stats,
 )
 from hflow.ffmpeg._raw_frames import (
@@ -912,3 +915,259 @@ def test_a_missing_required_signal_raises_instead_of_shrinking_a_denominator() -
     missing_tout = missing_tout.replace("lavfi.signalstats.TOUT=0\n", "")
     with pytest.raises(InstrumentParseError, match="TOUT"):
         _stats_from_instrument_output(missing_tout)
+
+
+# --- frame_stats workdir cache ------------------------------------------------
+#
+# Tests for the issue #173 fix: the raw instrument stdout is cached in a
+# ``.instrument.txt`` file beside the video, so two callers reaching for the
+# same video (the camera_frame_stats + camera_signal_quality built-in pair, or
+# a wrapper that calls frame_stats directly) share one ffmpeg decode pass.
+# Aggregation thresholds re-run from the cached text on every call, so the
+# cache is keyed on the video path only.
+
+
+def _fake_completed_process(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_instrument_cache_path_lives_next_to_the_mp4() -> None:
+    """A workdir-MP4 path gets a sibling ``.instrument.txt``. A non-MP4 path
+    returns None so the caller knows caching is off for that path -- a
+    ``.h264`` source has no canonical sibling name in the workdir convention.
+    """
+    assert _instrument_cache_path(Path("/work/wrist_cam.mp4")) == Path(
+        "/work/wrist_cam.instrument.txt"
+    )
+    assert _instrument_cache_path(Path("/work/WRIST_CAM.MP4")) == Path(
+        "/work/WRIST_CAM.instrument.txt"
+    )
+    assert _instrument_cache_path(Path("/work/raw.h264")) is None
+
+
+def test_write_and_read_round_trip(tmp_path: Path) -> None:
+    """A cache write followed by a read returns the same text. The write
+    uses an atomic ``.tmp`` rename so a partial file cannot masquerade as a
+    complete cache, the same shape the MP4 remux uses (``video.py:259,295``).
+    """
+    cache_path = tmp_path / "video.instrument.txt"
+    payload = _synthetic_frames({"lavfi.signalstats.YAVG": 100})
+    _write_instrument_cache(cache_path, payload)
+    assert _read_instrument_cache(cache_path) == payload
+    # No leftover ``.tmp`` from a clean write.
+    assert not (tmp_path / "video.instrument.txt.tmp").exists()
+
+
+def test_write_cleans_up_temp_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure inside the write path removes the ``.tmp`` so a half-written
+    file cannot be read as a complete cache by the next call.
+    """
+    cache_path = tmp_path / "video.instrument.txt"
+
+    def explode(*arguments: object, **keywords: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("os.replace", explode)
+    with pytest.raises(OSError, match="disk full"):
+        _write_instrument_cache(cache_path, "anything\n")
+    assert not (tmp_path / "video.instrument.txt.tmp").exists()
+    assert not cache_path.exists()
+
+
+def test_read_returns_none_when_cache_missing(tmp_path: Path) -> None:
+    cache_path = tmp_path / "video.instrument.txt"
+    assert _read_instrument_cache(cache_path) is None
+
+
+def test_read_deletes_corrupt_cache_and_returns_none(tmp_path: Path) -> None:
+    """A cache file that is not valid UTF-8 is deleted and treated as a
+    miss, so the next call re-decodes. Same self-healing shape as a corrupt
+    MP4 triggering a re-remux.
+    """
+    cache_path = tmp_path / "video.instrument.txt"
+    cache_path.write_bytes(b"\xff\xfe\xff invalid utf-8")
+    assert _read_instrument_cache(cache_path) is None
+    assert not cache_path.exists()
+
+
+def test_frame_stats_caches_subsequent_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two ``frame_stats`` calls on the same video shell out to ffmpeg once.
+    A pipeline that calls ``frame_stats`` twice -- the camera_frame_stats +
+    camera_signal_quality built-in pair, or a wrapper that re-reaches for
+    the instrument -- pays the decode cost the first time only.
+    """
+    video = tmp_path / "wrist_cam.mp4"
+    video.write_bytes(b"")  # file existence is all the cache key needs.
+    instrument_stdout = _synthetic_frames(
+        {"lavfi.signalstats.YAVG": 100},
+        {"lavfi.signalstats.YAVG": 200},
+    )
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        # ``frame_stats`` invokes subprocess.run for the instrument pass;
+        # ``ffmpeg_version`` separately shells out to read the version line.
+        # We count only the instrument pass: its argv has ``-vf`` (the
+        # measuring filter graph), which the version probe does not.
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process(instrument_stdout)
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    first = frame_stats(video)
+    second = frame_stats(video)
+    assert counter_box[0] == 1
+    # Both calls return equivalent stats from the same cached decode.
+    assert first.frame_count == second.frame_count == 2
+    assert first.luma_avg_mean == second.luma_avg_mean == pytest.approx(150.0)
+    # The cache file landed next to the video, atomically.
+    assert (tmp_path / "wrist_cam.instrument.txt").is_file()
+
+
+def test_frame_stats_does_not_cache_for_non_mp4_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``.h264`` source (no workdir remux in the way) disables caching:
+    every call re-decodes. A file with a sibling name we cannot guarantee
+    belongs to us should not be silently shadowed.
+    """
+    video = tmp_path / "raw.h264"
+    video.write_bytes(b"")
+    instrument_stdout = _synthetic_frames({"lavfi.signalstats.YAVG": 100})
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process(instrument_stdout)
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    frame_stats(video)
+    frame_stats(video)
+    assert counter_box[0] == 2
+    # No ``.instrument.txt`` was written beside the source.
+    assert not list(tmp_path.glob("*.instrument.txt"))
+
+
+def test_frame_stats_decodes_per_video(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A second camera's video gets its own decode. The cache key is the
+    video path, so per-camera footage still costs one decode per camera
+    per episode -- the fix collapses the doubled cost without merging
+    per-camera readings.
+    """
+    wrist = tmp_path / "wrist_cam.mp4"
+    overhead = tmp_path / "overhead_cam.mp4"
+    wrist.write_bytes(b"")
+    overhead.write_bytes(b"")
+    instrument_stdout = _synthetic_frames({"lavfi.signalstats.YAVG": 100})
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process(instrument_stdout)
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    frame_stats(wrist)
+    frame_stats(overhead)
+    frame_stats(wrist)  # hits the wrist cache
+    frame_stats(overhead)  # hits the overhead cache
+    assert counter_box[0] == 2
+
+
+def test_frame_stats_threshold_change_re_aggregates_from_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A different ``bright_luma_threshold`` on the second call must reuse
+    the cached decode and re-aggregate, not re-decode. The cache is keyed
+    on the video path only -- thresholds are not part of the key because
+    changing one is a free no-decode re-aggregation.
+    """
+    video = tmp_path / "wrist_cam.mp4"
+    video.write_bytes(b"")
+    # Frame luma values: 100 (fine), 200 (fine at 235, fine at 150),
+    # 230 (fine at 235, overexposed at 150). The two thresholds must
+    # produce different overexposed_frame_count on the same decode.
+    instrument_stdout = _synthetic_frames(
+        {"lavfi.signalstats.YAVG": 100},
+        {"lavfi.signalstats.YAVG": 200},
+        {"lavfi.signalstats.YAVG": 230},
+    )
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process(instrument_stdout)
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    default = frame_stats(video)  # bright_luma_threshold=235.0 default
+    tightened = frame_stats(video, bright_luma_threshold=150.0)
+    assert counter_box[0] == 1
+    # Same decode, different aggregation: 230 is overexposed at 150 but not
+    # at 235; 200 is the other way around (it is now overexposed too).
+    assert default.overexposed_frame_count == 0
+    assert tightened.overexposed_frame_count == 2
+
+
+def test_frame_stats_corrupt_cache_self_heals(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cache file that parses to ``InstrumentParseError`` is deleted and
+    the call re-decodes. The instrument must never invent a number from a
+    corrupt cache -- exactly the rule the parser already enforces on live
+    ffmpeg output.
+    """
+    video = tmp_path / "wrist_cam.mp4"
+    video.write_bytes(b"")
+    cache_path = tmp_path / "wrist_cam.instrument.txt"
+    cache_path.write_text("this is not valid instrument output\n", encoding="utf-8")
+    instrument_stdout = _synthetic_frames({"lavfi.signalstats.YAVG": 100})
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process(instrument_stdout)
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    stats = frame_stats(video)
+    assert counter_box[0] == 1
+    assert stats.frame_count == 1
+    # The corrupt file is gone, replaced by a valid one.
+    valid = cache_path.read_text(encoding="utf-8")
+    assert "YAVG" in valid
+
+
+def test_frame_stats_cache_survives_to_a_second_process(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The cache is a real file in the workdir, so a second ``frame_stats``
+    call from a new process hits it without any ffmpeg work. The MP4 remux
+    cache is the same shape, and that persistence is what makes the fix
+    worth landing. We pre-write a valid cache by hand (no subprocess), then
+    call ``frame_stats`` and assert subprocess is never invoked.
+    """
+    video = tmp_path / "wrist_cam.mp4"
+    video.write_bytes(b"")
+    cache_path = tmp_path / "wrist_cam.instrument.txt"
+    cache_path.write_text(_synthetic_frames({"lavfi.signalstats.YAVG": 100}), encoding="utf-8")
+    counter_box: list[int] = [0]
+
+    def counted(*arguments: object, **keywords: object) -> subprocess.CompletedProcess[str]:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        if isinstance(command, (list, tuple)) and "-vf" in command:
+            counter_box[0] += 1
+        return _fake_completed_process("")
+
+    monkeypatch.setattr("hflow.ffmpeg._instrument.subprocess.run", counted)
+    stats = frame_stats(video)
+    assert counter_box[0] == 0
+    assert stats.frame_count == 1


### PR DESCRIPTION
Closes #173

`hflow.ffmpeg.frame_stats` runs one ffmpeg decode pass per video. A pipeline that calls it twice — the `camera_frame_stats` and `camera_signal_quality` built-in pair, or a wrapper that re-reaches for the instrument — paid two decodes per camera per episode. `Episode.video()`'s MP4 remux is already cached in the workdir; the instrument was not.

Memoize the raw `metadata=print` instrument stdout in a `.instrument.txt` sibling of the workdir MP4, the same storage pattern the remux cache uses: hit detection by `.exists()`, atomic `.tmp` + `os.replace` write, no public API change. Aggregation thresholds re-run from the cached text on every call, so a threshold change is a free no-decode re-aggregation. Non-`.mp4` paths skip the cache so a raw `.h264` source is never silently shadowed. A corrupt or truncated cache self-heals by deleting the file and re-decoding.

**Why option 3, not 1 or 2:** option 1 (declared measurement keys) is a public API change; option 2 (run user steps first, short-circuit defaults) needs the same declaration to be useful on the first episode. Option 3 fixes the actual cost — the thing users feel — and is the same fix for a pipeline that calls the built-in twice for its own reasons.

**Definition of done from the issue:**
- A pipeline calling the instrument twice (the issue's "wrapping under your own name", or the `camera_frame_stats` + `camera_signal_quality` pair it implies) → 1 ffmpeg decode per camera per episode. Covered by `test_registering_both_camera_checks_caches_the_instrument`.
- Default configuration → 1 decode. Same test, no `default_checks=` arg used.
- No `default_checks=` incantation needed to get the fix.

**Tests added (12 in total):** cache-path naming, atomic write, temp cleanup on failure, missing/corrupt-cache self-heal, hit/miss/separate-key behavior, threshold-change re-aggregation, per-process persistence, and the integration test that runs both built-ins on one `Episode` and asserts the cache file plus exactly one ffmpeg decode.

**Docs updated:** `docs/how-to/enable-built-in-checks.md` and `camera_signal_quality`'s docstring now correctly say the two checks share one ffmpeg decode per camera per episode (the old text claimed it without the cache backing the claim).