### PR TITLE
fix(dataset): select only ok episodes by default

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -280,17 +280,20 @@ SELECT episode_id FROM episodes WHERE status != 'quarantined'
 SELECT episode_id FROM episodes WHERE status = 'ok'
 ```
 
-`hflow dataset create` is mostly already strict here, but by a different rule.
-Its default policy keeps `status != 'quarantined'` *and* requires every
-registered step to have a settled `check_runs` row, and `error` is not settled
-(see `SETTLED_STATUSES`). An episode whose critical check only ever crashed has
-no settled row for it and is excluded by that second rule, not the first.
+`hflow dataset create` applies `status = 'ok'` for you, so its default policy
+does not need this filter written by hand. It also requires every registered
+step to have a settled `check_runs` row, and `error` is not settled (see
+`SETTLED_STATUSES`).
 
-The gap is narrower than it looks, and it is worth knowing. If a settled run of
-that check version exists anywhere in the episode's history and a *later* run
-crashed, the step requirement is satisfied by the old row while the status
-column reads `unverified`, so the episode lands in the dataset. Filter on
-`status = 'ok'` in your selection SQL when you want the stricter reading.
+Those two rules overlap, and neither replaces the other. An episode whose
+critical check *only ever* crashed has no settled row at all, so the step
+requirement excludes it on its own. An episode that settled once and crashed on
+a later run is different: the step requirement is satisfied by the older row,
+and only the status column still reads `unverified`. That case is why the
+default policy filters on status rather than leaning on the step rule alone.
+
+Your own selection SQL gets neither rule for free. `status = 'ok'` is the one
+worth carrying over.
 
 Pinning a check version by hand (the mixed-version-corpus reality).
 `check_version` is a content hash, not ordered, so pin exact values (or filter

--- a/src/hflow/dataset.py
+++ b/src/hflow/dataset.py
@@ -28,7 +28,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from hflow.catalog import EPISODES_VIEW_STATUS_COLUMN
+from hflow.catalog import EPISODE_STATUS_OK, EPISODES_VIEW_STATUS_COLUMN
 from hflow.curation import CheckCoverage, CurationReport, curate
 from hflow.format import EPISODE_FORMAT_VERSION
 from hflow.steps import SETTLED_STATUSES
@@ -177,13 +177,25 @@ def default_dataset_sql(application: "App") -> str:
     1. **Current transform.** ``pipeline_version`` and ``schema_version`` must
        match what this App produces now, so a corpus half-reprocessed after a
        transform change does not mix two canonical behaviors in one dataset.
-    2. **Not quarantined.** The pipeline's own critical checks rejected it.
+    2. **Status is ``ok``.** Excludes two different things. ``quarantined`` is
+       the pipeline's own critical checks rejecting the episode. ``unverified``
+       is a critical check that crashed, so nobody actually checked it, and
+       that is the half rule 3 cannot see: a crash leaves no settled row, but
+       an EARLIER settled run of the same check satisfies rule 3 on its own,
+       and the episode would otherwise land in the dataset on the strength of
+       a result that a later run withdrew.
     3. **Every registered step settled, at its current version.** A check added
        last week that has not been backfilled leaves its episodes out rather
        than silently reporting a dataset with a hole in it.
     4. **One row per source recording**, which the ``episodes`` view already
        guarantees, so a reprocessed recording contributes its current
        generation and not both.
+
+    Rules 2 and 3 overlap without either being redundant. An episode whose
+    critical check ONLY ever crashed is dropped by rule 3, which needs a
+    settled row and never gets one, and rule 2 agrees. An episode that settled
+    once and crashed later is dropped by rule 2 alone. Neither rule subsumes
+    the other, so both stay.
 
     Rule 3 has two traps in it, and both of them yield an EMPTY dataset that
     looks like a policy decision:
@@ -200,7 +212,7 @@ def default_dataset_sql(application: "App") -> str:
     """
     settled_statuses = ", ".join(_quote_sql_string(status.value) for status in SETTLED_STATUSES)
     predicates = [
-        f"{EPISODES_VIEW_STATUS_COLUMN} != 'quarantined'",
+        f"{EPISODES_VIEW_STATUS_COLUMN} = '{EPISODE_STATUS_OK}'",
         f"pipeline_version = {_quote_sql_string(application.pipeline_version)}",
         f"schema_version = {_quote_sql_string(EPISODE_FORMAT_VERSION)}",
     ]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -97,7 +97,7 @@ class TestDefaultPolicy:
         _ingest(ingested_project, monkeypatch)
         app = hflow.import_pipeline_application(str(ingested_project / "pipeline.py"))
         sql = default_dataset_sql(app)
-        assert "status != 'quarantined'" in sql
+        assert "status = 'ok'" in sql
 
     def test_a_default_check_the_pipeline_supersedes_is_not_a_hole(
         self, tmp_path: Path, source_episode: Path, monkeypatch: pytest.MonkeyPatch
@@ -282,3 +282,59 @@ def test_a_manifest_is_never_overwritten(tmp_path: Path, monkeypatch: pytest.Mon
         write_dataset_manifest(
             workspace, name="clean", sql="SELECT episode_id FROM episodes", file_stem="pinned"
         )
+
+
+CRASHING_PIPELINE_SOURCE = """
+import os
+import hflow
+
+app = hflow.App("dataset-demo", default_checks=())
+
+
+@app.check(critical=True)
+def duration(ep: hflow.Episode) -> hflow.CheckResult:
+    if os.environ.get("CRASH_DURATION"):
+        raise RuntimeError("boom")
+    return hflow.CheckResult(measurements={"seconds": 1.0})
+"""
+
+
+class TestSettledThenCrashed:
+    """The one case the settled-steps rule cannot see on its own."""
+
+    @pytest.fixture
+    def project(self, tmp_path: Path, source_episode: Path) -> Path:
+        data_root = tmp_path / "data"
+        episodes_in = data_root / "episodes-in"
+        episodes_in.mkdir(parents=True)
+        (episodes_in / "episode_0001.mcap").write_bytes(source_episode.read_bytes())
+        (tmp_path / "pipeline.py").write_text(CRASHING_PIPELINE_SOURCE)
+        (tmp_path / "hflow.toml").write_text('data_root = "./data"\n')
+        return tmp_path
+
+    def test_a_later_crash_withdraws_an_earlier_settled_result(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CRASH_DURATION", raising=False)
+        _ingest(project, monkeypatch)
+
+        app = hflow.import_pipeline_application(str(project / "pipeline.py"))
+        assert create_dataset(app, "before-the-crash").row_count == 1
+
+        monkeypatch.setenv("CRASH_DURATION", "1")
+        # Exit 1: the crash is a processing error and ingest says so. --all-stages
+        # is what re-runs a step the catalog already records at its current
+        # version, which is what keeps this the same check_version as the
+        # settled run above rather than a version bump rule 3 would catch.
+        assert cli_main(["ingest", "--all-stages", "episodes-in/episode_0001.mcap"]) == 1
+
+        connection = duckdb.connect()
+        try:
+            statuses = connection.execute(
+                f"SELECT status FROM read_parquet('{project}/data/catalog/check_runs/**/*.parquet')"
+            ).fetchall()
+        finally:
+            connection.close()
+        assert sorted(str(row[0]) for row in statuses) == ["error", "measured"]
+
+        assert create_dataset(app, "after-the-crash").row_count == 0


### PR DESCRIPTION
Closes #181.

Implements the shape settled in the issue body: `default_dataset_sql` filters on `status = 'ok'`, and the settled-steps requirement stays exactly as it was.

## The test

This is the part that decides whether the change is real, so it goes first.

`TestSettledThenCrashed` builds the one case the step requirement cannot see. A pipeline with a critical check ingests the episode once and settles, and the dataset picks it up. The check then crashes on a re-run and the dataset drops it.

The re-run goes through `ingest --all-stages`, which is what re-runs a step the catalog already records at its current version. That detail is load-bearing. Bumping the check version would also produce a crashed run, but rule 3 would then catch the episode on its own and the test would pass without the predicate change. Keeping the version fixed is what leaves only the status column doing the work.

Verified against unfixed source. With the predicate reverted to `status != 'quarantined'` and everything else in place, the test fails. It also asserts the two `check_runs` rows really are `measured` and `error`, so a future change that stops recording the crash cannot make it pass vacuously.

`ingest --all-stages` returns 1 here, not 0. The crash is a processing error and the CLI reports it as one. The test asserts that rather than working around it.

## The change

`src/hflow/dataset.py` uses `EPISODE_STATUS_OK` from the catalog module rather than a second copy of the literal, so the vocabulary keeps one owner.

The docstring's rule 2 changes from "not quarantined" to what the status column now means, and says which half of it rule 3 cannot see. I added a short paragraph on why both rules stay: an episode that only ever crashed is dropped by rule 3 alone, an episode that settled then crashed is dropped by rule 2 alone, so neither subsumes the other.

## Docs

`docs/CATALOG.md` had a paragraph telling the reader that the divergence was the end state and handing them `status = 'ok'` as a workaround. Both halves stop being true. I kept the scope difference, since the dataset policy and a hand-written selection query still are not the same thing, and dropped the workaround.

One existing test pinned the old string and now pins the new one.

## Gates

```
uv run ruff check --fix     All checks passed!
uv run ruff format          168 files left unchanged
uv run ty check             All checks passed!
uv run pytest -q            988 passed, 9 skipped
```

I did not run lychee. It is not installed here, and the docs edit changed prose and inline code only, so no link in the file is new or different.

## One thing I did not do

The four surfaces outside this issue still teach `status != 'quarantined'`: `README.md:192`, `docs/RUNTIME.md:210`, `docs/how-to/enable-built-in-checks.md:229` and `examples/egocentric/curate.sql:12`. I raised these on #180 and left them alone again here. Say the word and I will take them in a separate PR.