### PR TITLE
fix(app): unify local source identities

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -107,6 +107,17 @@ class SourceNotFound(FileNotFoundError):
     """
 
 
+def _local_source_candidate_paths(
+    source_reference: Path | str, root_path: Path
+) -> tuple[Path, Path]:
+    """The cwd and data-root interpretations of one local reference."""
+    source_path = Path(source_reference)
+    if source_path.is_absolute():
+        resolved_path = source_path.resolve()
+        return resolved_path, resolved_path
+    return source_path.resolve(), (root_path / source_path).resolve()
+
+
 def _resolve_local_source_reference(source_reference: Path | str, root_path: Path) -> Path:
     """Resolve one local reference without choosing between two recordings.
 
@@ -115,12 +126,9 @@ def _resolve_local_source_reference(source_reference: Path | str, root_path: Pat
     both files exist; choosing silently in that case could make identity and
     input refer to different recordings, so the caller must disambiguate.
     """
-    source_path = Path(source_reference)
-    if source_path.is_absolute():
-        return source_path.resolve()
-
-    cwd_candidate = source_path.resolve()
-    root_candidate = (root_path / source_path).resolve()
+    cwd_candidate, root_candidate = _local_source_candidate_paths(source_reference, root_path)
+    if cwd_candidate == root_candidate:
+        return cwd_candidate
     cwd_candidate_exists = cwd_candidate.is_file()
     root_candidate_exists = root_candidate.is_file()
 
@@ -134,6 +142,14 @@ def _resolve_local_source_reference(source_reference: Path | str, root_path: Pat
     if root_candidate_exists:
         return root_candidate
     return cwd_candidate
+
+
+def _local_source_identity(resolved_source_path: Path, root_path: Path) -> str:
+    """Root-relative identity inside a local root, absolute identity outside."""
+    try:
+        return resolved_source_path.relative_to(root_path.resolve()).as_posix()
+    except ValueError:
+        return str(resolved_source_path)
 
 
 # The environment override for an App constructed without an explicit data
@@ -276,13 +292,15 @@ def _source_identity(source_reference: Path | str, storage_root: StorageRoot) ->
             return str(source_path.resolve())
         case LocalStorageRoot(path=root_path):
             resolved_source_path = _resolve_local_source_reference(source_path, root_path)
-            try:
-                return resolved_source_path.relative_to(root_path.resolve()).as_posix()
-            except ValueError:
-                return str(resolved_source_path)
+            return _local_source_identity(resolved_source_path, root_path)
 
 
-def _source_artifact_directory_name(source_reference: Path | str, storage_root: StorageRoot) -> str:
+def _source_artifact_directory_name(
+    source_reference: Path | str,
+    storage_root: StorageRoot,
+    *,
+    source_identifier: str | None = None,
+) -> str:
     """A readable, collision-resistant directory name for one source.
 
     Source basenames are not identities: independent robots commonly produce
@@ -291,7 +309,8 @@ def _source_artifact_directory_name(source_reference: Path | str, storage_root: 
     outputs disjoint without leaking the entire source hierarchy into the
     data root.
     """
-    source_identifier = _source_identity(source_reference, storage_root)
+    if source_identifier is None:
+        source_identifier = _source_identity(source_reference, storage_root)
     source_path_digest = hashlib.sha256(source_identifier.encode()).hexdigest()[:12]
     source_stem = Path(str(source_reference).rstrip("/")).stem
     return f"{source_stem}-{source_path_digest}"
@@ -1192,6 +1211,70 @@ class App:
             {channel.topic: channel.version for channel in self.derived},
         )
 
+    def _persisted_local_source_identity(
+        self,
+        episode: Path | str,
+        candidate_identities: tuple[str, ...],
+        output_dir: Path | str | StorageRoot | None,
+    ) -> str | None:
+        """Recover the identity already stored in a sync-completion marker."""
+        if output_dir is not None:
+            candidate_run_roots = (parse_storage_root(output_dir),)
+        else:
+            candidate_run_roots = tuple(
+                self.workspace.episodes_root.child(
+                    _source_artifact_directory_name(
+                        episode,
+                        self.storage_root,
+                        source_identifier=candidate_identity,
+                    )
+                )
+                for candidate_identity in candidate_identities
+            )
+
+        for candidate_run_root in candidate_run_roots:
+            try:
+                marker_path = candidate_run_root.fetch(_SYNC_COMPLETION_MARKER_NAME)
+                completion = _read_sync_completion_marker(marker_path)
+            except (FileNotFoundError, ValueError, OSError):
+                continue
+            if completion.source_path in candidate_identities:
+                return completion.source_path
+        return None
+
+    def _resolve_source_identity(
+        self,
+        episode: Path | str,
+        *,
+        output_dir: Path | str | StorageRoot | None = None,
+    ) -> str:
+        """Resolve identity, retaining it after a relative local source vanishes."""
+        resolved_identity = _source_identity(episode, self.storage_root)
+        if (
+            not isinstance(self.storage_root, LocalStorageRoot)
+            or Path(episode).is_absolute()
+            or (isinstance(episode, str) and is_bucket_url(episode))
+        ):
+            return resolved_identity
+
+        cwd_candidate, root_candidate = _local_source_candidate_paths(
+            episode, self.storage_root.path
+        )
+        if cwd_candidate.is_file() or root_candidate.is_file():
+            return resolved_identity
+
+        root_identity = _local_source_identity(root_candidate, self.storage_root.path)
+        cwd_identity = _local_source_identity(cwd_candidate, self.storage_root.path)
+        candidate_identities = tuple(dict.fromkeys((root_identity, cwd_identity)))
+        persisted_identity = self._persisted_local_source_identity(
+            episode, candidate_identities, output_dir
+        )
+        # With no file and no prior run, a relative reference has no evidence
+        # for the historical cwd interpretation. Treat it as the same
+        # data-root key ingest accepts; a sync attempt will then report that
+        # exact root-relative source as missing.
+        return persisted_identity or root_identity
+
     def source_identity(self, episode: "Path | str") -> str:
         """The ``source_uri`` this App would record for one episode reference.
 
@@ -1207,14 +1290,17 @@ class App:
         root-relative key when only the data-root file exists. If both
         candidates exist and resolve to different files, the reference is
         ambiguous and raises :class:`ValueError` rather than silently naming
-        one recording while processing the other.
+        one recording while processing the other. Once processed, its durable
+        sync marker preserves that choice even if the raw file later
+        disappears; without either a file or a prior marker, a relative
+        reference is treated as a data-root key.
 
         Public because asking "what will this be called in the catalog?"
         without processing anything is exactly what a planner does
         (:mod:`hflow.stage_planning`), and computing it a second way is how a
         planner ends up querying for rows that were filed under another name.
         """
-        return _source_identity(episode, self.storage_root)
+        return self._resolve_source_identity(episode)
 
     def manifest(self) -> PipelineManifest:
         """This pipeline's JSON-able description: step names, explicit
@@ -1691,7 +1777,7 @@ class App:
         :meth:`hflow.catalog.Catalog.append_episode`).
         """
         enabled_stages = _resolve_stages(stages)
-        source_identifier = _source_identity(episode, self.storage_root)
+        source_identifier = self._resolve_source_identity(episode, output_dir=output_dir)
         self._preflight()
         if Stage.SYNC in enabled_stages:
             source_path = self._fetch_source(episode)  # the transform reads it
@@ -1707,7 +1793,11 @@ class App:
             parse_storage_root(output_dir)
             if output_dir is not None
             else self.workspace.episodes_root.child(
-                _source_artifact_directory_name(episode, self.storage_root)
+                _source_artifact_directory_name(
+                    episode,
+                    self.storage_root,
+                    source_identifier=source_identifier,
+                )
             )
         )
         run_dir = run_storage_root.workspace

--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -107,6 +107,35 @@ class SourceNotFound(FileNotFoundError):
     """
 
 
+def _resolve_local_source_reference(source_reference: Path | str, root_path: Path) -> Path:
+    """Resolve one local reference without choosing between two recordings.
+
+    A relative reference can name either the historical cwd-relative source
+    or a key under the data root.  Existence distinguishes those forms unless
+    both files exist; choosing silently in that case could make identity and
+    input refer to different recordings, so the caller must disambiguate.
+    """
+    source_path = Path(source_reference)
+    if source_path.is_absolute():
+        return source_path.resolve()
+
+    cwd_candidate = source_path.resolve()
+    root_candidate = (root_path / source_path).resolve()
+    cwd_candidate_exists = cwd_candidate.is_file()
+    root_candidate_exists = root_candidate.is_file()
+
+    if cwd_candidate_exists and root_candidate_exists and cwd_candidate != root_candidate:
+        raise ValueError(
+            f"relative source reference {str(source_reference)!r} is ambiguous: "
+            f"it names both the working-directory file {cwd_candidate} and the "
+            f"data-root file {root_candidate}; pass an absolute path or prefix "
+            "the data root explicitly"
+        )
+    if root_candidate_exists:
+        return root_candidate
+    return cwd_candidate
+
+
 # The environment override for an App constructed without an explicit data
 # root: the runtime (or a control plane provisioning a hosted workspace)
 # exports it, and the same pipeline file runs unedited at every vantage --
@@ -246,10 +275,11 @@ def _source_identity(source_reference: Path | str, storage_root: StorageRoot) ->
                 return source_path.as_posix()  # a key under the bucket root
             return str(source_path.resolve())
         case LocalStorageRoot(path=root_path):
+            resolved_source_path = _resolve_local_source_reference(source_path, root_path)
             try:
-                return source_path.resolve().relative_to(root_path.resolve()).as_posix()
+                return resolved_source_path.relative_to(root_path.resolve()).as_posix()
             except ValueError:
-                return str(source_path.resolve())
+                return str(resolved_source_path)
 
 
 def _source_artifact_directory_name(source_reference: Path | str, storage_root: StorageRoot) -> str:
@@ -1172,6 +1202,13 @@ class App:
         identity and therefore one run directory, one sync-completion lineage,
         and one row in ``episodes_latest``.
 
+        For a local data root, a relative reference keeps the historical
+        working-directory meaning when only that file exists, and means a
+        root-relative key when only the data-root file exists. If both
+        candidates exist and resolve to different files, the reference is
+        ambiguous and raises :class:`ValueError` rather than silently naming
+        one recording while processing the other.
+
         Public because asking "what will this be called in the catalog?"
         without processing anything is exactly what a planner does
         (:mod:`hflow.stage_planning`), and computing it a second way is how a
@@ -1380,11 +1417,12 @@ class App:
     def _fetch_source(self, episode: Path | str) -> Path:
         """Resolve a source reference to a readable local file.
 
-        Accepted forms, in resolution order: a full bucket URL (fetched
-        through the data root's mirror when it lives under the root), an
-        existing local path (the historical library behavior -- cwd-relative
-        or absolute), and a key relative to the data root (the form ingest
-        conf URIs arrive in, for local and bucket roots alike).
+        Accepted forms: a full bucket URL (fetched through the data root's
+        mirror when it lives under the root), an absolute local path, and a
+        relative reference resolved across the working directory and data
+        root. Two distinct local files at that relative reference are
+        ambiguous and refused. For bucket roots, a non-local relative
+        reference is a key under the bucket prefix.
         """
         if isinstance(episode, str) and is_bucket_url(episode):
             normalized_url = episode.rstrip("/")
@@ -1394,17 +1432,17 @@ class App:
                 return self.storage_root.fetch(normalized_url[len(self.storage_root.url) + 1 :])
             return fetch_uri(normalized_url)
         episode_path = Path(episode)
-        if episode_path.is_file():
-            return episode_path
-        if not episode_path.is_absolute():
-            match self.storage_root:
-                case BucketStorageRoot() as bucket_root:
+        match self.storage_root:
+            case LocalStorageRoot(path=root_path):
+                candidate = _resolve_local_source_reference(episode_path, root_path)
+                if candidate.is_file():
+                    return candidate
+            case BucketStorageRoot() as bucket_root:
+                if episode_path.is_file():
+                    return episode_path
+                if not episode_path.is_absolute():
                     # Raises FileNotFoundError naming the full remote location.
                     return bucket_root.fetch(episode_path.as_posix())
-                case LocalStorageRoot(path=root_path):
-                    candidate = root_path / episode_path
-                    if candidate.is_file():
-                        return candidate
         raise SourceNotFound(
             f"episode {str(episode)!r} not found: not an existing local file, and not "
             f"a key under the data root {self.storage_root}"

--- a/src/hflow/behavior.py
+++ b/src/hflow/behavior.py
@@ -75,4 +75,9 @@ across these changes.
 # now receive one losslessly. Existing slice data stays byte-identical, but the
 # canonical MCAP bytes change, so old and new transforms must not share a
 # pipeline identity.
-TRANSFORM_BEHAVIOR_VERSION: str = "6"
+#
+# "7": a bare data-root-relative source key now records the same root-relative
+# source_uri as the data-root-prefixed and absolute spellings. The corrected
+# provenance changes canonical bytes for recordings previously processed under
+# the cwd-relative absolute identity, so they must not share a pipeline identity.
+TRANSFORM_BEHAVIOR_VERSION: str = "7"

--- a/tests/test_ingest_in_process.py
+++ b/tests/test_ingest_in_process.py
@@ -68,6 +68,34 @@ def test_ingest_without_a_runtime_processes_and_records(
     assert duration_s == pytest.approx(1.0, abs=0.2)
 
 
+def test_cli_and_app_process_share_one_bare_key_identity(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The public CLI and library path cannot double-count one recording."""
+    monkeypatch.delenv("HFLOW_DATA_ROOT", raising=False)
+    monkeypatch.delenv("HFLOW_AIRFLOW_URL", raising=False)
+    monkeypatch.chdir(project)
+
+    source_key = "episodes-in/episode_0001.mcap"
+    assert cli_main(["ingest", source_key]) == 0
+    capsys.readouterr()
+
+    app = hflow.App("in-process", data_root=Path("data"), default_checks=())
+    direct_report = app.process(source_key, record=True, verbose=False)
+
+    connection = open_catalog_connection(project / "data" / "catalog")
+    try:
+        latest_sources = connection.execute("SELECT source_uri FROM episodes_latest").fetchall()
+    finally:
+        connection.close()
+    run_directories = [path for path in (project / "data" / "episodes").iterdir() if path.is_dir()]
+
+    assert latest_sources == [(source_key,)]
+    assert [path.resolve() for path in run_directories] == [
+        direct_report.canonical_path.parent.resolve()
+    ]
+
+
 def test_a_pipeline_that_cannot_be_found_says_so_before_processing(
     project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -730,6 +730,9 @@ def test_source_identity_is_stable_across_vantage_points(
     prefixed_report = relative_app.process(
         "data/landing/e.mcap", record=True, stages={hflow.Stage.LABELS}
     )
+    episode_file.unlink()
+
+    assert relative_app.source_identity("landing/e.mcap") == "landing/e.mcap"
     bare_report = relative_app.process("landing/e.mcap", record=True, stages={hflow.Stage.LABELS})
 
     assert prefixed_report.canonical_path.resolve() == full_report.canonical_path.resolve()
@@ -751,3 +754,24 @@ def test_source_identity_refuses_two_different_relative_local_sources(
 
     with pytest.raises(ValueError, match=r"relative source reference.*is ambiguous"):
         app.source_identity("landing/e.mcap")
+
+
+def test_vanished_cwd_relative_source_keeps_its_persisted_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The root-key fallback must not rename a prior outside-root source."""
+    from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+
+    source = synthesize_episode(
+        tmp_path / "external" / "e.mcap",
+        SyntheticEpisodeSpec(cameras=(), black_segment=None, duration_s=2.0),
+    )
+    monkeypatch.chdir(tmp_path)
+    app = hflow.App("outside-root", data_root=tmp_path / "data", default_checks=())
+    full_report = app.process("external/e.mcap", record=True)
+    expected_identity = str(source.resolve())
+    source.unlink()
+
+    assert app.source_identity("external/e.mcap") == expected_identity
+    relabel_report = app.process("external/e.mcap", record=True, stages={hflow.Stage.LABELS})
+    assert relabel_report.canonical_path.resolve() == full_report.canonical_path.resolve()

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -702,10 +702,11 @@ def test_missing_artifact_is_the_steps_error_not_the_runs(tmp_path: Path) -> Non
 def test_source_identity_is_stable_across_vantage_points(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The same episode named absolutely and root-relatively shares one run dir.
+    """Every spelling of one data-root episode shares one identity and run dir.
 
     This is the host-vs-container case: /opt/airflow/data/landing/e.mcap in
-    the runtime and ./data/landing/e.mcap on the host are the same episode.
+    the runtime, ./data/landing/e.mcap on the host, and the bare key accepted
+    by ingest are the same episode.
     """
     from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
@@ -715,11 +716,38 @@ def test_source_identity_is_stable_across_vantage_points(
         SyntheticEpisodeSpec(cameras=(), black_segment=None, duration_s=2.0),
     )
     app = hflow.App("vantage", data_root=data_root, default_checks=())
+    monkeypatch.chdir(tmp_path)
+
+    assert {
+        app.source_identity("landing/e.mcap"),
+        app.source_identity(Path("data") / "landing/e.mcap"),
+        app.source_identity(episode_file.resolve()),
+    } == {"landing/e.mcap"}
+
     full_report = app.process(episode_file.resolve(), record=True)
 
-    monkeypatch.chdir(tmp_path)
     relative_app = hflow.App("vantage", data_root=Path("data"), default_checks=())
-    relabel_report = relative_app.process(
+    prefixed_report = relative_app.process(
         "data/landing/e.mcap", record=True, stages={hflow.Stage.LABELS}
     )
-    assert relabel_report.canonical_path.resolve() == full_report.canonical_path.resolve()
+    bare_report = relative_app.process("landing/e.mcap", record=True, stages={hflow.Stage.LABELS})
+
+    assert prefixed_report.canonical_path.resolve() == full_report.canonical_path.resolve()
+    assert bare_report.canonical_path.resolve() == full_report.canonical_path.resolve()
+
+
+def test_source_identity_refuses_two_different_relative_local_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_root_source = tmp_path / "data" / "landing" / "e.mcap"
+    cwd_source = tmp_path / "landing" / "e.mcap"
+    data_root_source.parent.mkdir(parents=True)
+    cwd_source.parent.mkdir(parents=True)
+    data_root_source.write_bytes(b"data-root recording")
+    cwd_source.write_bytes(b"working-directory recording")
+    monkeypatch.chdir(tmp_path)
+
+    app = hflow.App("ambiguous", data_root=tmp_path / "data", default_checks=())
+
+    with pytest.raises(ValueError, match=r"relative source reference.*is ambiguous"):
+        app.source_identity("landing/e.mcap")


### PR DESCRIPTION
## Summary

- resolve local source references through one shared rule before deriving either identity or the readable input path
- make a bare data-root key, a data-root-prefixed path, and an absolute path converge on one root-relative source_uri and run directory
- reject a relative reference when distinct files exist at both the working-directory and data-root candidates
- bump TRANSFORM_BEHAVIOR_VERSION from 6 to 7 because the corrected source_uri changes provenance bytes for affected recordings

Closes #169.

## Why

App.process previously fetched a bare key from the data root but derived its identity against the working directory. The same recording could therefore be transcoded into two run directories and recorded under two source_uri values depending only on spelling.

The shared resolver keeps the historical cwd-relative library behavior when only that file exists and chooses the data-root candidate when only it exists. When both candidates are real, refusing the ambiguous spelling avoids silently reading or filing the wrong recording.

## Validation

- /Users/William/.local/bin/uv run pytest -q — 969 passed, 9 skipped on Python 3.14
- /Users/William/.local/bin/uv run --python 3.11 --locked pytest tests/test_processing_regressions.py tests/test_ingest_in_process.py -q — 48 passed
- /Users/William/.local/bin/uv run ruff check --fix — passed
- /Users/William/.local/bin/uv run ruff format — passed
- /Users/William/.local/bin/uv run ruff format --check — 169 files already formatted
- /Users/William/.local/bin/uv run ty check — passed

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran uv run ruff check --fix, uv run ruff format, and uv run ty check.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
