### PR TITLE
refuse empty and whitespace-only measurement keys before the wide-view pivot

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -339,6 +339,12 @@ def _normalized_measurements(
     threshold and its complement at once, so storing one drops the episode
     from both sides of a cut while the key still claims to be measured.
 
+    An empty or whitespace-only key is refused as well: the wide view pivots
+    every key into a column, so an empty key becomes a column whose name is
+    the SQL expression that produced it -- a queryable surface with no name
+    a person would write and no rename path (docs/CATALOG.md, "Naming
+    measurement keys"). Refusing it here means nothing has been written yet.
+
     Real check code returns NumPy scalars (np.mean(), indexing, np.bool_
     verdicts), and only np.float64 subclasses a Python type -- the rest used
     to fall through every storage branch into all-NULL value columns while
@@ -359,6 +365,12 @@ def _normalized_measurements(
             raise ValueError(
                 f"check {check_name!r} measured {key!r} as {value!r}: "
                 "omit the key when a check has no finite value for this episode"
+            )
+        if not key.strip():
+            raise ValueError(
+                f"check {check_name!r} measured {key!r}: measurement keys must "
+                "not be empty or whitespace-only (an empty key becomes a "
+                "wide-view column named after the SQL that made it)"
             )
         normalized[key] = value
     return normalized

--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -354,6 +354,15 @@ def _normalized_measurements(
     """
     normalized: dict[str, MeasurementValue] = {}
     for key, value in measurements.items():
+        # Before the value checks: the key is wrong independently of what it
+        # holds, and reporting the value first would send a check author to
+        # fix a NaN only to hit the real problem on the next run.
+        if not key.strip():
+            raise ValueError(
+                f"check {check_name!r} measured {key!r}: measurement keys must "
+                "not be empty or whitespace-only (an empty key becomes a "
+                "wide-view column named after the SQL that made it)"
+            )
         if isinstance(value, np.generic):
             value = value.item()
         if not isinstance(value, MeasurementValue):
@@ -365,12 +374,6 @@ def _normalized_measurements(
             raise ValueError(
                 f"check {check_name!r} measured {key!r} as {value!r}: "
                 "omit the key when a check has no finite value for this episode"
-            )
-        if not key.strip():
-            raise ValueError(
-                f"check {check_name!r} measured {key!r}: measurement keys must "
-                "not be empty or whitespace-only (an empty key becomes a "
-                "wide-view column named after the SQL that made it)"
             )
         normalized[key] = value
     return normalized

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1220,6 +1220,55 @@ def test_measurement_key_claiming_an_episode_column_is_refused(tmp_path: Path) -
     assert list((tmp_path / "catalog" / "episodes").glob("*.parquet")) == []
 
 
+def test_empty_measurement_key_is_refused(tmp_path: Path) -> None:
+    """No empty measurement key may become a wide-view column (#160).
+
+    An empty key would pivot into a column whose name is the SQL expression
+    that produced it -- a queryable surface with no name a person would write
+    and no rename path (docs/CATALOG.md, "Naming measurement keys").
+    """
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="empty_key_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"": 1.0},
+    )
+    with pytest.raises(ValueError, match=r"'empty_key_check'.*''"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+    assert list((tmp_path / "catalog" / "episodes").glob("*.parquet")) == []
+
+
+def test_whitespace_only_measurement_key_is_refused(tmp_path: Path) -> None:
+    """Whitespace-only keys have the same "no name a person would write" problem (#160)."""
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="blank_key_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        measurements={"   ": 1.0},
+    )
+    with pytest.raises(ValueError, match=r"'blank_key_check'"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+    assert list((tmp_path / "catalog" / "episodes").glob("*.parquet")) == []
+
+
 def test_episodes_view_reserved_columns_match_queryable_episode_columns(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Fixes #160

## What changed

`_normalized_measurements` (catalog.py) now refuses an empty or whitespace-only measurement key, naming the check and the key in the same message shape as its existing value-coercion refusals. The check runs inside `append_episode` before anything is written (the episodes file is written manifest-last), so a refused append leaves no partial state.

Tags and interval labels are intentionally left out, per the issue's own reasoning: neither becomes a wide-view column, so the "no name a person would write" surface problem does not apply to them. Stripping whitespace silently was rejected as a rename, which docs/CATALOG.md ("Naming measurement keys") says never happens.

## Tests

Two new tests in tests/test_catalog_curation.py, mirroring `test_measurement_key_claiming_an_episode_column_is_refused`:

- `test_empty_measurement_key_is_refused` — `measurements={"": 1.0}` raises ValueError naming the check; no parquet written.
- `test_whitespace_only_measurement_key_is_refused` — `measurements={"   ": 1.0}` same.

## Validation

```
.venv/bin/python -m pytest tests/test_catalog_curation.py -q   # 65 passed
.venv/bin/python -m pytest -q                                  # 940 passed; 2 failed + 16 errors ALL confined to tests/test_ffmpeg.py (pre-existing env: no ffmpeg binary in WSL; reproduced in isolation)
.venv/bin/ruff check src/hflow/catalog.py tests/test_catalog_curation.py   # clean
.venv/bin/ruff format --check src/hflow/catalog.py tests/test_catalog_curation.py  # clean
.venv/bin/ty check                                              # clean
```