### PR TITLE
test(cli): cover stale pipeline app errors

### DIFF
--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -656,6 +656,62 @@ def test_cli_stale_reports_a_broken_pipeline_file_instead_of_crashing(
     assert "boom at import time" in capsys.readouterr().err
 
 
+def test_cli_stale_reports_an_explicitly_named_missing_app(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    Catalog(tmp_path / "catalog")
+    pipeline = tmp_path / "pipeline.py"
+    pipeline.write_text("value = 42\n")
+
+    exit_code = cli_main(
+        [
+            "stale",
+            "--catalog",
+            str(tmp_path / "catalog"),
+            "--pipeline",
+            f"{pipeline}:custom_name",
+        ]
+    )
+
+    assert exit_code == 2
+    assert "has no hflow.App named 'custom_name'" in capsys.readouterr().err
+
+
+def test_cli_stale_reports_a_pipeline_with_no_apps(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    Catalog(tmp_path / "catalog")
+    pipeline = tmp_path / "pipeline.py"
+    pipeline.write_text("value = 42\n")
+
+    exit_code = cli_main(
+        ["stale", "--catalog", str(tmp_path / "catalog"), "--pipeline", str(pipeline)]
+    )
+
+    assert exit_code == 2
+    assert "defines no hflow.App" in capsys.readouterr().err
+
+
+def test_cli_stale_reports_every_app_when_a_pipeline_is_ambiguous(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    Catalog(tmp_path / "catalog")
+    pipeline = tmp_path / "pipeline.py"
+    pipeline.write_text(
+        "import hflow\n\nkitchen = hflow.App('kitchen')\ngarage = hflow.App('garage')\n"
+    )
+
+    exit_code = cli_main(
+        ["stale", "--catalog", str(tmp_path / "catalog"), "--pipeline", str(pipeline)]
+    )
+
+    assert exit_code == 2
+    stderr = capsys.readouterr().err
+    assert "defines 2 hflow.App objects" in stderr
+    assert "'kitchen'" in stderr
+    assert "'garage'" in stderr
+
+
 def test_cli_stale_exit_code_returns_one_when_episodes_are_behind(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Closes #68

## Summary

- cover an explicitly named App that is absent from a pipeline module
- cover a pipeline module that defines no `hflow.App`
- cover an ambiguous pipeline module and require stderr to name both App candidates

All three tests exercise the `hflow stale --pipeline` CLI boundary, including exit code 2 and the user-facing stderr contract. Production code is unchanged.

## Validation

- focused three-test replay: 3 passed
- mutation check: changing `_command_stale`'s pipeline-resolution error return from 2 to 0 made all three new tests fail; restoring it returned them to green
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest -q` — 976 passed, 9 skipped

Disclosure: I used Codex to assist with implementation and verification, and reviewed the final diff and test evidence.
