### PR TITLE
fix: refuse non-finite catalog measurements

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -186,6 +186,13 @@ SELECT episode_id, "/wrist_cam/compressed/black_frame_pct" AS black_pct
 FROM episodes WHERE black_pct < 5.0
 ```
 
+**Omit the key rather than measuring NaN or infinity.** A non-finite float is
+refused at append time, naming the check and the key. NaN compares false against
+everything, so an episode carrying one falls out of both a threshold and its
+complement: it is in neither `black_pct < 1.0` nor `black_pct >= 1.0`, and it
+poisons any `avg()` over the corpus. A check with nothing to say about an episode
+says nothing, and the coverage denominator already records that it ran.
+
 **End the key with a unit the tooling knows.** The workspace UI labels a value
 by the token after the key's last `_`, so `_s`, `_ms`, `_ns`, `_hz`, `_pct`,
 `_ratio`, `_count`, `_bytes`, `_deg`, `_rad`, and `_m` render with their unit

--- a/packages/hflow-server/tests/ui_test_fixtures.py
+++ b/packages/hflow-server/tests/ui_test_fixtures.py
@@ -6,8 +6,11 @@ repository's root test conftest.
 """
 
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -29,6 +32,25 @@ STAMPS = EpisodeStamps(
     ffmpeg_version="ffmpeg version test",
     robot_software_version="sim-0.1.0",
 )
+
+
+@contextmanager
+def _appending_like_an_older_hflow() -> "Iterator[None]":
+    """Let one append write the JSON-illegal doubles a legacy catalog holds.
+
+    ``_normalized_measurements`` refuses a non-finite float at append time, so
+    no catalog written by this version can contain one. A catalog written
+    before that rule can, and the server reads catalogs rather than writing
+    them: it must still answer over one instead of returning a JSON body no
+    client can parse. Suspending the guard for this one append is how the
+    fixture states that, and it keeps the three tests that pin the API's
+    null-not-crash behaviour testing something reachable.
+    """
+    with mock.patch(
+        "hflow.catalog._normalized_measurements",
+        lambda check_name, measurements: dict(measurements),
+    ):
+        yield
 
 
 @dataclass(frozen=True)
@@ -69,6 +91,9 @@ def build_populated_workspace(tmp_path_factory: pytest.TempPathFactory) -> Popul
             measurements={
                 "max_velocity": max_velocity,
                 # JSON-illegal doubles: the API must null these, not crash.
+                # Appending one is refused as of #176, so these reach the
+                # parquet only under _appending_like_an_older_hflow(), which
+                # is what a catalog written before that rule looks like.
                 "nan_metric": float("nan"),
                 "inf_metric": float("inf"),
             },
@@ -93,22 +118,24 @@ def build_populated_workspace(tmp_path_factory: pytest.TempPathFactory) -> Popul
         "success": "true",
         "embodiment": "arm-1",
     }
-    first_append = catalog.append_episode(
-        canonical_path=canonical_file,
-        stamps=STAMPS,
-        episode_metadata=ok_metadata,
-        check_rows=[joint_check_row(1.5), contact_sheet_row],
-        orchestrator_run_id=SUPERSEDED_ORCHESTRATOR_RUN_ID,
-    )
-    # Distinct recorded_at so "latest run" ordering stays deterministic.
-    time.sleep(0.01)
-    second_append = catalog.append_episode(
-        canonical_path=canonical_file,
-        stamps=STAMPS,
-        episode_metadata=ok_metadata,
-        check_rows=[joint_check_row(2.0), contact_sheet_row],
-        orchestrator_run_id=LATEST_ORCHESTRATOR_RUN_ID,
-    )
+    # Only these two appends carry the JSON-illegal doubles.
+    with _appending_like_an_older_hflow():
+        first_append = catalog.append_episode(
+            canonical_path=canonical_file,
+            stamps=STAMPS,
+            episode_metadata=ok_metadata,
+            check_rows=[joint_check_row(1.5), contact_sheet_row],
+            orchestrator_run_id=SUPERSEDED_ORCHESTRATOR_RUN_ID,
+        )
+        # Distinct recorded_at so "latest run" ordering stays deterministic.
+        time.sleep(0.01)
+        second_append = catalog.append_episode(
+            canonical_path=canonical_file,
+            stamps=STAMPS,
+            episode_metadata=ok_metadata,
+            check_rows=[joint_check_row(2.0), contact_sheet_row],
+            orchestrator_run_id=LATEST_ORCHESTRATOR_RUN_ID,
+        )
     assert first_append.written and second_append.written
     assert first_append.episode_id == second_append.episode_id
     time.sleep(0.01)

--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -279,6 +279,11 @@ def _normalized_measurements(
 ) -> dict[str, MeasurementValue]:
     """Coerce NumPy scalars to Python scalars; refuse anything else loudly.
 
+    A non-finite float is refused here too, after the coercion so that
+    ``np.float64("nan")`` is caught as well: NaN compares false against every
+    threshold and its complement at once, so storing one drops the episode
+    from both sides of a cut while the key still claims to be measured.
+
     Real check code returns NumPy scalars (np.mean(), indexing, np.bool_
     verdicts), and only np.float64 subclasses a Python type -- the rest used
     to fall through every storage branch into all-NULL value columns while

--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -33,6 +33,7 @@ mirror (see ``hflow.storage``) -- the idioms above carry over unchanged.
 
 import hashlib
 import json
+import math
 import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
@@ -293,6 +294,11 @@ def _normalized_measurements(
             raise ValueError(
                 f"check {check_name!r} measured {key!r} as {type(value).__name__}: "
                 "measurements hold one int/float/str/bool per key"
+            )
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(
+                f"check {check_name!r} measured {key!r} as {value!r}: "
+                "omit the key when a check has no finite value for this episode"
             )
         normalized[key] = value
     return normalized

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -834,6 +834,72 @@ def test_numpy_scalar_measurements_round_trip(tmp_path: Path) -> None:
     assert wide == pytest.approx((np.float32(0.4).item(), 3.0))
 
 
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_float_measurements_are_refused(tmp_path: Path, bad_value: float) -> None:
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="camera_blackout",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"black_pct": bad_value},
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"camera_blackout.*black_pct.*omit the key.*no finite value",
+    ):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+
+def test_numpy_nan_measurements_are_refused(tmp_path: Path) -> None:
+    import numpy as np
+
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="numpy_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements=cast(dict, {"ratio": np.float64("nan")}),
+    )
+    with pytest.raises(ValueError, match=r"numpy_check.*ratio.*omit the key"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+
+def test_zero_and_non_float_measurements_are_still_accepted(tmp_path: Path) -> None:
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="mixed_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"zero": 0.0, "count": 0, "label": "ok", "flag": False},
+    )
+    result = Catalog(tmp_path / "catalog").append_episode(
+        canonical_path=canonical,
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[row],
+    )
+    assert result.written is True
+
+
 def test_numpy_measured_episode_survives_a_manifest_filter(tmp_path: Path) -> None:
     """A NumPy-measured episode must not vanish from a threshold-filtered manifest."""
     import numpy as np


### PR DESCRIPTION
Fixes #159

## Problem
Catalog measurement normalization accepted non-finite float values such as NaN and infinity. Those values can poison aggregate statistics and make threshold predicates drop an episode from both sides of a cut.

## Fix
After NumPy scalar coercion, `_normalized_measurements` now refuses non-finite Python floats with an error that names the check/key and tells the check author to omit the key when there is no finite value. Ordinary finite floats, ints, strings, and bools are unchanged.

## Tests
- `.venv/bin/pytest tests/test_catalog_curation.py -q`
- `.venv/bin/ty check`
- `.venv/bin/ruff check src/hflow/catalog.py tests/test_catalog_curation.py`
- `.venv/bin/ruff format --check src/hflow/catalog.py tests/test_catalog_curation.py`

## Agent Disclosure
This PR was prepared with AI agent assistance. I reviewed the final diff and test results before submission.