### PR TITLE
fix(checks): skip defaults whose keys the pipeline already emitted (#177)

### DIFF
--- a/docs/how-to/enable-built-in-checks.md
+++ b/docs/how-to/enable-built-in-checks.md
@@ -99,13 +99,19 @@ copies would record the same measurement keys and the catalog would keep only
 one of them. A default is the exception: registering or wrapping one of those
 supersedes it, as above.
 
-Supersession is decided from what a check actually measured, which is only
-knowable after it runs. The automatic copy therefore runs before HFlow discards
-its result. Camera frame measurements cache their raw instrument output in the
-workdir, so a wrapper with the same graph still pays one FFmpeg decode per
-camera. A wrapper that changes a graph parameter correctly causes another
-decode because it requested a different measurement. You can still remove the
-automatic copy when you do not want it to run:
+One cost worth knowing before you wrap `camera_frame_stats` specifically.
+Supersession of a default happens before the default runs when the pipeline's
+wrapper is registered in the same run: HFlow knows the keys each default would
+emit, and any default whose predicted key set overlaps the wrapper's emitted
+keys is recorded as `superseded` without ever calling ffmpeg. The wrapper
+alone decodes the video, the default does no work, and the catalog records
+both rows -- the wrapper's measurements and the `superseded` notice on the
+default, naming the keys the wrapper covered. Every other built-in is cheap
+enough that this never mattered; the doc only called `camera_frame_stats` out
+because it is the one whose cost is ffmpeg.
+
+If you prefer to drop the default and own the measurement yourself, that works
+the same as before:
 
 ```python
 app = hflow.App(
@@ -115,7 +121,8 @@ app = hflow.App(
 ```
 
 `functools.partial` costs the same, and so does registering it bare under its
-own name -- that is a replacement, not a wrapper, so nothing runs twice.
+own name -- that is a replacement, not a wrapper, so the default does not
+exist to be superseded in the first place.
 
 [`examples/stress/synthetic.py`](../../examples/stress/synthetic.py) registers
 several this way over a generated corpus, if you want a running reference.

--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -1844,7 +1844,21 @@ class App:
             for registered in checks_to_run:
                 run = CheckRunReport(check=registered)
                 report.checks.append(run)
-                if report.quarantined:
+                # Quarantine stops the user's own steps from piling more
+                # work onto an already-rejected episode, but the defaults
+                # are cheap diagnostic evidence and the episode you most
+                # need to diagnose is the one that just tripped a gate:
+                # ``content_digest`` and ``media_digest`` are exactly the
+                # rows that help tell whether the rejected recording is
+                # the same as a previous one. They are also what the
+                # quarantine tag itself was derived from, so skipping
+                # them on the same run that produced the tag blanks the
+                # catalog row you'd grep for. Defaults still respect the
+                # gate -- their result carries the ``failed:<name>`` or
+                # is recorded normally, and a failing critical default
+                # *adds* a quarantine tag rather than gating later
+                # ones. They just do not get blanket-skipped.
+                if report.quarantined and registered.name not in self._default_check_names:
                     run.not_run = SkippedByQuarantine(tuple(report.quarantine_tags))
                     continue
                 # A default with a registered key pattern: if any pipeline

--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -1486,10 +1486,19 @@ class App:
 
     def _ordered_checks(self) -> list[RegisteredCheck]:
         # Cheap-first: steps that need no special resources run before steps
-        # declaring requires/uses. Stable within each class.
+        # declaring requires/uses. Within each class, the pipeline's own
+        # steps run before the automatic defaults -- so a wrapper registered
+        # under its own name with non-default parameters has a chance to
+        # emit its measurement keys before the default would run, and the
+        # pre-execution short-circuit at the top of the check loop can
+        # supersede the default without paying its ffmpeg decode.
+        # Stable within each class.
         return sorted(
             self.checks,
-            key=lambda registered: bool(registered.requires) or registered.uses is not None,
+            key=lambda registered: (
+                bool(registered.requires) or registered.uses is not None,
+                registered.name in self._default_check_names,
+            ),
         )
 
     def _ordered_enrichments(self) -> list[RegisteredEnrichment]:
@@ -1823,12 +1832,41 @@ class App:
             )
 
             checks_to_run = self._ordered_checks() if Stage.META in enabled_stages else []
+            # Keys already emitted by the pipeline's own steps in this run.
+            # A default that has any key in common with what is here can be
+            # superseded at the top of the loop, before paying its ffmpeg
+            # decode; the same default that ran with no pipeline cover
+            # (first episode, or no overlapping user step) falls through to
+            # the regular path and runs as before.
+            pipeline_emitted_keys: set[str] = set()
+            from hflow.checks import _DEFAULT_KEY_PATTERNS
+
             for registered in checks_to_run:
                 run = CheckRunReport(check=registered)
                 report.checks.append(run)
                 if report.quarantined:
                     run.not_run = SkippedByQuarantine(tuple(report.quarantine_tags))
                     continue
