### PR TITLE
test(storage): cover bucket create-if-absent races

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,30 @@ never trigger the pinned-build download (a per-machine, network-bound step).
 Set at import time, before any test imports resolve the (cached) binary path.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from hflow.storage import BucketStorageRoot
 
 _system_ffmpeg = shutil.which("ffmpeg")
 if _system_ffmpeg is not None:
     os.environ.setdefault("HFLOW_FFMPEG", _system_ffmpeg)
+
+
+@pytest.fixture
+def bucket_over_tmp(tmp_path: Path) -> tuple[BucketStorageRoot, Path]:
+    """A real bucket root over obstore's local backend and its remote dir."""
+    pytest.importorskip("obstore", reason="bucket tests need the hflow[bucket] extra")
+    from hflow.storage import BucketStorageRoot
+
+    remote_dir = tmp_path / "bucket"
+    remote_dir.mkdir(parents=True, exist_ok=True)
+    root = BucketStorageRoot(f"file://{remote_dir}", mirror=tmp_path / "bucket-mirror")
+    return root, remote_dir

--- a/tests/test_bucket_create_if_absent.py
+++ b/tests/test_bucket_create_if_absent.py
@@ -1,0 +1,203 @@
+"""Deterministic races for bucket-backed create-if-absent publishers."""
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, Lock
+
+import duckdb
+import pytest
+
+import hflow
+from hflow.catalog import AppendResult, Catalog, CheckRunRow
+from hflow.curation import open_catalog_connection
+from hflow.dataset import ManifestAlreadyExistsError, write_dataset_manifest
+from hflow.ingest_ledger import IngestFailure, record_ingest_failure
+from hflow.storage import BucketStorageRoot
+from hflow.transform import EpisodeStamps
+from hflow.workspace import Workspace
+
+pytest.importorskip("obstore", reason="bucket tests need the hflow[bucket] extra")
+
+
+class _CreateIfAbsentRace:
+    """Hold two matching puts at the real storage operation and count losses."""
+
+    def __init__(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        target: Callable[[BucketStorageRoot, str], bool],
+    ) -> None:
+        self.attempts = 0
+        self.refusals = 0
+        self._barrier = Barrier(2)
+        self._lock = Lock()
+        store_file_if_absent = BucketStorageRoot.store_file_if_absent
+
+        def gated_store_file_if_absent(
+            root: BucketStorageRoot, local_file: Path, relative: str
+        ) -> bool:
+            if not target(root, relative):
+                return store_file_if_absent(root, local_file, relative)
+            with self._lock:
+                self.attempts += 1
+            self._barrier.wait(timeout=5)
+            created = store_file_if_absent(root, local_file, relative)
+            if not created:
+                with self._lock:
+                    self.refusals += 1
+            return created
+
+        monkeypatch.setattr(BucketStorageRoot, "store_file_if_absent", gated_store_file_if_absent)
+
+
+def _append_outcome(catalog: Catalog, canonical_path: Path) -> AppendResult:
+    stamps = EpisodeStamps(
+        schema_version="1",
+        pipeline_version="abc123def456",
+        ffmpeg_version="ffmpeg version test",
+        robot_software_version="sim-0.1.0",
+    )
+    row = CheckRunRow(
+        check_name="example_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.01,
+        measurements={"score": 1.0},
+        tags=["seen"],
+        intervals=[hflow.Interval(start_ns=0, end_ns=10, label="span")],
+    )
+    return catalog.append_episode(
+        canonical_path=canonical_path,
+        stamps=stamps,
+        episode_metadata={"task": "bucket race"},
+        check_rows=[row],
+    )
+
+
+def test_concurrent_bucket_catalog_appends_publish_one_complete_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bucket_over_tmp: tuple[BucketStorageRoot, Path],
+) -> None:
+    bucket_root, remote_dir = bucket_over_tmp
+    catalog = Catalog(bucket_root.child("catalog"))
+    canonical = tmp_path / "episode.canonical.mcap"
+    canonical.write_bytes(b"canonical episode")
+    race = _CreateIfAbsentRace(
+        monkeypatch,
+        lambda _root, relative: relative.startswith("episodes/"),
+    )
+
+    def append(_label: str) -> AppendResult:
+        return _append_outcome(catalog, canonical)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(append, ("A", "B")))
+
+    assert {result.written for result in results} == {True, False}
+    assert race.attempts == 2
+    assert race.refusals == 1
+    assert {result.episode_id for result in results} == {results[0].episode_id}
+    assert {result.run_fingerprint for result in results} == {results[0].run_fingerprint}
+
+    stem = f"{results[0].episode_id}-{results[0].run_fingerprint}"
+    timestamps: set[str] = set()
+    connection = duckdb.connect()
+    try:
+        for table_name in ("episodes", "check_runs", "measurements", "tags", "intervals"):
+            table_file = remote_dir / "catalog" / table_name / f"{stem}.parquet"
+            assert table_file.is_file()
+            rows = connection.execute(
+                "SELECT DISTINCT CAST(recorded_at AS VARCHAR) FROM read_parquet(?)",
+                [str(table_file)],
+            ).fetchall()
+            timestamps.update(recorded_at for (recorded_at,) in rows)
+    finally:
+        connection.close()
+    assert len(timestamps) == 1
+
+
+def test_concurrent_bucket_manifest_writes_publish_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bucket_over_tmp: tuple[BucketStorageRoot, Path],
+) -> None:
+    bucket_root, remote_dir = bucket_over_tmp
+    workspace = Workspace(bucket_root)
+    catalog = Catalog(workspace.catalog_root)
+    canonical = tmp_path / "episode.canonical.mcap"
+    canonical.write_bytes(b"canonical episode")
+    assert _append_outcome(catalog, canonical).written is True
+    race = _CreateIfAbsentRace(
+        monkeypatch,
+        lambda root, relative: root.url.endswith("/manifests") and relative == "pinned.parquet",
+    )
+
+    def write(_label: str) -> bool:
+        try:
+            written = write_dataset_manifest(
+                workspace,
+                name="clean",
+                sql="SELECT episode_id FROM episodes",
+                file_stem="pinned",
+            )
+        except ManifestAlreadyExistsError:
+            return False
+        assert written.report.row_count == 1
+        return True
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(write, ("A", "B")))
+
+    assert sorted(results) == [False, True]
+    assert race.attempts == 2
+    assert race.refusals == 1
+    manifest = remote_dir / "manifests" / "pinned.parquet"
+    assert manifest.is_file()
+    connection = duckdb.connect()
+    try:
+        assert connection.execute(
+            "SELECT count(*) FROM read_parquet(?)", [str(manifest)]
+        ).fetchone() == (1,)
+    finally:
+        connection.close()
+
+
+def test_concurrent_bucket_ingest_failures_publish_one_ledger_row(
+    monkeypatch: pytest.MonkeyPatch,
+    bucket_over_tmp: tuple[BucketStorageRoot, Path],
+) -> None:
+    bucket_root, _ = bucket_over_tmp
+    catalog_root = bucket_root.child("catalog")
+    race = _CreateIfAbsentRace(
+        monkeypatch,
+        lambda _root, relative: relative.startswith("ingest_failures/"),
+    )
+
+    def record(_label: str) -> IngestFailure:
+        return record_ingest_failure(
+            catalog_root,
+            source_uri="episodes-in/corrupt.mcap",
+            stage="sync",
+            pipeline_version="v1",
+            error=ValueError("boom"),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(record, ("A", "B")))
+
+    assert {result.attempt_fingerprint for result in results} == {results[0].attempt_fingerprint}
+    assert race.attempts == 2
+    assert race.refusals == 1
+    assert len(catalog_root.list_names("ingest_failures")) == 1
+
+    connection = open_catalog_connection(catalog_root)
+    try:
+        rows = connection.execute(
+            "SELECT source_uri, stage, pipeline_version, attempt_fingerprint FROM ingest_failures"
+        ).fetchall()
+    finally:
+        connection.close()
+    assert rows == [("episodes-in/corrupt.mcap", "sync", "v1", results[0].attempt_fingerprint)]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -30,14 +30,6 @@ from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 pytest.importorskip("obstore", reason="bucket tests need the hflow[bucket] extra")
 
 
-def bucket_over_tmp(tmp_path: Path, name: str = "bucket") -> tuple[BucketStorageRoot, Path]:
-    """A BucketStorageRoot backed by a local directory, plus that directory."""
-    remote_dir = tmp_path / name
-    remote_dir.mkdir(parents=True, exist_ok=True)
-    root = BucketStorageRoot(f"file://{remote_dir}", mirror=tmp_path / f"{name}-mirror")
-    return root, remote_dir
-
-
 class TestParseStorageRoot:
     def test_path_and_plain_string_are_local(self) -> None:
         assert parse_storage_root(Path("/tmp/x")) == LocalStorageRoot(Path("/tmp/x"))
