### PR TITLE
feat(runtime): plan outstanding stages in the Airflow lane

### DIFF
--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -63,10 +63,15 @@ step whose rows still say it ran -- a cleaned `media/` directory keeps its
 hflow ingest --all-stages episodes-in/*.mcap
 ```
 
-This applies to the in-process executor only. The Airflow lane runs the whole
-profile on every episode it is handed, because a stage set that varies per
-episode is not something a trigger conf can express without re-rendering every
-bundle.
+The Airflow lane plans too, and asks the same question in the same place. Each
+stage sub-DAG filters its own `uris` at plan time, after the sync sub-DAG has
+finished, so it reads the catalog state the in-process plan would read. A stage
+left with nothing outstanding skips rather than reporting a hollow success.
+
+`--all-stages` has a counterpart there: pass `all_stages: true` in the trigger
+conf and every stage runs over everything it was handed, whatever the catalog
+says. The master passes it down to every sub-DAG it triggers, and a directly
+triggered sub-DAG takes it in its own conf.
 
 ## Prerequisites
 

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -81,6 +81,7 @@ from hflow.runtime._templates import (
     EXTERNAL_PYTHON_BOOTSTRAP_REQUIREMENT,
     MASTER_DAG_TEMPLATE,
     MEDIA_PLAN_FILTER_TEMPLATE,
+    OUTSTANDING_PLAN_FILTER_TEMPLATE,
     SUB_DAG_ERROR_GATE_TEMPLATE,
     SUB_DAG_QUARANTINE_GATE_TEMPLATE,
 )
@@ -673,15 +674,30 @@ def render_sub_dag_source(
     # source; neutralize that one sequence for the prose slot.
     venv_python_documentation_text = venv_python_literal.replace('"""', '\\"\\"\\"')
     # Substituted separately because Template.substitute never re-expands
-    # variables inside substituted VALUES -- the filter's own $data_root must
-    # be resolved before injection. Local roots only: probing a BUCKET
-    # episode's channel list would download the whole file at plan time,
-    # costing more than the skipped camera-less cycle saves.
-    stage_plan_filter = (
-        MEDIA_PLAN_FILTER_TEMPLATE.substitute(data_root=data_root_literal)
-        if stage is Stage.MEDIA and not is_bucket_url(data_root)
-        else ""
-    )
+    # variables inside substituted VALUES -- a filter's own $data_root must be
+    # resolved before injection.
+    #
+    # The outstanding filter runs on every stage but sync, bucket roots
+    # included: it queries the catalog and never opens an episode, so the
+    # media filter's reason for skipping buckets does not transfer. It comes
+    # first, so the media probe only opens files that are going to be
+    # processed.
+    plan_filters = []
+    if stage is not Stage.SYNC:
+        plan_filters.append(
+            OUTSTANDING_PLAN_FILTER_TEMPLATE.substitute(
+                data_root=data_root_literal,
+                pipeline_filename=pipeline_filename_literal,
+                app_variable=app_variable,
+                stage_name=stage.value,
+            )
+        )
+    # Local roots only: probing a BUCKET episode's channel list would download
+    # the whole file at plan time, costing more than the skipped camera-less
+    # cycle saves.
+    if stage is Stage.MEDIA and not is_bucket_url(data_root):
+        plan_filters.append(MEDIA_PLAN_FILTER_TEMPLATE.substitute(data_root=data_root_literal))
+    stage_plan_filter = "".join(plan_filters)
     return template.substitute(
         dag_id=sub_dag_id,
         master_dag_id=master_dag_id,

--- a/src/hflow/runtime/_templates.py
+++ b/src/hflow/runtime/_templates.py
@@ -301,7 +301,8 @@ enabled stage set, then trigger only those sub-DAGs, chained sequentially
 -- no user venv, no hflow import.
 
 Trigger conf: {"uris": [...], "profile": "full", "mode": "batch"|"online",
-"batch_count": optional int}. "uris"/"mode"/"batch_count" pass through to
+"batch_count": optional int, "all_stages": optional bool}.
+"uris"/"mode"/"batch_count"/"all_stages" pass through to
 every triggered sub-DAG; mode "online" is the latency-first lane (one run per
 episode as it lands): each sub-DAG processes the conf's uris as one immediate
 batch, no bin-packing, no stagger.
@@ -354,7 +355,9 @@ $profile_table_rows
 **Trigger conf** -- `uris`: episode files relative to the data root;
 `profile`: a row above (default `full`); `mode`: `batch` bin-packs uris into
 staggered near-equal-byte shards, `online` is the latency-first lane (one
-immediate run, no batching, no stagger); `batch_count`: optional override.
+immediate run, no batching, no stagger); `batch_count`: optional override;
+`all_stages`: run every stage over everything it is handed instead of only
+what the catalog does not already record as current.
 
 Each sub-DAG (`$sync_dag_id`, `$meta_dag_id`, `$labels_dag_id`,
 `$media_dag_id`) is also directly triggerable with the same conf for
@@ -370,7 +373,13 @@ per-stage reruns -- e.g. a re-label pass over already-canonical episodes.
     tags=["$pipeline_tag", "master"],
     schedule=None,
     render_template_as_native_obj=True,
-    params={"uris": [], "profile": "full", "mode": "batch", "batch_count": None},
+    params={
+        "uris": [],
+        "profile": "full",
+        "mode": "batch",
+        "batch_count": None,
+        "all_stages": False,
+    },
 )
 def master_ingest():
     @task
@@ -421,6 +430,7 @@ def master_ingest():
                 "uris": "{{ params.uris }}",
                 "mode": "{{ params.mode }}",
                 "batch_count": "{{ params.batch_count }}",
+                "all_stages": "{{ params.all_stages }}",
             },
             wait_for_completion=True,
             deferrable=True,
@@ -463,7 +473,7 @@ plan -> process_batch (dynamically mapped) -> $gate_name, all via
 never meet Airflow's pins). Imports live inside the function bodies because
 the operator extracts each body to a temp file; only JSON-able data crosses
 task borders. Trigger conf: {"uris": [...], "mode": "batch"|"online",
-"batch_count": optional int}.
+"batch_count": optional int, "all_stages": optional bool}.
 """
 
 from airflow.sdk import dag, task
@@ -481,7 +491,8 @@ user dependencies never meet Airflow's pins.
 
 **Trigger conf** -- `uris`: episode files relative to the data root;
 `mode`: `batch` (bin-packed, staggered shards) or `online` (one immediate
-latency-first run); `batch_count`: optional override.
+latency-first run); `batch_count`: optional override; `all_stages`: run every
+uri handed over instead of only the ones this stage still owes work on.
 """
 
 
@@ -493,20 +504,33 @@ latency-first run); `batch_count`: optional override.
     tags=["$pipeline_tag", "stage:$stage_name"],
     schedule=None,
     render_template_as_native_obj=True,
-    params={"uris": [], "mode": "batch", "batch_count": None},
+    params={"uris": [], "mode": "batch", "batch_count": None, "all_stages": False},
 )
 def ingest_stage():
     @task.external_python(python=$venv_python, expect_airflow=False, skip_on_exit_code=99$task_queue_argument)
-    def plan(uris, mode, batch_count):
-        """Bin-pack uris into staggered batches; online is one immediate batch.
+    def plan(uris, mode, batch_count, all_stages):
+        """Narrow uris to what this stage still owes, then bin-pack them.
 
         The lane semantics live in hflow.stage_execution (one owner for every
-        execution backend); this task only feeds it the trigger conf.
+        execution backend); this task only feeds it the trigger conf. Any
+        narrowing happens first, so the bin-packer only ever sees work that
+        is going to run.
+
+        all_stages is the conf escape hatch: true runs every uri handed over,
+        whatever the catalog already records. It is the scheduled counterpart
+        of `hflow ingest --all-stages`, and exists for the one thing the
+        catalog cannot see -- an artifact deleted out from under a step whose
+        rows still say it ran.
         """
         from hflow.stage_execution import plan_stage_batches
 
         if not uris:
             return []
+        # Conf values arrive rendered; a native bool passes straight through
+        # and a hand-typed string is read the way every other flag in the
+        # project reads one.
+        if isinstance(all_stages, str):
+            all_stages = all_stages.strip().lower() in {"1", "true", "yes", "on"}
 $stage_plan_filter        return plan_stage_batches(
             [str(uri) for uri in uris],
             mode=mode,
@@ -587,6 +611,7 @@ _SUB_DAG_FOOTER = """\
         uris="{{ params.uris }}",
         mode="{{ params.mode }}",
         batch_count="{{ params.batch_count }}",
+        all_stages="{{ params.all_stages }}",
     )
     # partial() binds the run id once for every mapped instance: it is the
     # same value for the whole fan-out, and only expand()'s argument varies.
@@ -645,5 +670,61 @@ MEDIA_PLAN_FILTER_TEMPLATE = Template(
         uris = [uri for uri in uris if has_camera(uri)]
         if not uris:
             raise SystemExit(99)  # skip_on_exit_code: whole stage SKIPPED
+"""
+)
+
+
+# Injected into every stage sub-DAG's plan EXCEPT sync's (sync records no
+# steps and is its own cache, so it is never planned away). Asks the catalog
+# which of this run's uris still owe this stage work at the steps' current
+# versions, and drops the rest -- the same question `hflow ingest` asks
+# in-process, in the same place relative to sync, so the two lanes cost the
+# same for the same command.
+#
+# Placed BEFORE the media filter when a stage has both: this one is a catalog
+# query, the media one opens episodes, and narrowing first means fewer files
+# to open.
+#
+# Loading the user pipeline here is what the question costs. plan already runs
+# in the user venv (@task.external_python), and these are the same three
+# helpers process_batch calls, so nothing new is introduced -- but a pipeline
+# that will not import now fails at plan rather than at process_batch, which
+# is earlier and cheaper to read.
+#
+# When nothing is left the plan exits 99, which skip_on_exit_code turns into a
+# SKIPPED task (the UI shows a stage that had nothing to do, not a hollow
+# success); downstream tasks skip with it.
+OUTSTANDING_PLAN_FILTER_TEMPLATE = Template(
+    """\
+        if not all_stages:
+            import os
+
+            from hflow.app import DATA_ROOT_ENVIRONMENT_VARIABLE
+            from hflow.stage_execution import (
+                load_pipeline_application,
+                require_application_data_root,
+                resolve_user_pipeline_path,
+            )
+            from hflow.stage_planning import outstanding_stage_uris
+            from hflow.steps import Stage
+
+            expected_data_root = $data_root
+            # Same guard process_batch applies: an environment-portable
+            # pipeline resolves its root from this variable, and one that
+            # hardcodes a different literal is refused rather than planned
+            # against the wrong catalog.
+            os.environ[DATA_ROOT_ENVIRONMENT_VARIABLE] = expected_data_root
+            planning_app = load_pipeline_application(
+                resolve_user_pipeline_path($pipeline_filename), "$app_variable"
+            )
+            require_application_data_root(planning_app, expected_data_root)
+            uris = outstanding_stage_uris(
+                planning_app,
+                [str(uri) for uri in uris],
+                Stage("$stage_name"),
+                data_root=expected_data_root,
+            )
+            if not uris:
+                raise SystemExit(99)  # skip_on_exit_code: whole stage SKIPPED
 """
 )

--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -53,9 +53,13 @@ class StageSelection(StrEnum):
 
     A run's own vocabulary rather than a flag, because the two modes are
     genuinely different requests and a caller should have to name which one it
-    means. It is deliberately NOT conf vocabulary like :class:`hflow.steps.Stage`
-    -- the planner is direct-executor only (see :func:`plan_outstanding_stages`),
-    so nothing crosses into a rendered DAG.
+    means. It stays a direct-run type even though the scheduled lane now plans
+    too: what crosses the conf boundary there is one boolean per sub-DAG run
+    (``all_stages``), not a selection between named modes, and widening this
+    enum into conf vocabulary would oblige every rendered bundle to be
+    re-rendered whenever a member was added. :func:`outstanding_stage_uris` is
+    the scheduled lane's entry point and takes no selection at all -- the
+    caller decides whether to ask.
     """
 
     # Per episode, run only the stages whose steps the catalog does not already
@@ -267,3 +271,65 @@ def plan_outstanding_stages(
             outstanding_steps=tuple(sorted(outstanding_steps)),
         )
     return plans
+
+
+def outstanding_stage_uris(
+    application: "App",
+    uris: Sequence[str],
+    stage: Stage,
+    *,
+    data_root: str,
+) -> list[str]:
+    """Which of ``uris`` still owe ``stage`` work, in the order given.
+
+    The same question :func:`plan_outstanding_stages` answers for a direct
+    run, asked for one stage and answered in the caller's own vocabulary:
+    conf ``uris`` are data-root-relative strings, and the catalog files rows
+    under ``source_uri``. Translating between the two is the whole reason this
+    is not a bare call at the call site -- computing the identity a second way
+    is how a planner ends up querying for rows filed under another name, which
+    reads as "everything is outstanding" and quietly does nothing.
+
+    **Call this only after ``sync`` has completed for the same recordings**,
+    for the reason in the module docstring: before then the catalog names the
+    PREVIOUS generation. The scheduled lane satisfies that by running inside a
+    stage sub-DAG, which the master triggers after the sync sub-DAG finished.
+    Triggering a stage sub-DAG directly, without a sync pass over recordings
+    whose bytes changed, is the one case where this reads a stale id -- the
+    same exposure the direct executor has, and what the escape hatch is for.
+
+    ``Stage.SYNC`` is refused rather than answered. It records no step rows and
+    is its own cache, so "outstanding" is not a question the catalog can answer
+    about it, and an empty answer would filter away the stage that produces the
+    canonical file every later stage reads.
+
+    A recording with no episode in the catalog is KEPT, which is the one place
+    this deliberately differs from :func:`plan_outstanding_stages`. That
+    function drops it, and can, because the direct executor ran sync in the
+    same invocation and therefore knows a missing row means sync failed. A
+    stage sub-DAG knows no such thing: a directly triggered ``meta`` pass over
+    a corpus that was never synced looks identical from the catalog, and
+    dropping it would turn the loud ``FileNotFoundError`` that ``hflow ingest
+    --profile metadata_backfill`` raises today into a silent skip. Filtering
+    exists to stop paying for work that is already done, not to suppress
+    failures, so a recording the catalog cannot vouch for is handed on and
+    fails exactly as it does now.
+    """
+    if stage is Stage.SYNC:
+        message = "sync records no steps and is never planned away; it cannot be filtered"
+        raise ValueError(message)
+    if not uris:
+        return []
+    from hflow.stage_execution import resolve_episode_reference
+
+    identity_by_uri = {
+        uri: application.source_identity(resolve_episode_reference(data_root, str(uri)))
+        for uri in uris
+    }
+    plans = plan_outstanding_stages(application, list(identity_by_uri.values()), (stage,))
+    return [
+        uri
+        for uri in uris
+        if not isinstance(plan := plans.get(identity_by_uri[uri]), OutstandingStages)
+        or stage in plan.stages
+    ]

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -382,9 +382,14 @@ def test_master_dag_source_compiles_and_encodes_contract(
 
     assert 'dag_id="my_pipeline_ingest"' in dag_source
     assert "schedule=None" in dag_source
-    assert (
-        'params={"uris": [], "profile": "full", "mode": "batch", "batch_count": None}' in dag_source
-    )
+    assert '"uris": [],' in dag_source
+    assert '"profile": "full",' in dag_source
+    assert '"batch_count": None,' in dag_source
+    # The escape hatch is conf vocabulary on the master too, and it is passed
+    # down: a sub-DAG the master triggered must not plan work away when the
+    # operator asked for every stage.
+    assert '"all_stages": False,' in dag_source
+    assert '"all_stages": "{{ params.all_stages }}",' in dag_source
     # The master runs ENTIRELY in Airflow's environment: no user venv, no
     # hflow import -- the profile vocabulary is baked in as a literal.
     assert "external_python" not in dag_source
@@ -436,7 +441,10 @@ def test_sub_dag_sources_compile_and_encode_contract(config: RuntimeConfig, tmp_
 
         assert f'dag_id="my_pipeline_{stage.value}"' in dag_source
         assert "schedule=None" in dag_source
-        assert 'params={"uris": [], "mode": "batch", "batch_count": None}' in dag_source
+        assert (
+            'params={"uris": [], "mode": "batch", "batch_count": None, "all_stages": False}'
+            in dag_source
+        )
         # All three tasks run in the user venv via external python.
         assert dag_source.count("@task.external_python(python='/opt/venvs/user/bin/python'") == 3
         # Imports live inside the (indented) function bodies -- the operator
@@ -994,3 +1002,81 @@ def test_requirements_directory_says_is_a_directory(config: RuntimeConfig, tmp_p
     assert excinfo.value.errno == errno.EISDIR
     assert excinfo.value.filename == str(a_directory)
     assert "Is a directory" in str(excinfo.value)
+
+
+class TestScheduledStagePlanning:
+    """The plan-time filter that makes a scheduled re-ingest cost what a direct
+    one costs.
+
+    The predicate itself is covered by tests/test_stage_planning.py, which runs
+    it. What can only be checked here is the wiring: which sub-DAGs carry it,
+    which stage name each one asks about, and that the conf escape hatch
+    reaches it.
+    """
+
+    @staticmethod
+    def _sub_dag_sources(config: RuntimeConfig, bundle_dir: Path) -> dict[str, str]:
+        paths = render_bundle(config, bundle_dir)
+        return {
+            sub_dag_file.stem.removeprefix("ingest_"): sub_dag_file.read_text()
+            for sub_dag_file in paths.sub_dag_files
+        }
+
+    def test_every_stage_but_sync_filters_its_own_uris(
+        self, config: RuntimeConfig, tmp_path: Path
+    ) -> None:
+        sources = self._sub_dag_sources(config, tmp_path / "bundle")
+
+        # Sync is its own cache and records no steps, so it is never planned
+        # away -- filtering it would drop the stage that produces the canonical
+        # file every later stage reads.
+        assert "outstanding_stage_uris" not in sources["sync"]
+        for stage_name in ("meta", "labels", "media"):
+            source = sources[stage_name]
+            assert "outstanding_stage_uris" in source
+            # Each sub-DAG asks about ITS OWN stage. Asking about another one
+            # would filter on work that stage never records.
+            assert f'Stage("{stage_name}")' in source
+            # Ahead of plan_stage_batches: the bin-packer should only ever see
+            # work that is going to run.
+            assert source.index("outstanding_stage_uris") < source.index("plan_stage_batches(")
+            # Nothing outstanding is a SKIPPED stage, not a hollow success.
+            assert "raise SystemExit(99)" in source
+
+    def test_the_filter_precedes_the_camera_probe(
+        self, config: RuntimeConfig, tmp_path: Path
+    ) -> None:
+        """Media carries both. The catalog query is cheaper than opening
+        episodes, so narrowing first means fewer files opened for nothing."""
+        media_source = self._sub_dag_sources(config, tmp_path / "bundle")["media"]
+
+        assert media_source.index("outstanding_stage_uris") < media_source.index("has_camera")
+
+    def test_a_bucket_root_keeps_the_filter(self, config: RuntimeConfig, tmp_path: Path) -> None:
+        """The media probe is omitted on buckets because reading an episode's
+        channel list downloads the whole file. This one never opens an episode:
+        it syncs catalog parquet through the mirror, so the reason does not
+        transfer and a bucket deployment gets the saving too."""
+        from dataclasses import replace
+
+        sources = self._sub_dag_sources(
+            replace(config, data_root="gs://bucket/robot-data"), tmp_path / "bucket-bundle"
+        )
+
+        assert "has_camera" not in sources["media"]
+        for stage_name in ("meta", "labels", "media"):
+            assert "outstanding_stage_uris" in sources[stage_name]
+
+    def test_the_escape_hatch_reaches_the_filter(
+        self, config: RuntimeConfig, tmp_path: Path
+    ) -> None:
+        """`--all-stages` has no meaning to a DAG, so the scheduled lane needs
+        its own vocabulary for it. Without the conf reaching the filter there
+        would be no way to re-run a stage whose artifacts were deleted out from
+        under rows that still say it ran."""
+        sources = self._sub_dag_sources(config, tmp_path / "bundle")
+
+        for stage_name in ("meta", "labels", "media"):
+            source = sources[stage_name]
+            assert "if not all_stages:" in source
+            assert 'all_stages="{{ params.all_stages }}"' in source

--- a/tests/test_stage_planning.py
+++ b/tests/test_stage_planning.py
@@ -602,3 +602,23 @@ class TestTheRenderedPlanTask:
         batches = plan([EPISODE_URI], "batch", None, "true")
 
         assert [item for batch in batches for item in batch["items"]] == [EPISODE_URI]
+
+    @pytest.mark.parametrize("spelling", ["false", "no", "off", "0", "", "   "])
+    def test_a_conf_string_that_spells_no_leaves_the_filter_on(
+        self, project: Path, plan: RenderedPlan, spelling: str
+    ) -> None:
+        """The direction where a regression is silent.
+
+        Reading a false spelling as true does not fail anything: the stage
+        simply processes everything, which is what it did before this filter
+        existed. So the corpus stays correct and the run just costs what #172
+        was about, forever, with nothing saying so. Truthiness on the raw
+        string (``bool(all_stages)``) is the obvious wrong implementation and
+        every spelling here survives it.
+        """
+        _ingest(project)
+
+        with pytest.raises(SystemExit) as excinfo:
+            plan([EPISODE_URI], "batch", None, spelling)
+
+        assert excinfo.value.code == 99

--- a/tests/test_stage_planning.py
+++ b/tests/test_stage_planning.py
@@ -7,7 +7,9 @@ which is about ordering: it exists because a planner that ran before `sync`
 instead of after it would pass every other test in this file.
 """
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -421,3 +423,182 @@ class TestMediaPlanning:
         second = _ingest(project)
 
         assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 0
+
+
+class TestFilteringAScheduledStagesUris:
+    """The scheduled lane asks the same question, in conf vocabulary.
+
+    ``outstanding_stage_uris`` is what a rendered stage sub-DAG calls at plan
+    time. It takes the data-root-relative strings a trigger conf carries and
+    answers with the subset of them that stage still owes work on, so these
+    tests pin the translation as much as the planning: a conf uri that does not
+    reduce to the identity the catalog filed under reads as "everything is
+    outstanding" and quietly costs a full re-run.
+    """
+
+    @staticmethod
+    def _application(project: Path) -> hflow.App:
+        return hflow.import_pipeline_application(str(project / "pipeline.py"))
+
+    @staticmethod
+    def _filter(project: Path, stage: hflow.Stage, *uris: str) -> list[str]:
+        from hflow.stage_planning import outstanding_stage_uris
+
+        application = TestFilteringAScheduledStagesUris._application(project)
+        return outstanding_stage_uris(
+            application,
+            list(uris) or [EPISODE_URI],
+            stage,
+            data_root=str(project / "data"),
+        )
+
+    def test_an_unchanged_corpus_leaves_the_stage_nothing_to_do(self, project: Path) -> None:
+        """The whole point of the issue: the scheduled lane stops paying for a
+        decode pass the catalog already records."""
+        _ingest(project)
+
+        assert self._filter(project, hflow.Stage.META) == []
+
+    def test_a_synced_but_unchecked_recording_is_still_owed(self, project: Path) -> None:
+        """Sync alone leaves meta outstanding, which is the case the filter has
+        to keep: dropping it would silently never run the checks."""
+        application = self._application(project)
+        run_stages_directly(application, [EPISODE_URI], frozenset({hflow.Stage.SYNC}))
+
+        assert self._filter(project, hflow.Stage.META) == [EPISODE_URI]
+
+    def test_a_check_added_afterwards_makes_it_outstanding_again(self, project: Path) -> None:
+        _ingest(project)
+        (project / "pipeline.py").write_text(
+            PIPELINE_SOURCE
+            + """
+
+@app.check(version="1")
+def added_later(ep: hflow.Episode) -> hflow.CheckResult:
+    return hflow.CheckResult(evidence={})
+"""
+        )
+
+        assert self._filter(project, hflow.Stage.META) == [EPISODE_URI]
+
+    def test_a_recording_the_catalog_cannot_vouch_for_is_handed_on(self, project: Path) -> None:
+        """The one place this differs from the direct planner, which drops such
+        a recording because it ran sync itself and so knows the row is missing
+        because sync failed. A stage sub-DAG cannot tell that apart from a
+        corpus nobody has synced yet, and dropping it would turn the loud
+        FileNotFoundError that a meta-only run raises today into a silent skip.
+        Filtering is here to stop paying for finished work, not to swallow
+        failures."""
+        _ingest(project)
+        (project / "data" / "episodes-in" / "unreadable.mcap").write_bytes(b"not an mcap")
+
+        assert self._filter(
+            project, hflow.Stage.META, EPISODE_URI, "episodes-in/unreadable.mcap"
+        ) == ["episodes-in/unreadable.mcap"]
+
+    def test_the_conf_spelling_reaches_the_rows_the_catalog_filed(self, project: Path) -> None:
+        """A conf uri is relative to the DATA ROOT, not to the working
+        directory, and the two differ in every deployment: a task process runs
+        wherever the operator put it. Resolving the wrong one queries for rows
+        filed under another name, which reads as "outstanding" for a corpus
+        that is entirely up to date."""
+        _ingest(project)
+        elsewhere = project / "not-the-data-root"
+        elsewhere.mkdir()
+
+        with pytest.MonkeyPatch.context() as patched:
+            patched.chdir(elsewhere)
+
+            assert self._filter(project, hflow.Stage.META) == []
+
+    def test_sync_is_refused_rather_than_answered(self, project: Path) -> None:
+        """Sync records no steps and is its own cache, so an empty answer would
+        filter away the stage that produces the file every later stage reads."""
+        with pytest.raises(ValueError, match="never planned away"):
+            self._filter(project, hflow.Stage.SYNC)
+
+
+# What a rendered `plan` task is once its Airflow decorator is stripped: conf
+# values in, JSON-able batches out.
+RenderedPlan = Callable[[list[str], str, int | None, bool | str], list[dict[str, Any]]]
+
+
+class TestTheRenderedPlanTask:
+    """The filter as a stage sub-DAG actually runs it.
+
+    Everything above calls ``outstanding_stage_uris`` directly. What that
+    cannot catch is the injected snippet being wrong: it reaches the bundle as
+    a string, so a bad name or a missed substitution compiles and only fails
+    when a task runs, which needs Airflow and Docker. Extracting the rendered
+    ``plan`` body and calling it closes that gap without either, because the
+    body's whole contract is that it runs under plain CPython in the user venv.
+    """
+
+    @staticmethod
+    def _rendered_plan(project: Path, stage: hflow.Stage) -> RenderedPlan:
+        import ast
+
+        from hflow.runtime._bundle import render_dag_sources
+
+        sources = render_dag_sources(
+            master_dag_id="rendered",
+            pipeline_filename="pipeline.py",
+            app_variable="app",
+            data_root=str(project / "data"),
+            venv_python="/unused/python",
+        )
+        module = ast.parse(sources[f"rendered_{stage.value}"])
+        dag_function = next(
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.FunctionDef) and node.name == "ingest_stage"
+        )
+        plan_function = next(
+            node
+            for node in dag_function.body
+            if isinstance(node, ast.FunctionDef) and node.name == "plan"
+        )
+        # The decorator is Airflow's; the body underneath it is plain Python
+        # and is the only part this test is about.
+        plan_function.decorator_list = []
+        extracted = ast.Module(body=[plan_function], type_ignores=[])
+        ast.fix_missing_locations(extracted)
+        namespace: dict[str, RenderedPlan] = {}
+        exec(compile(extracted, "<rendered plan>", "exec"), namespace)
+        return namespace["plan"]
+
+    @pytest.fixture
+    def plan(self, project: Path, monkeypatch: pytest.MonkeyPatch) -> RenderedPlan:
+        monkeypatch.setenv("HFLOW_USER_DIR", str(project))
+        return self._rendered_plan(project, hflow.Stage.META)
+
+    def test_an_unchanged_corpus_skips_the_whole_stage(
+        self, project: Path, plan: RenderedPlan
+    ) -> None:
+        """Exit 99 is what skip_on_exit_code turns into a SKIPPED task, so the
+        UI shows a stage that had nothing to do rather than a hollow success."""
+        _ingest(project)
+
+        with pytest.raises(SystemExit) as excinfo:
+            plan([EPISODE_URI], "batch", None, False)
+
+        assert excinfo.value.code == 99
+
+    def test_all_stages_hands_the_whole_batch_over(self, project: Path, plan: RenderedPlan) -> None:
+        _ingest(project)
+
+        batches = plan([EPISODE_URI], "batch", None, True)
+
+        assert [item for batch in batches for item in batch["items"]] == [EPISODE_URI]
+
+    def test_a_conf_string_reads_as_the_flag_it_spells(
+        self, project: Path, plan: RenderedPlan
+    ) -> None:
+        """Airflow renders params into the call, and a hand-typed conf value
+        arrives as text. Reading "true" as a true value is what keeps the
+        escape hatch usable from the trigger form."""
+        _ingest(project)
+
+        batches = plan([EPISODE_URI], "batch", None, "true")
+
+        assert [item for batch in batches for item in batch["items"]] == [EPISODE_URI]


### PR DESCRIPTION
Closes #172.

A scheduled re-ingest now costs what an in-process one costs. Each stage sub-DAG filters its own `uris` at plan time and skips outright when nothing is left, so an unchanged corpus stops paying for decode passes and contact sheets the catalog already records.

The predicate is `outstanding_stage_uris` in `hflow.stage_planning`, sharing `plan_outstanding_stages` with `run_stages_directly` so the two lanes cannot answer differently. What the new function adds is the translation: conf `uris` are data-root-relative strings, the catalog files rows under `source_uri`, and computing that identity a second way is how a planner queries for rows filed under another name and reads everything as outstanding.

It reaches the DAGs through the slot `MEDIA_PLAN_FILTER_TEMPLATE` already uses, on every stage but sync. Sync records no steps and is its own cache, so `Stage.SYNC` raises rather than returning an answer. On media both filters apply and the catalog query goes first, since it does not open episodes and the camera probe does.

Bucket roots keep the filter. The media probe skips them because reading a channel list downloads the whole episode; a catalog query syncs catalog parquet through the mirror and never opens an episode, so that reason does not carry over.

`all_stages` is new trigger conf on the master and on every sub-DAG, the scheduled counterpart of `--all-stages`. The master passes it down, and a directly triggered sub-DAG takes it in its own conf. A string value is read the way every other flag here reads one, since a hand-typed conf arrives as text.

Two behaviour changes worth stating rather than leaving to be discovered.

`plan` now loads the user pipeline. It already ran in the user venv and these are the same three helpers `process_batch` calls, so no new machinery, but a pipeline that will not import now fails at `plan` instead of at `process_batch`.

A recording with no episode row is handed on, not dropped. This is the one place the scheduled filter differs from `plan_outstanding_stages`, and the difference is deliberate. That function drops such a recording because the direct executor ran sync itself and so knows the row is missing because sync failed. A stage sub-DAG cannot tell that from a corpus nobody synced, and dropping it would turn the loud `FileNotFoundError` a meta-only run raises today into a silent skip. Filtering is here to stop paying for finished work, not to swallow failures.

Budgets are computed after the filter, which was already the case: `_tally_batch_counts` counts what `process_batch` reported, not what the stage was handed. Below 800 episodes `run_failure_budget` is 8 either way. The gate that does change is `errors and errors == total`, which fires outside the budget: filter a run down to two episodes and have both error and it fails loudly, where 200 handed over with 2 errors would not. Everything that ran failed, so that is the right answer, but it is a change.

On evidence. I cannot run Airflow end to end, so the tests split three ways rather than claiming a full path was executed. `tests/test_stage_planning.py` runs the predicate against a real catalog. `tests/test_runtime_bundle.py` pins the wiring: which sub-DAGs carry the filter, which stage each asks about, the ordering against the camera probe, and the conf reaching it. Between them, `TestTheRenderedPlanTask` extracts the rendered `plan` body, strips its Airflow decorator and calls it, which is what catches a bad name or a missed substitution in an injected string; that snippet's contract is that it runs under plain CPython in the user venv, so calling it directly is a fair test of it. What none of them cover is Airflow scheduling the task, mapping the batches, or `skip_on_exit_code` turning exit 99 into a SKIPPED task.

Validation:

```
uv run pytest -q                                  992 passed, 9 skipped
uv run --python 3.11 --locked pytest -q           992 passed, 9 skipped
uv run --python 3.14 --locked pytest -q           992 passed, 9 skipped
uv run ruff check                                 All checks passed
uv run ruff format --check                        169 files already formatted
uv run ty check                                   All checks passed
```

The new tests fail against unpatched `src/` (15 failures), including the three that execute the rendered plan.

No `TRANSFORM_BEHAVIOR_VERSION` bump: nothing here changes the bytes the transform writes, only which episodes a stage is handed.

`docs/RUNTIME.md` said outright that planning applied to the in-process executor only. That paragraph is rewritten.