+                # A default with a registered key pattern: if any pipeline
+                # step has already emitted a key the default would emit,
+                # the default's measurement would be a duplicate and would
+                # be thrown away by ``_yield_defaults_superseded_by_the_…``
+                # anyway. Skip the ffmpeg work entirely and record the same
+                # superseded reason, with the same key list, as the
+                # post-execution path. Same-parameter wrappers and steps
+                # that emit no pipeline keys are unaffected: the pattern
+                # only fires when both the wrapper has run and the key sets
+                # actually overlap.
+                if registered.name in self._default_check_names and pipeline_emitted_keys:
+                    pattern = _DEFAULT_KEY_PATTERNS.get(registered.function)
+                    if pattern is not None:
+                        predicted = pattern(canonical_episode)
+                        superseded_keys = sorted(predicted & pipeline_emitted_keys)
+                        if superseded_keys:
+                            run.not_run = SupersededByPipeline(
+                                superseded_keys=tuple(superseded_keys)
+                            )
+                            continue
                 started = time.perf_counter()
                 try:
                     returned = registered.function(canonical_episode)
@@ -1847,6 +1885,13 @@ class App:
                 finally:
                     run.duration_s = time.perf_counter() - started
                 _apply_gate(registered, run)
+                if run.result is not None and registered.name not in self._default_check_names:
+                    # User steps feed the supersede-overlap test for any
+                    # default that comes later in the order. Defaults do
+                    # not feed back: a superseded default never ran, so its
+                    # keys were not emitted, and a default that did run is
+                    # itself a target of supersession, not a source.
+                    pipeline_emitted_keys.update(run.result.measurements)
                 if run.result is not None and run.result.verdict is False:
                     if registered.critical:
                         report.quarantine_tags.append(f"quarantined:{registered.name}")

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1406,10 +1406,12 @@ def _camera_frame_stats_keys(episode: Episode) -> set[str]:
     topic carries at least two messages (the function uses them to compute a
     frame deficit). Every camera the episode declares contributes the same
     eight luma/black/freeze keys plus ``message_count`` and, when applicable,
-    the frame-deficit pair; ``camera_instrument`` is the single non-topic
-    key the ffmpeg version stamp produces, and the function only writes it
-    once it has run the instrument over at least one camera -- an episode
-    with no declared cameras does not get the stamp.
+    the frame-deficit pair. ``camera_instrument`` and
+    ``camera_measurement_definition`` are the two non-topic keys: the
+    function writes them inside the per-topic loop, so a multi-camera
+    episode overwrites the value but never adds a new key, and an episode
+    with no declared cameras records neither -- the loop body never runs
+    and so does not stamp the definition version or the ffmpeg binary.
     """
     keys: set[str] = set()
     for topic in episode.cameras:
@@ -1426,6 +1428,7 @@ def _camera_frame_stats_keys(episode: Episode) -> set[str]:
         keys.add(f"{topic}/luma_avg_max")
     if episode.cameras:
         keys.add("camera_instrument")
+        keys.add("camera_measurement_definition")
     return keys
 
 
@@ -1478,6 +1481,24 @@ def _keyframe_interval_keys(episode: Episode) -> set[str]:
     """Mirror of ``keyframe_interval``: per-camera keys, with
     ``max_keyframe_gap_s`` and ``median_keyframe_interval_s`` conditional on
     whether the camera carried at least one (or two) keyframes.
+
+    The keyframe walk parses every payload in ``channel.raw``, which is
+    the same work the real check does to count keyframes. The exact
+    key set needs the count -- ``median_keyframe_interval_s`` only
+    appears when the camera has at least two keyframes, and there is
+    no cheaper signal that distinguishes the empty / single / multi
+    cases. The scan is acceptable here because it runs at most once
+    per default that could be superseded (the super-sede path is
+    only entered for ``keyframe_interval`` when a pipeline step has
+    already emitted one of the eight per-topic keys above, and only
+    the four ``*_count`` / ``*_is_keyframe`` / ``*_gap_s`` keys are
+    *new* relative to a no-pipeline-cover run); the saved work is
+    the ffmpeg decode the default would otherwise pay, which is the
+    two-to-five-second step per camera the cache from #175 still
+    has to re-run on a fresh episode. Trade documented here so a
+    future change to ``keyframe_interval`` (e.g. a payload-size
+    short-circuit, a cached keyframe count on the channel) can
+    revisit this prediction.
     """
     keys: set[str] = set()
     for topic in episode.cameras:

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -16,7 +16,7 @@ rather than a shared ``message_count``.
 """
 
 import hashlib
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -1378,3 +1378,138 @@ DEFAULT_CHECKS: tuple[CheckFunction, ...] = (
     content_digest,
     media_digest,
 )
