### PR TITLE
cli: describe runtime subcommands in help output

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -462,6 +462,11 @@ def _build_parser() -> argparse.ArgumentParser:
     down_parser = subparsers.add_parser(
         "down",
         help="stop the Compose runtime (containers only; volumes survive)",
+        description=(
+            "Stop the local Docker Compose runtime rendered by `hflow up`. "
+            "Containers are removed while volumes survive unless `--volumes` is "
+            "passed for a full reset."
+        ),
     )
     down_parser.add_argument(
         "--bundle-dir",
@@ -481,6 +486,12 @@ def _build_parser() -> argparse.ArgumentParser:
     ingest_parser = subparsers.add_parser(
         "ingest",
         help="trigger the master ingest DAG over episode URIs (relative to the data root)",
+        description=(
+            "Submit one or more episode URIs to the master ingest DAG, or process "
+            "them in-process when no runtime is addressed. URIs are relative to the "
+            "configured data root; the command prints the triggered run or processing "
+            "summary."
+        ),
     )
     ingest_parser.add_argument(
         "uris",
@@ -536,6 +547,11 @@ def _build_parser() -> argparse.ArgumentParser:
     status_parser = subparsers.add_parser(
         "status",
         help="runtime health summary with plain-language diagnostics",
+        description=(
+            "Inspect the health of the local or remote Airflow runtime addressed by "
+            "the bundle and endpoint options. Prints a plain-language health summary "
+            "and diagnostics for operators."
+        ),
     )
     status_parser.add_argument(
         "--bundle-dir",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,24 @@ from hflow import __version__
 from hflow.cli import _build_parser, main
 
 
+@pytest.mark.parametrize(
+    ("command", "expected_description"),
+    [
+        ("down", "Stop the local Docker Compose runtime rendered by `hflow up`"),
+        ("ingest", "Submit one or more episode URIs to the master ingest DAG"),
+        ("status", "Inspect the health of the local or remote Airflow runtime"),
+    ],
+)
+def test_runtime_command_help_has_a_description(
+    command: str, expected_description: str, capsys: CaptureFixture
+) -> None:
+    with pytest.raises(SystemExit) as exception:
+        _build_parser().parse_args([command, "--help"])
+
+    assert exception.value.code == 0
+    assert expected_description in capsys.readouterr().out
+
+
 def test_cli_version(capsys: CaptureFixture) -> None:
     with pytest.raises(SystemExit) as exception:
         _build_parser().parse_args(["--version"])


### PR DESCRIPTION
## Summary

- Add descriptive help text for `hflow down`, `hflow ingest`, and `hflow status`.
- Add CLI regression coverage verifying each command exposes its description.
- Keep command behavior unchanged.

## Motivation

These runtime subcommands previously displayed only their usage and options when
invoked with `--help`. The added descriptions explain what each command does,
what it requires, and what operators can expect it to print.

## Testing

- `uv run pytest tests/test_cli.py -q`
- `uv run pytest -q`
- `uv run ruff check src/hflow/cli.py tests/test_cli.py`
- `uv run ruff format --check src/hflow/cli.py tests/test_cli.py`
- `uv run ty check`
- `git diff --check`

Closes #61
