### PR TITLE
cli: describe dataset, export, and serve commands

### DIFF
--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -179,6 +179,11 @@ def _build_parser() -> argparse.ArgumentParser:
     dataset_parser = subparsers.add_parser(
         "dataset",
         help="create version-pinned dataset manifests from the pipeline's own policy",
+        description=(
+            "Group commands that turn the pipeline's policy into version-pinned "
+            "dataset manifests. Use `create` to select episodes and write a "
+            "Parquet manifest plus its provenance sidecar."
+        ),
     )
     dataset_subparsers = dataset_parser.add_subparsers(dest="dataset_command", required=True)
     dataset_create_parser = dataset_subparsers.add_parser(
@@ -223,6 +228,11 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser = subparsers.add_parser(
         "export",
         help="export catalog selections in portable downstream formats",
+        description=(
+            "Group commands for exporting catalog selections in portable downstream "
+            "formats. Use `snapshot` to write a tool-neutral directory of Parquet "
+            "tables and optional media assets."
+        ),
     )
     export_subparsers = export_parser.add_subparsers(dest="export_command", required=True)
     snapshot_export_parser = export_subparsers.add_parser(
@@ -571,6 +581,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "UI assets installed (requires the hflow-server package). Distinct from "
             "`up`, which starts the runtime that PROCESSES episodes -- this only "
             "reads the data root, and can trigger a run on a runtime that exists."
+        ),
+        description=(
+            "Serve this workspace over HTTP with REST endpoints over the catalog, "
+            "episodes, artifacts, and optional UI assets. The server reads the data "
+            "root and can trigger an existing runtime, but it does not process "
+            "episodes itself; use `hflow up` for that."
         ),
     )
     serve_parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,24 @@ def test_runtime_command_help_has_a_description(
     assert expected_description in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("command", "expected_description"),
+    [
+        ("dataset", "Group commands that turn the pipeline's policy into version-pinned"),
+        ("export", "Group commands for exporting catalog selections in portable downstream"),
+        ("serve", "Serve this workspace over HTTP with REST endpoints over the catalog"),
+    ],
+)
+def test_top_level_command_help_has_a_description(
+    command: str, expected_description: str, capsys: CaptureFixture
+) -> None:
+    with pytest.raises(SystemExit) as exception:
+        _build_parser().parse_args([command, "--help"])
+
+    assert exception.value.code == 0
+    assert expected_description in capsys.readouterr().out
+
+
 def test_cli_version(capsys: CaptureFixture) -> None:
     with pytest.raises(SystemExit) as exception:
         _build_parser().parse_args(["--version"])


### PR DESCRIPTION
## Summary

- Add detailed help descriptions for `hflow dataset`, `hflow export`, and `hflow serve`.
- Add CLI regression coverage verifying each parent command exposes its description.
- Keep command behavior unchanged.

## Motivation

These commands previously displayed only usage, options, or subcommand lists
when invoked with `--help`. The added descriptions explain each command's
purpose, current subcommand/output, and how `hflow serve` differs from the
processing runtime started by `hflow up`.

## Testing

- `uv run pytest tests/test_cli.py -q`
- `uv run pytest -q`
- `uv run ruff check src/hflow/cli.py tests/test_cli.py`
- `uv run ruff format --check src/hflow/cli.py tests/test_cli.py`
- `uv run ty check`
- `git diff --check`

Closes #193