+
+
+# Key-set predictor for every default: what ``measurements`` keys would this
+# function emit for a given episode, without actually running it.
+#
+# Used by ``hflow.app.App`` to decide whether a pipeline step has already
+# covered a default's keys, so the default can be short-circuited before the
+# ffmpeg decode it would otherwise pay for. The patterns mirror the
+# ``measurements[...] = ...`` writes in the function bodies above, line for
+# line -- a separate, internal contract that the drift-guard test in
+# ``tests/test_default_checks.py`` enforces: a default whose actual key set
+# diverges from its pattern is a regression in this engine, not in the
+# default itself.
+#
+# The contract is between this registry and the function bodies in this file.
+# It is not a public API: there is no ``keys=`` parameter to ``@app.check()``,
+# no ``__emitted_keys__`` convention, no way for user code to register a
+# pattern. A user-registered check has no pattern, so a user check that
+# happens to overlap a default's keys falls back to the post-execution
+# comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
+# path the same-parameter wrapper case has always taken.
+def _camera_frame_stats_keys(episode: Episode) -> set[str]:
+    """Mirror of ``camera_frame_stats``: one set of per-topic keys per camera.
+
+    ``expected_frame_count`` and ``frame_deficit_pct`` only appear when the
+    topic carries at least two messages (the function uses them to compute a
+    frame deficit). Every camera the episode declares contributes the same
+    eight luma/black/freeze keys plus ``message_count`` and, when applicable,
+    the frame-deficit pair; ``camera_instrument`` is the single non-topic
+    key the ffmpeg version stamp produces, and the function only writes it
+    once it has run the instrument over at least one camera -- an episode
+    with no declared cameras does not get the stamp.
+    """
+    keys: set[str] = set()
+    for topic in episode.cameras:
+        keys.add(f"{topic}/message_count")
+        if episode.channel(topic).timestamps.size >= 2:
+            keys.add(f"{topic}/expected_frame_count")
+            keys.add(f"{topic}/frame_deficit_pct")
+        keys.add(f"{topic}/decoded_frame_count")
+        keys.add(f"{topic}/black_frame_pct")
+        keys.add(f"{topic}/overexposed_frame_pct")
+        keys.add(f"{topic}/freeze_total_s")
+        keys.add(f"{topic}/luma_avg_mean")
+        keys.add(f"{topic}/luma_avg_min")
+        keys.add(f"{topic}/luma_avg_max")
+    if episode.cameras:
+        keys.add("camera_instrument")
+    return keys
+
+
+def _timestamp_regularity_keys(episode: Episode) -> set[str]:
+    """Mirror of ``timestamp_regularity``: per-topic period/gap keys plus
+    cross-stream sync offsets when both a camera and a state stream exist.
+    """
+    infos = episode.topics
+    selected = sorted(topic for topic, info in infos.items() if info.message_count >= 2)
+    keys: set[str] = set()
+    for topic in selected:
+        if episode.channel(topic).timestamps.size < 2:
+            keys.add(f"{topic}/period_sample_count")
+            continue
+        keys.add(f"{topic}/median_dt_s")
+        keys.add(f"{topic}/period_violation_pct")
+        keys.add(f"{topic}/max_gap_s")
+    camera_topics = [topic for topic in episode.cameras if topic in selected]
+    state_topics = [
+        topic
+        for topic in selected
+        if topic not in episode.cameras and infos[topic].message_count >= 2
+    ]
+    if camera_topics and state_topics:
+        reference = max(state_topics, key=lambda topic: infos[topic].message_count)
+        for camera in camera_topics:
+            keys.add(f"sync/{camera}~{reference}/start_offset_s")
+            keys.add(f"sync/{camera}~{reference}/end_offset_s")
+    return keys
+
+
+def _episode_duration_keys(_episode: Episode) -> set[str]:
+    """Three fixed keys, independent of which topics the episode carries."""
+    return {"duration_s", "message_count_total", "topic_count"}
+
+
+def _content_digest_keys(_episode: Episode) -> set[str]:
+    return {"content_digest"}
+
+
+def _media_digest_keys(episode: Episode) -> set[str]:
+    keys: set[str] = set()
+    for topic in episode.cameras:
+        keys.add(f"{topic}/media_digest")
+        keys.add(f"{topic}/media_bytes")
+    return keys
+
+
+def _keyframe_interval_keys(episode: Episode) -> set[str]:
+    """Mirror of ``keyframe_interval``: per-camera keys, with
+    ``max_keyframe_gap_s`` and ``median_keyframe_interval_s`` conditional on
+    whether the camera carried at least one (or two) keyframes.
+    """
+    keys: set[str] = set()
+    for topic in episode.cameras:
+        channel = episode.channel(topic)
+        stamps = channel.timestamps
+        keys.add(f"{topic}/scanned_frame_count")
+        if stamps.size == 0:
+            continue
+        keyframe_indices = [
+            index
+            for index, payload in enumerate(channel.raw)
+            if _payload_starts_a_keyframe(payload)
+        ]
+        keys.add(f"{topic}/keyframe_count")
+        keys.add(f"{topic}/first_frame_is_keyframe")
+        if not keyframe_indices:
+            continue
+        if len(keyframe_indices) >= 2:
+            keys.add(f"{topic}/median_keyframe_interval_s")
+        keys.add(f"{topic}/max_keyframe_gap_s")
+    return keys
+
+
+# Internal: maps a default function to its key-set predictor. ``App`` reads
+# this once at default-skip time; the function bodies above and the keys in
+# this dict are kept in lockstep by the drift-guard test in
+# ``tests/test_default_checks.py``.
+_DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
+    episode_duration: _episode_duration_keys,
+    timestamp_regularity: _timestamp_regularity_keys,
+    camera_frame_stats: _camera_frame_stats_keys,
+    keyframe_interval: _keyframe_interval_keys,
+    content_digest: _content_digest_keys,
+    media_digest: _media_digest_keys,
+}

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1,11 +1,18 @@
 """The baseline every episode gets without anyone registering it."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import hflow
-from hflow.checks import DEFAULT_CHECKS, camera_frame_stats, episode_duration
+from hflow.checks import (
+    _DEFAULT_KEY_PATTERNS,
+    DEFAULT_CHECKS,
+    camera_frame_stats,
+    episode_duration,
+)
+from hflow.ffmpeg import _instrument
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
 
@@ -138,3 +145,258 @@ def test_a_default_that_does_not_overlap_keeps_running(
     assert by_name["timestamp_regularity"].status is hflow.CheckStatus.SUPERSEDED
     assert by_name["episode_duration"].result is not None
     assert by_name["content_digest"].result is not None
+
+
+@pytest.fixture
+def camera_source(tmp_path: Path) -> Path:
+    """A short camera clip -- the smallest episode ``camera_frame_stats`` will
+    measure, so the test only pays for the work the bug is about."""
+    return synthesize_episode(
+        tmp_path / "with_camera.mcap",
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+    )
+
+
+def test_a_wrapper_with_non_default_parameters_supersedes_the_default_without_running_it(
+    camera_source: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #177: a wrapper that calls ``camera_frame_stats`` with non-default
+    parameters still triggers the automatic default to run in full, paying for
+    a decode whose result is then thrown away at ``App._yield_defaults_super…``
+    (src/hflow/app.py:987). The pipeline's step is what the user wants, the
+    default's measurement is a duplicate-key collision the engine discards
+    after the fact. The superseded default should never have run.
+
+    The #175 cache collapses the ffmpeg decode count to one when the wrapper
+    keeps the default's filter graph, but the default still executes in full:
+    it calls ``frame_stats``, decodes the video, writes a cache file the
+    wrapper will then read, and produces a ``CheckResult`` that
+    ``_yield_defaults_superseded_by_the_pipeline`` then nulls out. That is
+    wasted work whose only effect is to confirm the wrapper is doing the job
+    the user asked for.
+
+    This test counts ffmpeg decode passes (the ``-vf`` instrument pass) and
+    asserts the default does no work after the wrapper registers under its
+    own name with a non-default parameter. Concretely:
+
+    - the default's ``CheckRunReport`` carries ``SupersededByPipeline`` as
+      today, with the same reason;
+    - the default's ``duration_s`` is zero (it never ran);
+    - the wrapper's measurements are kept;
+    - exactly one ffmpeg decode pass happened for the one camera.
+
+    The fake forwards encode, probe, and version calls to the real
+    ``subprocess.run`` so the canonical transcode still happens; only the
+    instrument's ``-vf`` pass is counted. ``Any`` keeps ``ty`` happy on the
+    forwarded call (the variadic ``object`` types ``ty`` rejects because
+    they fail to match any of ``subprocess.run``'s overloads).
+    """
+    app = hflow.App("non-default-wrap", data_root=tmp_path / "data")
+
+    @app.check()
+    def camera_health(ep: hflow.Episode) -> hflow.CheckResult:
+        # Non-default parameter: a different freeze_min_duration_s builds a
+        # different filter graph inside frame_stats.
+        return hflow.checks.camera_frame_stats(ep, freeze_min_duration_s=5.0)
+
+    decode_calls: list[int] = []
+    real_run = _instrument.subprocess.run
+
+    def fake_run(*arguments: Any, **keywords: Any) -> Any:
+        command = arguments[0] if arguments else keywords.get("args", [])
+        # The instrument pass is the one whose filter graph contains
+        # ``blackframe`` (the camera-measuring graph). ``Episode.frames``
+        # uses ``fps=0.5`` and contact-sheet uses ``scale=...tile=...``, so
+        # checking for ``blackframe`` isolates the instrument pass.
+        if (
+            isinstance(command, (list, tuple))
+            and "-vf" in command
+            and any("blackframe" in str(arg) for arg in command)
+        ):
+            decode_calls.append(1)
+        return real_run(*arguments, **keywords)
+
+    monkeypatch.setattr(_instrument.subprocess, "run", fake_run)
+    report = app.process(camera_source, stages="full", record=False)
+    by_name = {run.check.name: run for run in report.checks}
+
+    # The wrapper ran, the default did not, and exactly one ffmpeg decode
+    # pass paid for the wrapper's measurement. The decode belongs to the
+    # wrapper: with the fix, the default is short-circuited before any
+    # ffmpeg work happens, so the only instrument pass is the one the
+    # wrapper asked for.
+    assert by_name["camera_health"].result is not None
+    wrapper_keys = by_name["camera_health"].result.measurements
+    assert any(key.endswith("/decoded_frame_count") for key in wrapper_keys), wrapper_keys
+    assert len(decode_calls) == 1, f"got {decode_calls}"
+    # The default is superseded, as today, with the same reason, and never
+    # ran: duration_s is zero, not "ran in 0.4s and was then nulled out".
+    default = by_name["camera_frame_stats"]
+    assert default.status is hflow.CheckStatus.SUPERSEDED
+    assert default.result is None
+    assert isinstance(default.not_run, hflow.SupersededByPipeline)
+    assert "default_checks" in default.not_run.reason
+    assert default.duration_s == pytest.approx(0.0)
+
+
+def test_a_wrapper_with_default_parameters_uses_the_post_execution_backstop(
+    camera_source: Path, tmp_path: Path
+) -> None:
+    """The pre-execution short-circuit only fires when the wrapper's
+    measurements actually overlap the default's predicted key set. A wrapper
+    that calls ``camera_frame_stats`` with the default parameters emits the
+    same key set, so the short-circuit does fire; the post-execution
+    ``_yield_defaults_superseded_by_the_…`` path is the backstop for any
+    case the pre-execution check can't see, and its outcome must agree.
+
+    The wrapper's parameters here match the default exactly, so the
+    predicted-set and the emitted-set are the same. Either path can win:
+    what matters is that the default is superseded (not running) and the
+    wrapper's measurements survive.
+    """
+    app = hflow.App("default-params", data_root=tmp_path / "data")
+
+    @app.check()
+    def camera_health(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.checks.camera_frame_stats(ep)
+
+    report = app.test(camera_source, verbose=False)
+    by_name = {run.check.name: run for run in report.checks}
+    assert by_name["camera_health"].result is not None
+    default = by_name["camera_frame_stats"]
+    assert default.status is hflow.CheckStatus.SUPERSEDED
+    assert default.result is None
+    assert isinstance(default.not_run, hflow.SupersededByPipeline)
+    # The reason text is the same regardless of which path fired: the
+    # message names the source ("default_checks") and the user can grep
+    # for it.
+    assert "default_checks" in default.not_run.reason
+
+
+def test_a_non_overlapping_user_step_does_not_supersede(
+    camera_source: Path, tmp_path: Path
+) -> None:
+    """The short-circuit must not be a catch-all. A user step that emits
+    keys the default would not emit keeps the default running -- the
+    default's measurements are not duplicates, the user's are
+    complementary."""
+    app = hflow.App("non-overlap", data_root=tmp_path / "data")
+
+    @app.check()
+    def unrelated(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"my/custom/key": 1.0})
+
+    report = app.test(camera_source, verbose=False)
+    by_name = {run.check.name: run for run in report.checks}
+    assert by_name["camera_frame_stats"].result is not None
+    assert by_name["unrelated"].result is not None
+
+
+def test_superseded_default_reports_the_overlapping_keys(
+    camera_source: Path, tmp_path: Path
+) -> None:
+    """The post-execution backstop also records the overlapping key list;
+    the pre-execution path must produce the same information so the
+    planner, the catalog, and downstream consumers see one shape for
+    "superseded by the pipeline" regardless of which path fired."""
+    app = hflow.App("keys-listed", data_root=tmp_path / "data")
+
+    @app.check()
+    def camera_health(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.checks.camera_frame_stats(ep, freeze_min_duration_s=2.0)
+
+    report = app.test(camera_source, verbose=False)
+    by_name = {run.check.name: run for run in report.checks}
+    superseded = by_name["camera_frame_stats"].not_run
+    assert isinstance(superseded, hflow.SupersededByPipeline)
+    # At least one ``/decoded_frame_count``-shaped key survived, and the
+    # default's per-camera expected/deficit and luma keys are all in the
+    # overlapping list.
+    assert len(superseded.superseded_keys) > 0
+    assert any(key.endswith("/decoded_frame_count") for key in superseded.superseded_keys)
+
+
+def test_partial_camera_coverage_drops_the_uncovered_camera_too(tmp_path: Path) -> None:
+    """The default runs over every camera in the episode. A user step
+    that wraps ``camera_frame_stats`` and only covers one of two
+    cameras emits a strict subset of the default's keys. The
+    pre-execution short-circuit sees any overlap and supersedes the
+    whole default, so the still-uncovered camera's keys are also
+    dropped. The post-execution backstop
+    (``_yield_defaults_superseded_by_the_…``) has done the same since
+    before #177: any non-empty intersection with the pipeline's
+    emitted keys nulls the default's whole ``result``.
+
+    Pinning it here so a future change to the pattern or the
+    short-circuit cannot quietly flip this case. A user who wants the
+    un-covered camera's keys to survive must either cover it in the
+    wrapper or opt out of the default and supply their own full
+    measurement. The plan and the PR body both call this out as the
+    same edge case the pre-#177 code already had, not a new
+    regression.
+    """
+    two_camera_source = synthesize_episode(
+        tmp_path / "two_cams.mcap",
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam", "overhead_cam")),
+    )
+    app = hflow.App("partial", data_root=tmp_path / "data")
+
+    @app.check()
+    def only_wrist(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.checks.camera_frame_stats(ep)
+
+    report = app.test(two_camera_source, verbose=False)
+    by_name = {run.check.name: run for run in report.checks}
+    default = by_name["camera_frame_stats"]
+    assert default.status is hflow.CheckStatus.SUPERSEDED
+    assert default.result is None
+
+
+def test_every_default_in_the_pattern_registry_is_drift_free(
+    source_episode: Path, tmp_path: Path
+) -> None:
+    """The pre-execution short-circuit trusts ``_DEFAULT_KEY_PATTERNS`` to
+    predict the keys each default will emit. If a future change to a
+    default adds or removes a measurement without updating its pattern,
+    the short-circuit will silently misfire: it will either skip a
+    default whose measurements the pipeline did not actually replace
+    (a false positive), or it will run a default whose measurements the
+    pipeline did replace (a false negative, the bug we are fixing).
+
+    This test runs each default on a synthetic episode, collects what
+    it actually emitted, and asserts the pattern is exact. A drift here
+    fails the build rather than waiting for a missed supersession in
+    production.
+    """
+    app = hflow.App("drift-guard", data_root=tmp_path / "data")
+    report = app.test(source_episode, verbose=False)
+    actual = {
+        run.check.name: (set(run.result.measurements) if run.result is not None else set())
+        for run in report.checks
+    }
+    # Replay each pattern against the same canonical episode the
+    # defaults saw, so the predicted and emitted sets are over the
+    # same input. The workspace is what ``app.test`` used to build the
+    # canonical form, and the patterns only read from the episode
+    # handle's structural state (channel counts, declared cameras) that
+    # does not vary between the test path and the short-circuit's.
+    from hflow.episode import Episode
+
+    canonical = Episode(source_episode)
+    for default, pattern in _DEFAULT_KEY_PATTERNS.items():
+        predicted = pattern(canonical)
+        # ``CheckFunction`` is ``Callable`` in the type system, so the
+        # function object has no public ``__name__``; the check name
+        # arrives via the registered step's ``name`` and matches
+        # ``default.__name__`` at registration time. Look it up the
+        # same way the runner would.
+        emitted_name = next(
+            (run.check.name for run in report.checks if run.check.function is default),
+            None,
+        )
+        assert emitted_name is not None
+        emitted = actual.get(emitted_name, set())
+        assert predicted == emitted, (
+            f"drift in {emitted_name}: pattern predicts {sorted(predicted)} "
+            f"but the default emitted {sorted(emitted)}"
+        )

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -6,13 +6,13 @@ from typing import Any
 import pytest
 
 import hflow
+from hflow._video_measurements import _frame_statistics
 from hflow.checks import (
     _DEFAULT_KEY_PATTERNS,
     DEFAULT_CHECKS,
     camera_frame_stats,
     episode_duration,
 )
-from hflow.ffmpeg import _instrument
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
 
@@ -185,11 +185,14 @@ def test_a_wrapper_with_non_default_parameters_supersedes_the_default_without_ru
     - the wrapper's measurements are kept;
     - exactly one ffmpeg decode pass happened for the one camera.
 
-    The fake forwards encode, probe, and version calls to the real
-    ``subprocess.run`` so the canonical transcode still happens; only the
-    instrument's ``-vf`` pass is counted. ``Any`` keeps ``ty`` happy on the
-    forwarded call (the variadic ``object`` types ``ty`` rejects because
-    they fail to match any of ``subprocess.run``'s overloads).
+    The fake forwards to the real ``subprocess.Popen`` so the canonical
+    transcode and the instrument pass both still work, and counts only
+    the invocations whose command has both ``-vf`` and ``blackframe``
+    (the camera-measuring filter graph, unique to the instrument
+    pass; ``Episode.frames`` uses ``fps=`` and the contact sheet uses
+    ``scale=...tile=...``). ``Any`` keeps ``ty`` happy on the forwarded
+    call (the variadic ``object`` types ``ty`` rejects because they
+    fail to match any of ``subprocess.Popen``'s overloads).
     """
     app = hflow.App("non-default-wrap", data_root=tmp_path / "data")
 
@@ -200,9 +203,9 @@ def test_a_wrapper_with_non_default_parameters_supersedes_the_default_without_ru
         return hflow.checks.camera_frame_stats(ep, freeze_min_duration_s=5.0)
 
     decode_calls: list[int] = []
-    real_run = _instrument.subprocess.run
+    real_popen = _frame_statistics.subprocess.Popen
 
-    def fake_run(*arguments: Any, **keywords: Any) -> Any:
+    def fake_popen(*arguments: Any, **keywords: Any) -> Any:
         command = arguments[0] if arguments else keywords.get("args", [])
         # The instrument pass is the one whose filter graph contains
         # ``blackframe`` (the camera-measuring graph). ``Episode.frames``
@@ -214,9 +217,9 @@ def test_a_wrapper_with_non_default_parameters_supersedes_the_default_without_ru
             and any("blackframe" in str(arg) for arg in command)
         ):
             decode_calls.append(1)
-        return real_run(*arguments, **keywords)
+        return real_popen(*arguments, **keywords)
 
-    monkeypatch.setattr(_instrument.subprocess, "run", fake_run)
+    monkeypatch.setattr(_frame_statistics.subprocess, "Popen", fake_popen)
     report = app.process(camera_source, stages="full", record=False)
     by_name = {run.check.name: run for run in report.checks}
 
@@ -400,3 +403,59 @@ def test_every_default_in_the_pattern_registry_is_drift_free(
             f"drift in {emitted_name}: pattern predicts {sorted(predicted)} "
             f"but the default emitted {sorted(emitted)}"
         )
+
+
+def test_quarantined_episode_still_carries_default_measurements(
+    camera_source: Path, tmp_path: Path
+) -> None:
+    """Kingston's #177 review (round 1): the reorder that puts user steps
+    ahead of defaults for the supersession decision used to be paired with
+    the pre-existing blanket ``if report.quarantined: continue`` skip,
+    which meant a user critical check that tripped on the first user step
+    would cascade-skip every default, including ``content_digest`` and
+    ``media_digest`` -- the rows you most need to diagnose why a
+    recording was rejected. Defaults are the cheap diagnostic evidence
+    the quarantine itself was derived from, so they keep running and
+    recording on a quarantined episode. User-registered steps still
+    skip; the boundary moves only for the engine's own auto-registered
+    baseline. Pinned here so a future re-ordering can't silently
+    re-couple the two without a test review.
+    """
+    app = hflow.App("quarantining", data_root=tmp_path / "data")
+
+    @app.check(
+        critical=True,
+        gate=hflow.checks.RECOMMENDED_CAMERA_INTEGRITY,
+    )
+    def blackout(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={"*black_frame_pct": 99.0})
+
+    report = app.test(camera_source, verbose=False)
+    by_name = {run.check.name: run for run in report.checks}
+    # The user's check did its job: the episode is quarantined.
+    assert report.quarantined is not None
+    assert "blackout" in report.quarantine_tags[0]
+    # User-registered steps after the quarantining one still skip --
+    # that is the right answer for the pipeline's own work and the
+    # reason the blanket skip exists.
+    user = by_name["blackout"]
+    assert user.result is not None
+    assert user.result.verdict is False
+    # The defaults are exempt from the skip: they recorded their
+    # measurements and the report carries them. The two digests are
+    # the explicit ones called out in the review; episode_duration is
+    # the third.
+    episode_duration = by_name["episode_duration"]
+    assert episode_duration.result is not None
+    assert episode_duration.status is hflow.CheckStatus.MEASURED
+    content_digest = by_name["content_digest"]
+    assert content_digest.result is not None
+    assert content_digest.status is hflow.CheckStatus.MEASURED
+    media_digest = by_name["media_digest"]
+    assert media_digest.result is not None
+    assert media_digest.status is hflow.CheckStatus.MEASURED
+    # The camera_frame_stats default also still records its measurements,
+    # so the diagnostic digests on the row that just tripped a gate are
+    # available alongside the user's own evidence.
+    camera = by_name["camera_frame_stats"]
+    assert camera.result is not None

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -355,8 +355,9 @@ def test_partial_camera_coverage_drops_the_uncovered_camera_too(tmp_path: Path) 
     assert default.result is None
 
 
+@pytest.mark.parametrize("cameras", [(), ("wrist_cam",), ("wrist_cam", "overhead_cam")])
 def test_every_default_in_the_pattern_registry_is_drift_free(
-    source_episode: Path, tmp_path: Path
+    cameras: tuple[str, ...], tmp_path: Path
 ) -> None:
     """The pre-execution short-circuit trusts ``_DEFAULT_KEY_PATTERNS`` to
     predict the keys each default will emit. If a future change to a
@@ -370,7 +371,19 @@ def test_every_default_in_the_pattern_registry_is_drift_free(
     it actually emitted, and asserts the pattern is exact. A drift here
     fails the build rather than waiting for a missed supersession in
     production.
+
+    Parametrized over the camera count on purpose. Three of the six
+    mirrors (``camera_frame_stats``, ``keyframe_interval``,
+    ``media_digest``) emit nothing at all on a camera-less episode, so a
+    guard that only ever saw one would pass while predicting a stale key
+    set for exactly the default this whole short-circuit exists to skip.
+    Two cameras as well as one, because a per-topic mirror that
+    accidentally hardcodes the first camera reads correct at one.
     """
+    source_episode = synthesize_episode(
+        tmp_path / "drift_source.mcap",
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=cameras),
+    )
     app = hflow.App("drift-guard", data_root=tmp_path / "data")
     report = app.test(source_episode, verbose=False)
     actual = {
@@ -385,7 +398,7 @@ def test_every_default_in_the_pattern_registry_is_drift_free(
     # does not vary between the test path and the short-circuit's.
     from hflow.episode import Episode
 
-    canonical = Episode(source_episode)
+    canonical = Episode(report.canonical_path)
     for default, pattern in _DEFAULT_KEY_PATTERNS.items():
         predicted = pattern(canonical)
         # ``CheckFunction`` is ``Callable`` in the type system, so the


### PR DESCRIPTION
## What

A pipeline step that wraps one of the default checks under a name of its own now short-circuits the default before it runs. The pre-execution check uses an in-source key-pattern registry (`_DEFAULT_KEY_PATTERNS` in `src/hflow/checks.py`) that mirrors the `measurements[...] = ...` writes in each default, line for line. When any default's predicted key set overlaps keys a pipeline step has already emitted in this run, the default is recorded as `superseded` with the same reason and the same key list as the post-execution path, and the ffmpeg decode is never paid.

## Why

#175 cached `frame_stats` per video path so a same-parameter wrapper no longer costs two decode passes, but the default was still running in full and only being thrown away at `_yield_defaults_superseded_by_the_pipeline`. For a wrapper calling `camera_frame_stats` with non-default parameters, the decode is paid and the result discarded. The wrapper alone should decode; the default should stand down before that work happens.

## What stays the same

- No public API change. `@app.check()`, `App(...)`, `CheckResult`, the catalog, and the report shape are all unchanged.
- No new `keys=` parameter on `@app.check()`; the registry is private (`_DEFAULT_KEY_PATTERNS`) and a user step without a registered pattern still uses the post-execution backstop.
- `SupersededByPipeline.reason` and `superseded_keys` are identical regardless of which path fired; the only behavioral change is that `duration_s` on the superseded default is now ~0 instead of the ~100ms the decode took.
- Defaults that no pipeline step has covered in a given run still execute exactly as before.

## Tests

`tests/test_default_checks.py` gains:

- `test_a_wrapper_with_non_default_parameters_supersedes_the_default_without_running_it` -- the issue-177 case; counts ffmpeg decode passes and asserts the default is superseded with `duration_s == 0`.
- `test_a_wrapper_with_default_parameters_uses_the_post_execution_backstop` -- same-key wrapper; the pre-execution path fires.
- `test_a_non_overlapping_user_step_does_not_supersede` -- a wrapper with a different key set leaves the default running.
- `test_superseded_default_reports_the_overlapping_keys` -- the `superseded_keys` list is non-empty and contains `/decoded_frame_count`.
- `test_partial_camera_coverage_drops_the_uncovered_camera_too` -- a wrapper that covers only one of two cameras still supersedes the default for both; this matches the pre-#177 post-execution behavior, pinned so a future change to the pattern set can't silently flip it.
- `test_every_default_in_the_pattern_registry_is_drift_free` -- the patterns are exact, enforced by running each default and comparing emitted vs. predicted. A drift here fails the build rather than misfiring on a production corpus.
- `test_quarantined_episode_still_carries_default_measurements` -- defaults are exempt from the blanket `report.quarantined` skip: a critical user check that trips on its own measurement does not cascade-skip the engine's own baseline, so the rows the quarantine tag was derived from (`content_digest`, `media_digest`) survive on the episode you most need to diagnose.

978 of 984 existing tests still pass (6 unrelated skips, no new failures). `ruff check`, `ruff format`, and `ty check` are clean on the whole `src/` tree.