@@ -157,8 +149,8 @@ class TestLocalStorageRoot:
 
 
 class TestBucketStorageRoot:
-    def test_round_trip_and_listing(self, tmp_path: Path) -> None:
-        root, remote_dir = bucket_over_tmp(tmp_path)
+    def test_round_trip_and_listing(self, bucket_over_tmp: tuple[BucketStorageRoot, Path]) -> None:
+        root, remote_dir = bucket_over_tmp
         root.write_bytes("catalog/episodes/a.parquet", b"aa")
         assert (remote_dir / "catalog" / "episodes" / "a.parquet").read_bytes() == b"aa"
         assert root.exists("catalog/episodes/a.parquet")
@@ -168,22 +160,28 @@ class TestBucketStorageRoot:
         assert root.list_names("catalog") == ["catalog/episodes/a.parquet"]
         assert root.list_names() == ["catalog/episodes/a.parquet"]
 
-    def test_write_bytes_if_absent_is_store_native(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_write_bytes_if_absent_is_store_native(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         assert root.write_bytes_if_absent("marker", b"v1") is True
         assert root.write_bytes_if_absent("marker", b"v2") is False
         assert root.read_bytes("marker") == b"v1"
 
-    def test_store_file_if_absent_warms_the_mirror(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_store_file_if_absent_warms_the_mirror(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         source_file = tmp_path / "row.parquet"
         source_file.write_bytes(b"rows")
         assert root.store_file_if_absent(source_file, "catalog/tags/x.parquet") is True
         assert (root.mirror / "catalog" / "tags" / "x.parquet").read_bytes() == b"rows"
         assert root.store_file_if_absent(source_file, "catalog/tags/x.parquet") is False
 
-    def test_fetch_downloads_once_then_reuses_etag(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_fetch_downloads_once_then_reuses_etag(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         root.write_bytes("landing/e.mcap", b"episode-bytes")
         first = root.fetch("landing/e.mcap")
         assert first == root.mirror / "landing" / "e.mcap"
@@ -194,15 +192,19 @@ class TestBucketStorageRoot:
         first.write_bytes(b"locally-poisoned")
         assert root.fetch("landing/e.mcap").read_bytes() == b"locally-poisoned"
 
-    def test_fetch_redownloads_when_remote_changed(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_fetch_redownloads_when_remote_changed(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         root.write_bytes("landing/e.mcap", b"version-one")
         assert root.fetch("landing/e.mcap").read_bytes() == b"version-one"
         root.write_bytes("landing/e.mcap", b"version-two!")  # changed size => changed etag
         assert root.fetch("landing/e.mcap").read_bytes() == b"version-two!"
 
-    def test_fetch_missing_raises_file_not_found(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_fetch_missing_raises_file_not_found(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         with pytest.raises(FileNotFoundError):
             root.fetch("landing/missing.mcap")
 
@@ -224,8 +226,10 @@ class TestBucketStorageRoot:
         assert excinfo.value.filename == str(a_directory)
         assert "Is a directory" in str(excinfo.value)
 
-    def test_publish_uploads_and_warms_mirror(self, tmp_path: Path) -> None:
-        root, remote_dir = bucket_over_tmp(tmp_path)
+    def test_publish_uploads_and_warms_mirror(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, remote_dir = bucket_over_tmp
         produced_file = tmp_path / "out.mcap"
         produced_file.write_bytes(b"canonical")
         uri = root.publish(produced_file, "episodes/e/e.canonical.mcap")
@@ -234,16 +238,20 @@ class TestBucketStorageRoot:
         # A fetch right after a publish is served from the warmed mirror.
         assert root.fetch("episodes/e/e.canonical.mcap").read_bytes() == b"canonical"
 
-    def test_publish_from_inside_mirror(self, tmp_path: Path) -> None:
-        root, remote_dir = bucket_over_tmp(tmp_path)
+    def test_publish_from_inside_mirror(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, remote_dir = bucket_over_tmp
         staged_file = root.workspace / "episodes" / "e" / "e.canonical.mcap"
         staged_file.parent.mkdir(parents=True)
         staged_file.write_bytes(b"staged")
         root.publish(staged_file, "episodes/e/e.canonical.mcap")
         assert (remote_dir / "episodes" / "e" / "e.canonical.mcap").read_bytes() == b"staged"
 
-    def test_sync_into_mirror_downloads_only_missing(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_sync_into_mirror_downloads_only_missing(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         root.write_bytes("catalog/episodes/a.parquet", b"aa")
         root.write_bytes("catalog/tags/t.parquet", b"tt")
         mirror = root.sync_into_mirror(("catalog/episodes", "catalog/tags"))
@@ -253,19 +261,23 @@ class TestBucketStorageRoot:
         root.sync_into_mirror(("catalog/tags",))
         assert (mirror / "catalog" / "tags" / "t.parquet").read_bytes() == b"local-final"
 
-    def test_child_shares_the_mirror_subtree(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_child_shares_the_mirror_subtree(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         catalog_child = root.child("catalog")
         assert catalog_child.url == f"{root.url}/catalog"
         assert catalog_child.mirror == root.mirror / "catalog"
 
-    def test_workspace_writes_breadcrumb(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_workspace_writes_breadcrumb(
+        self, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        root, _ = bucket_over_tmp
         workspace = root.workspace
         assert (workspace / ".mirror-of").read_text().strip() == root.url
 
-    def test_uri_for(self, tmp_path: Path) -> None:
-        root, _ = bucket_over_tmp(tmp_path)
+    def test_uri_for(self, bucket_over_tmp: tuple[BucketStorageRoot, Path]) -> None:
+        root, _ = bucket_over_tmp
         assert root.uri_for("episodes/e.mcap") == f"{root.url}/episodes/e.mcap"
 
     def test_store_options_configure_the_store_and_survive_child(
@@ -329,8 +341,10 @@ class TestFetchUri:
 
 
 class TestBucketPipeline:
-    def test_process_publishes_episode_marker_and_catalog(self, tmp_path: Path) -> None:
-        data_root, remote_directory = bucket_over_tmp(tmp_path, "pipeline-bucket")
+    def test_process_publishes_episode_marker_and_catalog(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        data_root, remote_directory = bucket_over_tmp
         source_path = synthesize_episode(
             tmp_path / "source.mcap",
             SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
@@ -378,8 +392,10 @@ class TestBucketPipeline:
         assert repeated_report.catalog_entry is not None
         assert repeated_report.catalog_entry.written is False
 
-    def test_failed_bucket_sync_removes_remote_completion_proof(self, tmp_path: Path) -> None:
-        data_root, remote_directory = bucket_over_tmp(tmp_path, "failed-sync-bucket")
+    def test_failed_bucket_sync_removes_remote_completion_proof(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
+        data_root, remote_directory = bucket_over_tmp
         source_path = synthesize_episode(
             tmp_path / "source.mcap",
             SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
@@ -425,10 +441,12 @@ class TestLiveBucket:
 class TestHardening:
     """Regressions from the adversarial review of the bucket feature."""
 
-    def test_reserved_suffix_keys_are_refused(self, tmp_path: Path) -> None:
+    def test_reserved_suffix_keys_are_refused(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
         # A real object named like a sidecar would collide with mirror
         # bookkeeping (fetch would overwrite it with etag text).
-        root, _ = bucket_over_tmp(tmp_path)
+        root, _ = bucket_over_tmp
         with pytest.raises(ValueError, match="reserved"):
             root.write_bytes("landing/e.mcap.remote-etag", b"x")
         with pytest.raises(ValueError, match="reserved"):
@@ -475,11 +493,13 @@ class TestHardening:
         assert "AWS_ACCESS_KEY_ID" not in os.environ
         assert os.environ["AWS_SECRET_ACCESS_KEY"] == "real-looking-value"
 
-    def test_fetch_and_publish_share_a_mirror_entry_lock(self, tmp_path: Path) -> None:
+    def test_fetch_and_publish_share_a_mirror_entry_lock(
+        self, tmp_path: Path, bucket_over_tmp: tuple[BucketStorageRoot, Path]
+    ) -> None:
         # Smoke-level: the lock file appears next to the entry and repeated
         # fetch/publish cycles stay correct (the interleaving itself needs
         # multiple processes; the lock's existence is the observable seam).
-        root, _ = bucket_over_tmp(tmp_path)
+        root, _ = bucket_over_tmp
         produced = tmp_path / "canonical.mcap"
         produced.write_bytes(b"v1")
         root.publish(produced, "episodes/e/e.canonical.mcap")


### PR DESCRIPTION
## Summary

Add deterministic bucket-backed concurrency coverage for the three create-if-absent publishers named in #165:

- catalog episode appends
- dataset manifest writes
- ingest-failure ledger records

Each race holds two callers at the real `BucketStorageRoot.store_file_if_absent` operation, counts the losing conditional put, and verifies the published business outcome in the backing store. The existing `file://` bucket helper is now a shared fixture so these tests and the storage suite exercise the same obstore-backed seam.

## Why

The local-storage races did not prove that the bucket conditional-put path arbitrates concurrent writers. These tests make both callers pass their early existence checks, release them together at the actual store operation, and require exactly one refusal. They then verify the resulting artifacts: one complete catalog outcome with a single `recorded_at`, one readable one-row manifest, and one queryable ledger row.

This is intentionally test-only. No catalog, dataset, ledger, or storage production behavior changes.

Closes #165.

## Validation

- `python -m pytest -q tests/test_bucket_create_if_absent.py tests/test_storage.py` — 44 passed, 1 skipped
- 50 consecutive runs of `python -m pytest -q tests/test_bucket_create_if_absent.py` — all passed
- `python -m pytest -q` — 967 passed, 9 skipped
- `ruff check .` — passed
- `ruff format --check .` — passed
- `ty check` — passed

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] Documentation is not applicable: this is a test-only change with no changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` (using the existing project virtual environment).
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility; production and stored formats are unchanged.
