### PR TITLE
refactor(checks): camera_frame_stats owns its key set (#182)

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -34,6 +34,7 @@ from hflow._video_measurements import (
     FrameStatisticsSettings,
     InsufficientVideoFrames,
     LumaRangeEvidence,
+    VideoFrameStatistics,
     measure_camera_motion,
 )
 from hflow.episode import Episode
@@ -244,6 +245,160 @@ def joint_discontinuity(
     )
 
 
+def camera_frame_stats_keys(episode: Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+    """The one statement of ``camera_frame_stats``' measurement key set.
+
+    The check's body iterates this function's output, so a key is emitted
+    exactly when it is named here -- there is no second list in production
+    code to fall out of sync with (#182). ``cameras=None`` resolves to
+    ``episode.cameras`` here exactly as it does in the body, so the fact and
+    the body can never disagree about what was selected. ``App``'s
+    pre-decode supersession consults this function through
+    ``_DEFAULT_KEY_PATTERNS``, which only ever sees the automatic bare
+    registration (a configured variant is a different function object and
+    takes the post-execution path), so the fact is always called with
+    default parameters.
+
+    Per topic: ``message_count`` always; ``expected_frame_count`` and
+    ``frame_deficit_pct`` only when the topic carries at least two messages;
+    the seven decoded-evidence keys always. ``camera_instrument`` and
+    ``camera_measurement_definition`` are the two non-topic keys; they ride
+    inside the per-topic selection, so an episode with no cameras emits
+    nothing at all.
+    """
+    selected = list(cameras) if cameras is not None else episode.cameras
+    keys: set[str] = set()
+    for topic in selected:
+        keys.add(f"{topic}/message_count")
+        if episode.channel(topic).timestamps.size >= 2:
+            keys.add(f"{topic}/expected_frame_count")
+            keys.add(f"{topic}/frame_deficit_pct")
+        keys.update(
+            f"{topic}/{name}"
+            for name in (
+                "decoded_frame_count",
+                "black_frame_pct",
+                "overexposed_frame_pct",
+                "freeze_total_s",
+                "luma_avg_mean",
+                "luma_avg_min",
+                "luma_avg_max",
+            )
+        )
+    if selected:
+        keys.add("camera_instrument")
+        keys.add("camera_measurement_definition")
+    return keys
+
+
+@dataclass(frozen=True)
+class _CameraIntermediates:
+    """Everything one camera key's value needs from its topic, computed once.
+
+    The instrument call is the expensive step (one ffmpeg decode per topic,
+    cached on disk across runs); one instance per topic keeps the key
+    dispatch at dict-lookup cost instead of re-decoding per key.
+    """
+
+    stamps_ns: np.ndarray
+    stats: VideoFrameStatistics
+    # None below two messages, mirroring the branches that need a rate.
+    expected_frame_count: int | None
+
+
+def _camera_intermediates(
+    episode: Episode,
+    topic: str,
+    *,
+    expected_hz: dict[str, float] | None = None,
+    black_frame_amount_pct: int = 98,
+    black_pixel_threshold: int = 17,
+    freeze_noise_db: float = -60.0,
+    freeze_min_duration_s: float = 2.0,
+    bright_luma_threshold: float = 235.0,
+) -> _CameraIntermediates:
+    stamps_ns = episode.channel(topic).timestamps
+    stats = measure_video_frame_statistics_for_hflow(
+        episode.video(topic),
+        settings=FrameStatisticsSettings(
+            black_frame_minimum_pixel_share_percent=black_frame_amount_pct,
+            black_pixel_luma_threshold=black_pixel_threshold,
+            freeze_noise_tolerance_decibels=freeze_noise_db,
+            freeze_minimum_duration_seconds=freeze_min_duration_s,
+            overexposed_average_luma_threshold=bright_luma_threshold,
+        ),
+    )
+    expected_frame_count = None
+    if stamps_ns.size >= 2:
+        deltas_s = np.diff(stamps_ns) / 1e9
+        declared_hz = (expected_hz or {}).get(topic)
+        expected_period_s = 1.0 / declared_hz if declared_hz else float(np.median(deltas_s))
+        span_s = float((stamps_ns[-1] - stamps_ns[0]) / 1e9)
+        expected_frame_count = round(span_s / expected_period_s) + 1
+    return _CameraIntermediates(stamps_ns, stats, expected_frame_count)
+
+
+def _camera_value(
+    key: str, intermediates_by_topic: dict[str, _CameraIntermediates]
+) -> MeasurementValue:
+    """The value of one measurement key from its topic's intermediates.
+
+    Raises on any key it does not recognise. The fact names the keys, so an
+    unbranched name means the fact and the dispatcher disagree, and letting
+    ``match`` fall through to ``None`` would surface only as a null value in
+    a run that used ``record=True`` (#182). A mismapped *field* returns a
+    plausible number and cannot crash -- the full-measurement fixtures in
+    ``tests/test_default_checks.py`` are what catch those.
+    """
+    # Parse from the right: topics are paths (``/wrist_cam/compressed``), so
+    # the topic prefix itself contains slashes and only the LAST separator
+    # divides topic from measurement name. A bare key has no slash at all.
+    topic, sep, name = key.rpartition("/")
+    if sep:
+        if topic not in intermediates_by_topic:
+            raise ValueError(f"camera_frame_stats has no branch for the key {key!r}")
+        inter = intermediates_by_topic[topic]
+        match name:
+            case "message_count":
+                return inter.stamps_ns.size
+            case "expected_frame_count":
+                # The fact names this key only for topics carrying at least
+                # two stamps, which is exactly when intermediates hold a rate.
+                assert inter.expected_frame_count is not None
+                return inter.expected_frame_count
+            case "frame_deficit_pct":
+                expected_frame_count = inter.expected_frame_count
+                assert expected_frame_count is not None
+                return float(
+                    100.0 * (expected_frame_count - inter.stamps_ns.size) / expected_frame_count
+                )
+            case "decoded_frame_count":
+                return inter.stats.decoded_frame_count
+            case "black_frame_pct":
+                return inter.stats.black_frame_percent
+            case "overexposed_frame_pct":
+                return inter.stats.overexposed_frame_percent
+            case "freeze_total_s":
+                return inter.stats.freeze_total_seconds
+            case "luma_avg_mean":
+                return inter.stats.average_luma_mean
+            case "luma_avg_min":
+                return inter.stats.average_luma_minimum
+            case "luma_avg_max":
+                return inter.stats.average_luma_maximum
+        raise ValueError(f"camera_frame_stats has no branch for the key {key!r}")
+    if name == "camera_instrument":
+        # An explicit check version does not identify the measuring instrument,
+        # and FFmpeg builds can produce different readings. Record the pinned
+        # build so measurements remain interpretable across upgrades. One build
+        # measures every topic in a run, so any computed topic's provenance
+        # answers it.
+        return next(iter(intermediates_by_topic.values())).stats.provenance.ffmpeg_version
+    if name == "camera_measurement_definition":
+        return FRAME_STATISTICS_DEFINITION_VERSION
+    raise ValueError(f"camera_frame_stats has no branch for the key {key!r}")
+
+
 def camera_frame_stats(
     episode: Episode,
     *,
@@ -275,59 +430,45 @@ def camera_frame_stats(
     dark. Signal-quality measurements from the same decode pass -- coding
     range, exposure, impulse noise -- live in
     :func:`camera_signal_quality`.
+
+    The emitted key set is owned by :func:`camera_frame_stats_keys`: this
+    body iterates that function's output and routes each key through
+    ``_camera_value``, so a key the fact does not name cannot be emitted.
+    The trade is one right-to-left key parse (``rpartition``) plus one dict
+    lookup per key on top of the ffmpeg decode each topic already pays (#182).
     """
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
-    measurements: dict[str, MeasurementValue] = {}
+    intermediates_by_topic = {
+        topic: _camera_intermediates(
+            episode,
+            topic,
+            expected_hz=expected_hz,
+            black_frame_amount_pct=black_frame_amount_pct,
+            black_pixel_threshold=black_pixel_threshold,
+            freeze_noise_db=freeze_noise_db,
+            freeze_min_duration_s=freeze_min_duration_s,
+            bright_luma_threshold=bright_luma_threshold,
+        )
+        for topic in selected_cameras
+    }
+    measurements: dict[str, MeasurementValue] = {
+        key: _camera_value(key, intermediates_by_topic)
+        for key in sorted(camera_frame_stats_keys(episode, cameras=selected_cameras))
+    }
     intervals: list[Interval] = []
     for topic in selected_cameras:
-        stamps_ns = episode.channel(topic).timestamps
-        message_count = len(stamps_ns)
-        measurements[f"{topic}/message_count"] = message_count
-        if message_count >= 2:
-            deltas_s = np.diff(stamps_ns) / 1e9
-            declared_hz = (expected_hz or {}).get(topic)
-            expected_period_s = 1.0 / declared_hz if declared_hz else float(np.median(deltas_s))
-            span_s = float((stamps_ns[-1] - stamps_ns[0]) / 1e9)
-            expected_frame_count = round(span_s / expected_period_s) + 1
-            measurements[f"{topic}/expected_frame_count"] = expected_frame_count
-            measurements[f"{topic}/frame_deficit_pct"] = float(
-                100.0 * (expected_frame_count - message_count) / expected_frame_count
-            )
-
-        frame_statistics = measure_video_frame_statistics_for_hflow(
-            episode.video(topic),
-            settings=FrameStatisticsSettings(
-                black_frame_minimum_pixel_share_percent=black_frame_amount_pct,
-                black_pixel_luma_threshold=black_pixel_threshold,
-                freeze_noise_tolerance_decibels=freeze_noise_db,
-                freeze_minimum_duration_seconds=freeze_min_duration_s,
-                overexposed_average_luma_threshold=bright_luma_threshold,
-            ),
-        )
-        measurements[f"{topic}/decoded_frame_count"] = frame_statistics.decoded_frame_count
-        measurements[f"{topic}/black_frame_pct"] = frame_statistics.black_frame_percent
-        measurements[f"{topic}/overexposed_frame_pct"] = frame_statistics.overexposed_frame_percent
-        measurements[f"{topic}/freeze_total_s"] = frame_statistics.freeze_total_seconds
-        measurements[f"{topic}/luma_avg_mean"] = frame_statistics.average_luma_mean
-        measurements[f"{topic}/luma_avg_min"] = frame_statistics.average_luma_minimum
-        measurements[f"{topic}/luma_avg_max"] = frame_statistics.average_luma_maximum
-        # An explicit check version does not identify the measuring instrument,
-        # and FFmpeg builds can produce different readings. Record the pinned
-        # build so measurements remain interpretable across upgrades. Text keeps
-        # it out of the wide view's numeric columns.
-        measurements["camera_instrument"] = frame_statistics.provenance.ffmpeg_version
-        measurements["camera_measurement_definition"] = FRAME_STATISTICS_DEFINITION_VERSION
-        if message_count:
+        inter = intermediates_by_topic[topic]
+        if inter.stamps_ns.size:
             # Instrument times are seconds from the MP4 start, which is the
             # camera's first message; map freezes back onto the log clock.
-            stream_start_ns = int(stamps_ns[0])
+            stream_start_ns = int(inter.stamps_ns[0])
             intervals.extend(
                 Interval(
                     start_ns=stream_start_ns + int(freeze_interval.start_seconds * 1e9),
                     end_ns=stream_start_ns + int(freeze_interval.end_seconds * 1e9),
                     label=f"freeze:{topic}",
                 )
-                for freeze_interval in frame_statistics.freeze_intervals
+                for freeze_interval in inter.stats.freeze_intervals
             )
     return CheckResult(measurements=measurements, intervals=intervals)
 
@@ -1419,39 +1560,6 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
 # happens to overlap a default's keys falls back to the post-execution
 # comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
 # path the same-parameter wrapper case has always taken.
-def _camera_frame_stats_keys(episode: Episode) -> set[str]:
-    """Mirror of ``camera_frame_stats``: one set of per-topic keys per camera.
-
-    ``expected_frame_count`` and ``frame_deficit_pct`` only appear when the
-    topic carries at least two messages (the function uses them to compute a
-    frame deficit). Every camera the episode declares contributes the same
-    eight luma/black/freeze keys plus ``message_count`` and, when applicable,
-    the frame-deficit pair. ``camera_instrument`` and
-    ``camera_measurement_definition`` are the two non-topic keys: the
-    function writes them inside the per-topic loop, so a multi-camera
-    episode overwrites the value but never adds a new key, and an episode
-    with no declared cameras records neither -- the loop body never runs
-    and so does not stamp the definition version or the ffmpeg binary.
-    """
-    keys: set[str] = set()
-    for topic in episode.cameras:
-        keys.add(f"{topic}/message_count")
-        if episode.channel(topic).timestamps.size >= 2:
-            keys.add(f"{topic}/expected_frame_count")
-            keys.add(f"{topic}/frame_deficit_pct")
-        keys.add(f"{topic}/decoded_frame_count")
-        keys.add(f"{topic}/black_frame_pct")
-        keys.add(f"{topic}/overexposed_frame_pct")
-        keys.add(f"{topic}/freeze_total_s")
-        keys.add(f"{topic}/luma_avg_mean")
-        keys.add(f"{topic}/luma_avg_min")
-        keys.add(f"{topic}/luma_avg_max")
-    if episode.cameras:
-        keys.add("camera_instrument")
-        keys.add("camera_measurement_definition")
-    return keys
-
-
 def _timestamp_regularity_keys(episode: Episode) -> set[str]:
     """Mirror of ``timestamp_regularity``: per-topic period/gap keys plus
     cross-stream sync offsets when both a camera and a state stream exist.
@@ -1543,13 +1651,16 @@ def _keyframe_interval_keys(episode: Episode) -> set[str]:
 
 
 # Internal: maps a default function to its key-set predictor. ``App`` reads
-# this once at default-skip time; the function bodies above and the keys in
-# this dict are kept in lockstep by the drift-guard test in
-# ``tests/test_default_checks.py``.
+# this once at default-skip time. For the five still-mirrored defaults the
+# predictor restates its body's writes, and the drift-guard test in
+# ``tests/test_default_checks.py`` keeps the two in lockstep.
+# ``camera_frame_stats`` maps to its own fact function
+# (:func:`camera_frame_stats_keys`), whose output that body itself iterates --
+# prediction and emission are the same statement there (#182).
 _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
     episode_duration: _episode_duration_keys,
     timestamp_regularity: _timestamp_regularity_keys,
-    camera_frame_stats: _camera_frame_stats_keys,
+    camera_frame_stats: camera_frame_stats_keys,
     keyframe_interval: _keyframe_interval_keys,
     content_digest: _content_digest_keys,
     media_digest: _media_digest_keys,

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1,16 +1,29 @@
 """The baseline every episode gets without anyone registering it."""
 
+from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 
 import hflow
-from hflow._video_measurements import _frame_statistics
+from hflow._video_measurements import (
+    FRAME_STATISTICS_DEFINITION_VERSION,
+    FrameStatisticsProvenance,
+    FrameStatisticsSettings,
+    LumaRangeEvidence,
+    VideoFrameStatistics,
+    _frame_statistics,
+)
 from hflow.checks import (
     _DEFAULT_KEY_PATTERNS,
     DEFAULT_CHECKS,
+    _camera_value,
+    _CameraIntermediates,
     camera_frame_stats,
+    camera_frame_stats_keys,
     episode_duration,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
@@ -485,3 +498,384 @@ def test_quarantined_episode_still_carries_default_measurements(
     # available alongside the user's own evidence.
     camera = by_name["camera_frame_stats"]
     assert camera.result is not None
+
+
+def _assert_measurements_match_pinned(measurements: dict[str, object], pinned: dict) -> None:
+    """Full-dict comparison for the #182 value fixtures: keys AND values.
+
+    A plain number pins exact equality (counts and the frame-deficit
+    arithmetic are deterministic); a ``(low, high)`` tuple pins an inclusive
+    range for the ffmpeg-rendered quantities whose exact values track the
+    runner's build (the convention ``test_checks.py`` already uses); a
+    callable is an arbitrary predicate. Tight enough that a dispatcher
+    branch reading the wrong field fails here instead of writing a
+    plausible number into the catalog.
+    """
+    assert set(measurements) == set(pinned), sorted(set(measurements) ^ set(pinned))
+    for key, expected in pinned.items():
+        actual = measurements[key]
+        if callable(expected):
+            assert expected(actual), f"{key}: {actual!r} failed its predicate pin"
+        elif isinstance(expected, tuple):
+            low, high = expected
+            assert low <= actual <= high, f"{key}: {actual!r} outside [{low}, {high}]"
+        else:
+            assert actual == pytest.approx(expected), f"{key}: {actual!r} != {expected!r}"
+
+
+def _pinned_camera_measurements(
+    topic: str,
+    *,
+    frames: int,
+    expected_frame_count: int | None = None,
+    frame_deficit_pct: float | None = None,
+    black_frame_pct: tuple[float, float] | float = (0.0, 50.0),
+    overexposed_frame_pct: tuple[float, float] | float = (0.0, 50.0),
+) -> dict[str, object]:
+    """Hand-written expectation for one camera topic, from the fact's
+    docstring -- ground truth independent of both fact and dispatcher.
+
+    ``frame_deficit_pct`` is a hardcoded float literal for the fixture, not
+    a formula restatement: if the dispatcher's arithmetic is wrong, the
+    formula would agree with the bug and the test would pass on a wrong
+    answer. ``black_frame_pct`` and ``overexposed_frame_pct`` accept either
+    a tight range or an exact float so a black<->overexposed swap cannot
+    pass when the fixture has one and not the other.
+    """
+    pinned: dict[str, object] = {
+        f"{topic}/message_count": frames,
+        f"{topic}/decoded_frame_count": frames,
+        f"{topic}/freeze_total_s": 0.0,
+        f"{topic}/black_frame_pct": black_frame_pct,
+        f"{topic}/overexposed_frame_pct": overexposed_frame_pct,
+        f"{topic}/luma_avg_min": (0.0, 255.0),
+        f"{topic}/luma_avg_mean": (0.0, 255.0),
+        f"{topic}/luma_avg_max": (0.0, 255.0),
+    }
+    if expected_frame_count is not None:
+        pinned[f"{topic}/expected_frame_count"] = expected_frame_count
+        assert frame_deficit_pct is not None
+        pinned[f"{topic}/frame_deficit_pct"] = frame_deficit_pct
+    return pinned
+
+
+# ``black_segment=(0.2, 0.5)`` puts a black run inside the 1-second window
+# (the spec's default of (2.0, 3.0) misses it), so ``black_frame_pct`` is
+# non-zero. testsrc2 (the first camera) renders no blown highlights, so
+# ``overexposed_frame_pct`` is exactly 0.0. A black<->overexposed swap
+# would try to satisfy the wrong pin on each side and fail.
+_ONE_CAMERA_PIN = {
+    "frames": 15,
+    "expected_frame_count": 15,
+    # 15 stamps over 1s at 15Hz, expected 15: literal 0.0, NOT the formula.
+    "frame_deficit_pct": 0.0,
+    "black_frame_pct": (30.0, 40.0),  # measured 33.33 in the inside-segment fixture
+    "overexposed_frame_pct": 0.0,  # testsrc2 never blows highlights
+}
+# The second camera renders an inverted smptebars pattern (no black run), so
+# the discriminator goes the other way: a tight range for overexposed, an
+# exact 0.0 for black. Same shape, opposite polarity -- the swap-test logic
+# reads the polarity, not the camera name.
+_OTHER_CAMERA_PIN = {
+    "frames": 15,
+    "expected_frame_count": 15,
+    "frame_deficit_pct": 0.0,
+    "black_frame_pct": 0.0,  # smptebars never produces blackframes
+    "overexposed_frame_pct": (0.0, 5.0),  # smptebars has luma but not blowouts
+}
+_TWO_STAMP_PIN = {
+    "frames": 2,
+    "expected_frame_count": 2,
+    "frame_deficit_pct": 0.0,
+    # A 2-frame, 2-second fixture has no chance to grow black or overexposed
+    # runs; both stay at 0.0. The strict pin catches a swap that lands 0.0
+    # on the wrong side when the wrist_cam fixture above has 33.33 / 0.0.
+    "black_frame_pct": 0.0,
+    "overexposed_frame_pct": 0.0,
+}
+
+
+CAMERA_VALUE_FIXTURE_CASES = [
+    pytest.param(SyntheticEpisodeSpec(duration_s=1.0, cameras=()), {}, id="zero-cameras"),
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",), black_segment=(0.2, 0.5)),
+        {"wrist_cam": _ONE_CAMERA_PIN},
+        id="one-camera",
+    ),
+    pytest.param(
+        SyntheticEpisodeSpec(
+            duration_s=1.0, cameras=("wrist_cam", "overhead_cam"), black_segment=(0.2, 0.5)
+        ),
+        {
+            "wrist_cam": _ONE_CAMERA_PIN,
+            "overhead_cam": _OTHER_CAMERA_PIN,
+        },
+        id="two-cameras",
+    ),
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=2.0, image_hz=1.0, cameras=("wrist_cam",)),
+        {"wrist_cam": _TWO_STAMP_PIN},
+        id="two-stamp-topic",
+    ),
+]
+
+
+@pytest.mark.parametrize(("spec", "camera_pins"), CAMERA_VALUE_FIXTURE_CASES)
+def test_camera_frame_stats_emits_exactly_the_documented_measurements(
+    spec: SyntheticEpisodeSpec, camera_pins: dict[str, dict[str, int]], tmp_path: Path
+) -> None:
+    """The #182 condition: the fixture asserts the full measurement dict,
+    values included, against ground truth written by hand -- so a mismapped
+    dispatcher branch (luma_avg_min reading average_luma_maximum) fails in
+    CI instead of recording a plausible wrong number."""
+    source = synthesize_episode(tmp_path / "value_source.mcap", spec)
+    report = hflow.App("value-fixture", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "camera_frame_stats")
+    assert run.result is not None
+
+    pinned: dict[str, object] = {}
+    if camera_pins:
+        pinned["camera_instrument"] = lambda value: (
+            isinstance(value, str) and value.startswith("ffmpeg")
+        )
+        pinned["camera_measurement_definition"] = FRAME_STATISTICS_DEFINITION_VERSION
+
+    from hflow.episode import Episode
+
+    canonical_cameras = Episode(report.canonical_path).cameras
+    topic_by_name = {
+        name: next(topic for topic in canonical_cameras if name in topic) for name in camera_pins
+    }
+    for name, fixture in camera_pins.items():
+        pinned.update(_pinned_camera_measurements(topic_by_name[name], **fixture))
+
+    _assert_measurements_match_pinned(dict(run.result.measurements), pinned)
+
+    if not camera_pins:
+        # Zero cameras emits nothing at all, intervals included: every write,
+        # even the bare instrument keys, lives inside the per-topic selection.
+        assert run.result.intervals == []
+
+    for name in camera_pins:
+        topic = topic_by_name[name]
+        minimum = float(run.result.measurements[f"{topic}/luma_avg_min"])
+        mean = float(run.result.measurements[f"{topic}/luma_avg_mean"])
+        maximum = float(run.result.measurements[f"{topic}/luma_avg_max"])
+        if "wrist_cam" in topic:
+            # testsrc2 changes every frame, so the statistics are strictly
+            # ordered and a swapped dispatcher branch cannot satisfy this.
+            assert minimum < mean < maximum
+        else:
+            # smptebars renders one still pattern: per-frame luma differs only
+            # by encoder noise, far tighter than a field mismap could hide.
+            assert maximum - minimum < 0.5
+
+
+def test_a_single_stamp_camera_topic_errors_before_any_measurement(
+    tmp_path: Path,
+) -> None:
+    """Pre-existing upstream contract, pinned so the refactor cannot be
+    blamed for it: ``Episode.video`` needs at least two timestamps to infer
+    a frame rate, so a one-stamp camera errors before any measurement
+    exists. What the refactor owns is the fact's prediction for such a
+    topic -- no rate pair -- which is what the supersession gate consults."""
+    source = synthesize_episode(
+        tmp_path / "sparse_source.mcap",
+        SyntheticEpisodeSpec(duration_s=1.0, image_hz=1.0, cameras=("wrist_cam",)),
+    )
+    report = hflow.App("single-stamp", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "camera_frame_stats")
+    assert run.result is None
+    assert "at least 2" in (run.error or "")
+
+    from hflow.episode import Episode
+
+    topic = Episode(report.canonical_path).cameras[0]
+    assert camera_frame_stats_keys(Episode(report.canonical_path), cameras=[topic]) == {
+        f"{topic}/message_count",
+        f"{topic}/decoded_frame_count",
+        f"{topic}/black_frame_pct",
+        f"{topic}/overexposed_frame_pct",
+        f"{topic}/freeze_total_s",
+        f"{topic}/luma_avg_mean",
+        f"{topic}/luma_avg_min",
+        f"{topic}/luma_avg_max",
+        "camera_instrument",
+        "camera_measurement_definition",
+    }
+
+
+def test_the_body_emits_what_the_fact_names_even_when_the_fact_withdraws_one(
+    camera_source: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Delegation guard for #182: the body must walk the fact's output. If
+    withdrawing one named key does not withdraw it from the emitted
+    measurements, the body is carrying its own key list again and the
+    refactor is void."""
+    real_fact = hflow.checks.camera_frame_stats_keys
+
+    def poisoned(episode: hflow.Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+        selected = list(cameras) if cameras is not None else episode.cameras
+        return real_fact(episode, cameras=cameras) - {f"{selected[0]}/black_frame_pct"}
+
+    monkeypatch.setattr(hflow.checks, "camera_frame_stats_keys", poisoned)
+
+    report = hflow.App("poison", data_root=tmp_path / "data").test(camera_source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "camera_frame_stats")
+    assert run.result is not None
+
+    from hflow.episode import Episode
+
+    topic = Episode(report.canonical_path).cameras[0]
+    assert set(run.result.measurements) == {
+        f"{topic}/message_count",
+        f"{topic}/expected_frame_count",
+        f"{topic}/frame_deficit_pct",
+        f"{topic}/decoded_frame_count",
+        f"{topic}/overexposed_frame_pct",
+        f"{topic}/freeze_total_s",
+        f"{topic}/luma_avg_mean",
+        f"{topic}/luma_avg_min",
+        f"{topic}/luma_avg_max",
+        "camera_instrument",
+        "camera_measurement_definition",
+    }
+
+
+def test_a_key_nobody_branches_on_raises_instead_of_appending_null(
+    camera_source: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dispatcher's explicit failure: match-with-no-branch returning None
+    would surface only as a null measurement under record=True (#182). A key
+    the fact names and the dispatcher forgot must raise where it happens."""
+    real_fact = hflow.checks.camera_frame_stats_keys
+
+    def haunted(episode: hflow.Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+        return real_fact(episode, cameras=cameras) | {"ghost/mystery"}
+
+    monkeypatch.setattr(hflow.checks, "camera_frame_stats_keys", haunted)
+
+    report = hflow.App("unknown-key", data_root=tmp_path / "data").test(
+        camera_source, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "camera_frame_stats")
+    assert run.result is None
+    assert run.error is not None
+    assert "no branch" in run.error
+
+
+def test_a_bare_key_nobody_branches_on_raises_too() -> None:
+    with pytest.raises(ValueError, match="no branch"):
+        _camera_value("not_a_camera_thing", {})
+
+
+def test_declared_expected_hz_wins_and_median_delta_fills_in(tmp_path: Path) -> None:
+    """The precedence the intermediates copy verbatim: the parameter wins per
+    topic; the median inter-message delta is the only fallback; two-way, no
+    metadata step in the chain."""
+    source = synthesize_episode(
+        tmp_path / "hz_source.mcap",
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+    )
+
+    from hflow.episode import Episode
+
+    baseline_report = hflow.App("hz-fallback", data_root=tmp_path / "data-a").test(
+        source, verbose=False
+    )
+
+    # Parameters ride a wrapper -- the documented way to configure a built-in.
+    # Its emitted keys overlap the default's, so the default stands down and
+    # the wrapper's own run carries the declared-hz measurements.
+    declared_app = hflow.App("hz-declared", data_root=tmp_path / "data-b")
+
+    @declared_app.check(version="1")
+    def camera_health(ep: hflow.Episode) -> hflow.CheckResult:
+        return hflow.checks.camera_frame_stats(ep, expected_hz=dict.fromkeys(ep.cameras, 30.0))
+
+    declared_report = declared_app.test(source, verbose=False)
+
+    baseline_run = next(r for r in baseline_report.checks if r.check.name == "camera_frame_stats")
+    declared_run = next(r for r in declared_report.checks if r.check.name == "camera_health")
+    assert baseline_run.result is not None
+    assert declared_run.result is not None
+
+    topic = Episode(baseline_report.canonical_path).cameras[0]
+    # 15 stamps at exactly one fifteenth of a second: the median delta rate
+    # reproduces exactly 15 frames over the observed span, deficit zero.
+    assert baseline_run.result.measurements[f"{topic}/expected_frame_count"] == 15
+    assert baseline_run.result.measurements[f"{topic}/frame_deficit_pct"] == pytest.approx(0.0)
+    # Declaring 30 Hz doubles the expectation over the same span:
+    # round((14/15) * 30) + 1 == 29, and 15 delivered frames miss by that much.
+    assert declared_run.result.measurements[f"{topic}/expected_frame_count"] == 29
+    assert declared_run.result.measurements[f"{topic}/frame_deficit_pct"] == pytest.approx(
+        100.0 * (29 - 15) / 29
+    )
+
+
+def test_dispatcher_message_count_and_decoded_frame_count_read_distinct_sources() -> None:
+    """The two branches are sourced from different fields: the channel
+    stamp array (one entry per MCAP message) and the ffmpeg filter graph's
+    decoded frame count (one per MP4 frame). A branch swap that reads
+    ``inter.stamps_ns.size`` for ``decoded_frame_count`` -- or vice versa
+    -- produces a plausible number and cannot crash; this is the unit-level
+    guard for that failure class, no App, no video, no ffmpeg.
+
+    The integration fixtures (above) hold the two equal at 15 by
+    construction (one access unit per message), which is why this
+    dispatcher-level test is the load-bearing one for the swap case.
+    """
+
+    # ``VideoFrameStatistics`` is a frozen dataclass with 28 required fields.
+    # Build a real instance with zeros for the fields the dispatcher does
+    # NOT read, then ``dataclasses.replace`` the one the test pins. Only
+    # the ``decoded_frame_count`` branch reads ``stats.decoded_frame_count``;
+    # the dispatcher never touches the rest in this test, so zero defaults
+    # do not contaminate the assertion.
+    stub_provenance = FrameStatisticsProvenance(
+        measurement_definition_version="video-frame-statistics/v1",
+        ffmpeg_version="unit-test-stub",
+        filter_graph="stub",
+        settings=FrameStatisticsSettings(),
+    )
+    base_stats = VideoFrameStatistics(
+        decoded_frame_count=0,
+        duration_seconds=0.0,
+        black_frame_count=0,
+        black_frame_percent=0.0,
+        overexposed_frame_count=0,
+        overexposed_frame_percent=0.0,
+        freeze_intervals=(),
+        freeze_total_seconds=0.0,
+        average_luma_mean=0.0,
+        average_luma_minimum=0.0,
+        average_luma_maximum=0.0,
+        black_pixel_share_mean=0.0,
+        black_pixel_share_maximum=0.0,
+        minimum_luma=0.0,
+        maximum_luma=0.0,
+        luma_range_evidence=LumaRangeEvidence.NOMINAL_LIMITED_RANGE_COMPATIBLE,
+        tenth_percentile_luma_mean=0.0,
+        ninetieth_percentile_luma_mean=0.0,
+        clipped_highlight_frame_percent=0.0,
+        crushed_shadow_frame_percent=0.0,
+        frame_difference_mean=0.0,
+        frame_difference_maximum=0.0,
+        temporal_outlier_mean=0.0,
+        temporal_outlier_maximum=0.0,
+        out_of_legal_range_mean=0.0,
+        out_of_legal_range_maximum=0.0,
+        provenance=stub_provenance,
+    )
+    stats = replace(base_stats, decoded_frame_count=15)
+    inter = _CameraIntermediates(
+        stamps_ns=np.arange(13),
+        stats=stats,
+        expected_frame_count=None,
+    )
+    by_topic = {"/cam0": inter}
+
+    assert _camera_value("/cam0/message_count", by_topic) == 13
+    assert _camera_value("/cam0/decoded_frame_count", by_topic) == 15
+    # A swap that returns 15 for message_count -- or 13 for decoded_frame_count
+    # -- would have to break both asserts, not just one.


### PR DESCRIPTION
Part 1 of #182. This removes the hand-maintained `_DEFAULT_KEY_PATTERNS`
mirror for `camera_frame_stats` and replaces it with one function that owns
the key set.

Instead of a mirror that restates the body, `camera_frame_stats_keys` is now
the single place that states which keys the check emits. The body iterates
over the fact's output and routes each key through a small dispatcher,
`_camera_value`. A key the fact does not name cannot be emitted, and a key
with no branch raises where it happens instead of writing a null into a
`record=True` catalog row.

## What changed

- `camera_frame_stats_keys(episode, *, cameras=None)`: the single statement
  of the key set. Per topic it emits `message_count` always,
  `expected_frame_count` and `frame_deficit_pct` only when there are 2 or
  more stamps, and the seven decoded-evidence keys always. `camera_instrument`
  and `camera_measurement_definition` are part of the per-topic selection, so
  a zero-camera episode emits nothing, intervals included.

- `_CameraIntermediates` and `_camera_intermediates`: computes the
  expected-period precedence (declared `expected_hz` per topic, else median
  inter-message delta) once per topic, copied verbatim from the old body.

- `_camera_value`: the dispatcher. It uses `rpartition("/")` rather than
  `partition`, because camera topics are themselves paths like
  `/wrist_cam/compressed`, so only the last separator splits topic from
  measurement name. Unknown keys raise `ValueError`.

- The body now builds intermediates first, then runs one dict comprehension
  over `sorted(camera_frame_stats_keys(...))`. `_DEFAULT_KEY_PATTERNS`
  routes to the fact.

## What stays the same

Every measurement key, value, and the freeze-interval mapping are unchanged
for existing callers. The fact is called with default parameters on automatic
registration, exactly as before.

## Behavior notes

Edge cases the single-key-set shape makes explicit:

- `camera_instrument` provenance is read from the first selected camera topic
  via `next(iter(intermediates_by_topic.values()))`. The value is identical on
  every topic in a run because one pinned ffmpeg build measures the whole
  episode.

- Duplicate entries in a `cameras=` list behave exactly as before this
  refactor. Each listed occurrence is decoded and contributes its freeze
  intervals. The fact's measurement keys dedupe (they are a set), so
  measurement values are written once, but interval emission follows the
  pre-refactor per-occurrence behavior.

- All instrument decodes run before any value is computed. If a decode fails,
  the run raises before partial measurements exist, rather than leaving a
  half-populated result.

## Tests

Value-asserting fixtures over zero, one, and two cameras plus a two-stamp
topic. These assert the full measurement dict, values included, against
hand-written expectations.

The one-camera fixture puts a black run inside the 1-second window (the spec
default of `(2.0, 3.0)` misses it), so `black_frame_pct` is pinned to
`[30, 40]` and `overexposed_frame_pct` to exactly `0.0`. A black/overexposed
branch swap goes red (proved by mutation).

A unit-level guard feeds the dispatcher a stub with `decoded_frame_count=15`
against 13 stamps, so a message/decoded branch swap goes red too (proved by
mutation). The integration fixtures hold the two equal at 15 by construction
(one access unit per canonical message), which is exactly why the unit guard
exists.

Also covered: the poison test (withdrawing a key from the fact must withdraw
it from the body's output), the `expected_hz` precedence test, the existing
one-stamp error contract, and the unknown-key raise end to end.

## Out of scope

The other five defaults (`episode_duration`, `timestamp_regularity`,
`keyframe_interval`, `content_digest`, `media_digest`) still use their mirrors
and follow in their own PRs. Two user wrappers sharing one path-keyed cache is
#177 follow-up territory, unchanged here.