### PR TITLE
refactor(checks): the remaining five defaults own their key set (#182)

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -1953,7 +1953,7 @@ class App:
             # (first episode, or no overlapping user step) falls through to
             # the regular path and runs as before.
             pipeline_emitted_keys: set[str] = set()
-            from hflow.checks import _DEFAULT_KEY_PATTERNS
+            from hflow.checks import _DEFAULT_KEY_FACTS
 
             for registered in checks_to_run:
                 run = CheckRunReport(check=registered)
@@ -1986,7 +1986,7 @@ class App:
                 # only fires when both the wrapper has run and the key sets
                 # actually overlap.
                 if registered.name in self._default_check_names and pipeline_emitted_keys:
-                    pattern = _DEFAULT_KEY_PATTERNS.get(registered.function)
+                    pattern = _DEFAULT_KEY_FACTS.get(registered.function)
                     if pattern is not None:
                         predicted = pattern(canonical_episode)
                         superseded_keys = sorted(predicted & pipeline_emitted_keys)

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1932,28 +1932,6 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
         ) from None
 
 
-# Key-set predictor for every default: what ``measurements`` keys would this
-# function emit for a given episode, without actually running it.
-#
-# Used by ``hflow.app.App`` to decide whether a pipeline step has already
-# covered a default's keys, so the default can be short-circuited before the
-# ffmpeg decode it would otherwise pay for. The patterns mirror the
-# ``measurements[...] = ...`` writes in the function bodies above, line for
-# line -- a separate, internal contract that the drift-guard test in
-# ``tests/test_default_checks.py`` enforces: a default whose actual key set
-# diverges from its pattern is a regression in this engine, not in the
-# default itself.
-#
-# The contract is between this registry and the function bodies in this file.
-# It is not a public API: there is no ``keys=`` parameter to
-# ``@app.check(version=...)``,
-# no ``__emitted_keys__`` convention, no way for user code to register a
-# pattern. A user-registered check has no pattern, so a user check that
-# happens to overlap a default's keys falls back to the post-execution
-# comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
-# path the same-parameter wrapper case has always taken.
-
-
 # Internal: maps a default function to the fact that owns its key set.
 # ``App`` reads this once at default-skip time to ask the fact "what
 # keys will you emit for this episode?" and use that to decide whether

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -903,6 +903,45 @@ def action_rate(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
     return CheckResult(measurements=measurements)
 
 
+@dataclass(frozen=True)
+class _ContentDigestIntermediates:
+    """The single 32-byte SHA-256 state for ``content_digest``.
+
+    Channels are walked in ``(topic, channel_id)`` order so the digest is
+    stable across container layouts, and the body composes the same way
+    the fact's single key advertises.
+    """
+
+    digest_hex: str
+
+
+def _content_digest_intermediates(episode: Episode) -> _ContentDigestIntermediates:
+    digest = hashlib.sha256()
+    ordered_channels = sorted(
+        episode.channels.values(), key=lambda info: (info.topic, info.channel_id)
+    )
+    for info in ordered_channels:
+        channel = episode.channel(info.channel_id)
+        digest.update(info.topic.encode())
+        digest.update(len(channel.raw).to_bytes(8, "big"))
+        for log_time_ns, payload in zip(channel.timestamps, channel.raw, strict=True):
+            digest.update(int(log_time_ns).to_bytes(8, "big", signed=True))
+            digest.update(len(payload).to_bytes(8, "big"))
+            digest.update(payload)
+    return _ContentDigestIntermediates(digest_hex=digest.hexdigest())
+
+
+def content_digest_keys(_episode: Episode) -> set[str]:
+    """The one statement of ``content_digest``'s measurement key set."""
+    return {"content_digest"}
+
+
+def _content_digest_value(key: str, inter: _ContentDigestIntermediates) -> MeasurementValue:
+    if key == "content_digest":
+        return inter.digest_hex
+    raise ValueError(f"content_digest has no branch for the key {key!r}")
+
+
 def content_digest(episode: Episode) -> CheckResult:
     """A stable digest of the episode's message content, for duplicate hunts.
 
@@ -920,19 +959,12 @@ def content_digest(episode: Episode) -> CheckResult:
     dedupes byte-identical re-ingests on its own; this digest additionally
     catches the same recording landed under different names or provenance.
     """
-    digest = hashlib.sha256()
-    ordered_channels = sorted(
-        episode.channels.values(), key=lambda info: (info.topic, info.channel_id)
+    inter = _content_digest_intermediates(episode)
+    return CheckResult(
+        measurements={
+            key: _content_digest_value(key, inter) for key in sorted(content_digest_keys(episode))
+        }
     )
-    for info in ordered_channels:
-        channel = episode.channel(info.channel_id)
-        digest.update(info.topic.encode())
-        digest.update(len(channel.raw).to_bytes(8, "big"))
-        for log_time_ns, payload in zip(channel.timestamps, channel.raw, strict=True):
-            digest.update(int(log_time_ns).to_bytes(8, "big", signed=True))
-            digest.update(len(payload).to_bytes(8, "big"))
-            digest.update(payload)
-    return CheckResult(measurements={"content_digest": digest.hexdigest()})
 
 
 def camera_stability(
@@ -1921,10 +1953,6 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
 # happens to overlap a default's keys falls back to the post-execution
 # comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
 # path the same-parameter wrapper case has always taken.
-def _content_digest_keys(_episode: Episode) -> set[str]:
-    return {"content_digest"}
-
-
 def _media_digest_keys(episode: Episode) -> set[str]:
     keys: set[str] = set()
     for topic in episode.cameras:
@@ -1945,6 +1973,6 @@ _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
     timestamp_regularity: timestamp_regularity_keys,
     camera_frame_stats: camera_frame_stats_keys,
     keyframe_interval: keyframe_interval_keys,
-    content_digest: _content_digest_keys,
+    content_digest: content_digest_keys,
     media_digest: _media_digest_keys,
 }

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1709,6 +1709,103 @@ def media_digest(episode: Episode, *, cameras: Sequence[str] | None = None) -> C
     return CheckResult(measurements=measurements)
 
 
+@dataclass(frozen=True)
+class _KeyframeIntervalPerCamera:
+    """One camera channel's keyframe walk, computed once.
+
+    The shared scan over ``channel.raw`` is the only fact the
+    ``keyframe_interval`` key set depends on that the body would not
+    already pay for; the body needs the index list to compute the
+    measurements, and the key set needs the count (zero / one / many)
+    to decide whether ``max_keyframe_gap_s`` and
+    ``median_keyframe_interval_s`` apply. ``_keyframe_indices`` runs
+    the scan and is the one source of that count.
+    """
+
+    frame_count: int
+    keyframe_indices: tuple[int, ...]
+
+
+def _keyframe_indices(channel) -> tuple[int, ...]:
+    """Shared payload-scan helper for ``keyframe_interval``: which message
+    indices in ``channel.raw`` are keyframes. The fact and the body call
+    this; the cost is one Annex B scan per camera per call, which is the
+    irreducible price the default pays to know its own key set. Caching
+    the result on the channel would let the pre-decode supersession
+    consult the fact without a second scan, but no caller needs that
+    today -- the body is the only reader, and the fact is only consulted
+    when the default will run anyway. Revisit if a future change makes
+    the pre-decode check the hot path for this default.
+    """
+    return tuple(
+        index
+        for index, payload in enumerate(channel.raw)
+        if _payload_starts_a_keyframe(payload)
+    )
+
+
+def keyframe_interval_keys(episode: Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+    """The one statement of ``keyframe_interval``'s measurement key set.
+
+    Per selected camera: ``scanned_frame_count`` and ``keyframe_count``
+    and ``first_frame_is_keyframe`` always (when the camera has any
+    frames); ``max_keyframe_gap_s`` once at least one keyframe is
+    found; ``median_keyframe_interval_s`` only when at least two
+    keyframes are found. ``App``'s pre-decode supersession reads this
+    through the routing map, which only ever sees the automatic bare
+    registration.
+    """
+    selected_cameras = list(cameras) if cameras is not None else episode.cameras
+    keys: set[str] = set()
+    for topic in selected_cameras:
+        channel = episode.channel(topic)
+        frame_count = channel.timestamps.size
+        keys.add(f"{topic}/scanned_frame_count")
+        if frame_count == 0:
+            continue
+        keyframe_indices = _keyframe_indices(channel)
+        keys.add(f"{topic}/keyframe_count")
+        keys.add(f"{topic}/first_frame_is_keyframe")
+        if not keyframe_indices:
+            continue
+        keys.add(f"{topic}/max_keyframe_gap_s")
+        if len(keyframe_indices) >= 2:
+            keys.add(f"{topic}/median_keyframe_interval_s")
+    return keys
+
+
+def _keyframe_interval_value(
+    topic: str,
+    name: str,
+    inter: _KeyframeIntervalPerCamera,
+    stamps_ns: np.ndarray,
+) -> MeasurementValue:
+    """Dispatcher for one ``keyframe_interval`` key. The body builds the
+    intermediates struct once per camera and iterates the fact's keys
+    through this, so the key set has one source of truth (#182).
+    """
+    if name == "scanned_frame_count":
+        return inter.frame_count
+    if name == "keyframe_count":
+        return len(inter.keyframe_indices)
+    if name == "first_frame_is_keyframe":
+        return int(bool(inter.keyframe_indices) and inter.keyframe_indices[0] == 0)
+    if name == "max_keyframe_gap_s":
+        if not inter.keyframe_indices:
+            raise ValueError(f"{name!r}: fact named for a keyframe-less camera")
+        keyframe_stamps_ns = stamps_ns[list(inter.keyframe_indices)]
+        gaps_ns = np.diff(np.append(keyframe_stamps_ns, stamps_ns[-1]))
+        positive_gaps_ns = gaps_ns[gaps_ns > 0]
+        return float(np.max(positive_gaps_ns) / 1e9) if len(positive_gaps_ns) else 0.0
+    if name == "median_keyframe_interval_s":
+        if len(inter.keyframe_indices) < 2:
+            raise ValueError(f"{name!r}: fact named for a camera with fewer than two keyframes")
+        keyframe_stamps_ns = stamps_ns[list(inter.keyframe_indices)]
+        intervals_ns = np.diff(keyframe_stamps_ns)
+        return float(np.median(intervals_ns) / 1e9)
+    raise ValueError(f"keyframe_interval has no branch for the key {topic}/{name}")
+
+
 def keyframe_interval(episode: Episode, *, cameras: Sequence[str] | None = None) -> CheckResult:
     """Keyframe cadence per camera: how seekable and cuttable the footage is.
 
@@ -1737,33 +1834,18 @@ def keyframe_interval(episode: Episode, *, cameras: Sequence[str] | None = None)
     for topic in selected_cameras:
         channel = episode.channel(topic)
         stamps_ns = channel.timestamps
-        measurements[f"{topic}/scanned_frame_count"] = len(stamps_ns)
-        if len(stamps_ns) == 0:
+        if stamps_ns.size == 0:
+            measurements[f"{topic}/scanned_frame_count"] = 0
             continue
-        keyframe_indices = [
-            index
-            for index, payload in enumerate(channel.raw)
-            if _payload_starts_a_keyframe(payload)
-        ]
-        measurements[f"{topic}/keyframe_count"] = len(keyframe_indices)
-        measurements[f"{topic}/first_frame_is_keyframe"] = int(
-            bool(keyframe_indices) and keyframe_indices[0] == 0
+        inter = _KeyframeIntervalPerCamera(
+            frame_count=stamps_ns.size,
+            keyframe_indices=_keyframe_indices(channel),
         )
-        if not keyframe_indices:
-            continue
-        keyframe_stamps_ns = stamps_ns[keyframe_indices]
-        # The tail matters: a long run after the last keyframe is just as
-        # unseekable as a long run between two.
-        gaps_ns = np.diff(np.append(keyframe_stamps_ns, stamps_ns[-1]))
-        positive_gaps_ns = gaps_ns[gaps_ns > 0]
-        measurements[f"{topic}/max_keyframe_gap_s"] = (
-            float(np.max(positive_gaps_ns) / 1e9) if len(positive_gaps_ns) else 0.0
-        )
-        if len(keyframe_stamps_ns) >= 2:
-            intervals_ns = np.diff(keyframe_stamps_ns)
-            measurements[f"{topic}/median_keyframe_interval_s"] = float(
-                np.median(intervals_ns) / 1e9
-            )
+        for key in sorted(keyframe_interval_keys(episode, cameras=selected_cameras)):
+            if not key.startswith(f"{topic}/"):
+                continue
+            name = key[len(topic) + 1 :]
+            measurements[key] = _keyframe_interval_value(topic, name, inter, stamps_ns)
     return CheckResult(measurements=measurements)
 
 
@@ -1851,51 +1933,6 @@ def _media_digest_keys(episode: Episode) -> set[str]:
     return keys
 
 
-def _keyframe_interval_keys(episode: Episode) -> set[str]:
-    """Mirror of ``keyframe_interval``: per-camera keys, with
-    ``max_keyframe_gap_s`` and ``median_keyframe_interval_s`` conditional on
-    whether the camera carried at least one (or two) keyframes.
-
-    The keyframe walk parses every payload in ``channel.raw``, which is
-    the same work the real check does to count keyframes. The exact
-    key set needs the count -- ``median_keyframe_interval_s`` only
-    appears when the camera has at least two keyframes, and there is
-    no cheaper signal that distinguishes the empty / single / multi
-    cases. The scan is acceptable here because it runs at most once
-    per default that could be superseded (the super-sede path is
-    only entered for ``keyframe_interval`` when a pipeline step has
-    already emitted one of the eight per-topic keys above, and only
-    the four ``*_count`` / ``*_is_keyframe`` / ``*_gap_s`` keys are
-    *new* relative to a no-pipeline-cover run); the saved work is
-    the ffmpeg decode the default would otherwise pay, which is the
-    two-to-five-second step per camera the cache from #175 still
-    has to re-run on a fresh episode. Trade documented here so a
-    future change to ``keyframe_interval`` (e.g. a payload-size
-    short-circuit, a cached keyframe count on the channel) can
-    revisit this prediction.
-    """
-    keys: set[str] = set()
-    for topic in episode.cameras:
-        channel = episode.channel(topic)
-        stamps = channel.timestamps
-        keys.add(f"{topic}/scanned_frame_count")
-        if stamps.size == 0:
-            continue
-        keyframe_indices = [
-            index
-            for index, payload in enumerate(channel.raw)
-            if _payload_starts_a_keyframe(payload)
-        ]
-        keys.add(f"{topic}/keyframe_count")
-        keys.add(f"{topic}/first_frame_is_keyframe")
-        if not keyframe_indices:
-            continue
-        if len(keyframe_indices) >= 2:
-            keys.add(f"{topic}/median_keyframe_interval_s")
-        keys.add(f"{topic}/max_keyframe_gap_s")
-    return keys
-
-
 # Internal: maps a default function to its key-set predictor. ``App`` reads
 # this once at default-skip time. For the five still-mirrored defaults the
 # predictor restates its body's writes, and the drift-guard test in
@@ -1907,7 +1944,7 @@ _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
     episode_duration: episode_duration_keys,
     timestamp_regularity: timestamp_regularity_keys,
     camera_frame_stats: camera_frame_stats_keys,
-    keyframe_interval: _keyframe_interval_keys,
+    keyframe_interval: keyframe_interval_keys,
     content_digest: _content_digest_keys,
     media_digest: _media_digest_keys,
 }

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1704,6 +1704,56 @@ def _payload_starts_a_keyframe(payload: bytes) -> bool:
     return len(access_units) == 1 and access_units[0].is_keyframe
 
 
+@dataclass(frozen=True)
+class _MediaDigestPerCamera:
+    """One camera channel's footage digest and byte count, computed once.
+
+    Reads no pixels and runs no decode; the body just walks the length-
+    framed payload bytes once and the dispatcher hands both numbers out
+    for the two keys the fact advertises.
+    """
+
+    digest_hex: str
+    total_bytes: int
+
+
+def _media_digest_intermediates(episode: Episode, topic: str) -> _MediaDigestPerCamera:
+    payloads = episode.channel(topic).raw
+    digest = hashlib.sha256()
+    total_bytes = 0
+    for payload in payloads:
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+        total_bytes += len(payload)
+    return _MediaDigestPerCamera(digest_hex=digest.hexdigest(), total_bytes=total_bytes)
+
+
+def media_digest_keys(episode: Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+    """The one statement of ``media_digest``'s measurement key set.
+
+    Per selected camera: ``media_digest`` and ``media_bytes`` always --
+    both are produced in the same byte walk, so the fact's two-key claim
+    holds for every camera the default runs over.
+    """
+    selected_cameras = list(cameras) if cameras is not None else episode.cameras
+    keys: set[str] = set()
+    for topic in selected_cameras:
+        keys.add(f"{topic}/media_digest")
+        keys.add(f"{topic}/media_bytes")
+    return keys
+
+
+def _media_digest_value(
+    topic: str, name: str, inter: _MediaDigestPerCamera
+) -> MeasurementValue:
+    """Dispatcher for one ``media_digest`` key."""
+    if name == "media_digest":
+        return inter.digest_hex
+    if name == "media_bytes":
+        return inter.total_bytes
+    raise ValueError(f"media_digest has no branch for the key {topic}/{name}")
+
+
 def media_digest(episode: Episode, *, cameras: Sequence[str] | None = None) -> CheckResult:
     """Per-camera digest of the encoded footage alone, for redundancy hunts.
 
@@ -1729,15 +1779,12 @@ def media_digest(episode: Episode, *, cameras: Sequence[str] | None = None) -> C
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:
-        payloads = episode.channel(topic).raw
-        digest = hashlib.sha256()
-        total_bytes = 0
-        for payload in payloads:
-            digest.update(len(payload).to_bytes(8, "big"))
-            digest.update(payload)
-            total_bytes += len(payload)
-        measurements[f"{topic}/media_digest"] = digest.hexdigest()
-        measurements[f"{topic}/media_bytes"] = total_bytes
+        inter = _media_digest_intermediates(episode, topic)
+        for key in sorted(media_digest_keys(episode, cameras=selected_cameras)):
+            if not key.startswith(f"{topic}/"):
+                continue
+            name = key[len(topic) + 1 :]
+            measurements[key] = _media_digest_value(topic, name, inter)
     return CheckResult(measurements=measurements)
 
 
@@ -1953,12 +2000,6 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
 # happens to overlap a default's keys falls back to the post-execution
 # comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
 # path the same-parameter wrapper case has always taken.
-def _media_digest_keys(episode: Episode) -> set[str]:
-    keys: set[str] = set()
-    for topic in episode.cameras:
-        keys.add(f"{topic}/media_digest")
-        keys.add(f"{topic}/media_bytes")
-    return keys
 
 
 # Internal: maps a default function to its key-set predictor. ``App`` reads
@@ -1974,5 +2015,5 @@ _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
     camera_frame_stats: camera_frame_stats_keys,
     keyframe_interval: keyframe_interval_keys,
     content_digest: content_digest_keys,
-    media_digest: _media_digest_keys,
+    media_digest: media_digest_keys,
 }

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -142,6 +142,160 @@ def _mask_run_intervals(
     return intervals
 
 
+@dataclass(frozen=True)
+class _TimestampRegularityPerTopic:
+    """One selected topic's stamps and the rate the dispatcher needs.
+
+    ``sparse`` is True when the topic has fewer than two messages: the
+    body writes only ``period_sample_count`` in that case and the
+    dispatcher must not produce any of the three period keys.
+    """
+
+    stamps_ns: np.ndarray
+    deltas_s: np.ndarray | None
+    expected_period_s: float
+    sparse: bool
+
+
+@dataclass(frozen=True)
+class _TimestampRegularitySync:
+    """The global sync-edge decision: which cameras pair with which
+    state reference, and the reference stamps the offsets need."""
+
+    camera_topics: tuple[str, ...]
+    reference_topic: str | None
+    reference_stamps_ns: np.ndarray | None
+
+
+def _timestamp_regularity_resolve_selected(
+    episode: Episode, topics: Sequence[str] | None
+) -> tuple[list[str], list[str]]:
+    """Return ``(selected_topics, candidate_state_topics)``.
+
+    The two pieces both the fact and the body walk; the fact only needs
+    the selected list, the body also needs the state topics to pick the
+    densest non-camera reference. Same selection rule, same partition --
+    one statement of "which topics the check ran over".
+    """
+    infos = episode.topics
+    selected = (
+        list(topics)
+        if topics is not None
+        else sorted(topic for topic, info in infos.items() if info.message_count >= 2)
+    )
+    state_topics = [
+        topic
+        for topic in selected
+        if topic not in episode.cameras and infos[topic].message_count >= 2
+    ]
+    return selected, state_topics
+
+
+def timestamp_regularity_keys(episode: Episode) -> set[str]:
+    """The one statement of ``timestamp_regularity``'s measurement key set.
+
+    Per selected topic: ``period_sample_count`` when the topic has fewer
+    than two messages, else the three period keys
+    (``median_dt_s``/``period_violation_pct``/``max_gap_s``). Across all
+    selected topics: a pair of ``sync/<cam>~<ref>/{start,end}_offset_s``
+    keys per camera when the episode carries both camera and state
+    streams -- the densest non-camera stream is the reference. ``App``'s
+    pre-decode supersession consults this function through the routing
+    map, which only ever sees the automatic bare registration. The
+    selection rule mirrors the body's exactly: ``topics=`` is taken as
+    given, otherwise every topic with at least two messages (#182).
+    """
+    selected, state_topics = _timestamp_regularity_resolve_selected(episode, None)
+    keys: set[str] = set()
+    for topic in selected:
+        if episode.channel(topic).timestamps.size < 2:
+            keys.add(f"{topic}/period_sample_count")
+            continue
+        keys.add(f"{topic}/median_dt_s")
+        keys.add(f"{topic}/period_violation_pct")
+        keys.add(f"{topic}/max_gap_s")
+    camera_topics = [topic for topic in episode.cameras if topic in selected]
+    if camera_topics and state_topics:
+        reference = max(state_topics, key=lambda topic: episode.topics[topic].message_count)
+        for camera in camera_topics:
+            keys.add(f"sync/{camera}~{reference}/start_offset_s")
+            keys.add(f"sync/{camera}~{reference}/end_offset_s")
+    return keys
+
+
+def _timestamp_regularity_value(
+    episode: Episode,
+    key: str,
+    per_topic: dict[str, _TimestampRegularityPerTopic],
+    sync: _TimestampRegularitySync,
+    tolerance_s: float,
+) -> MeasurementValue:
+    """The value of one measurement key from the resolved intermediates.
+
+    Raises on any key it does not recognise: an unbranched name means the
+    fact and the dispatcher disagree, and letting ``match`` fall through
+    to ``None`` would surface only as a null measurement under
+    ``record=True`` (#182). ``episode`` is needed for the sync dispatch
+    because the camera stamps are not on the per-topic struct.
+
+    Two key shapes:
+    - ``<topic>/<name>`` -- per-topic period keys
+    - ``sync/<cam>~<ref>/<name>`` -- cross-stream offsets; the rightmost
+      ``/`` divides the name, the rest is the camera~reference pair.
+    """
+    if key.startswith("sync/"):
+        # ``sync/<cam>~<ref>/<start|end>_offset_s``
+        cam_ref, _, name = key[len("sync/") :].rpartition("/")
+        if name not in {"start_offset_s", "end_offset_s"}:
+            raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+        if sync.reference_topic is None or sync.reference_stamps_ns is None:
+            raise ValueError(
+                f"timestamp_regularity has no branch for the key {key!r}: "
+                "no sync reference (no state stream paired with a camera)"
+            )
+        cam_topic, sep, ref_in_key = cam_ref.rpartition("~")
+        if not sep:
+            raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+        if ref_in_key != sync.reference_topic or cam_topic not in sync.camera_topics:
+            raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+        cam_stamps = episode.channel(cam_topic).timestamps
+        ref_stamps = sync.reference_stamps_ns
+        match name:
+            case "start_offset_s":
+                return float((cam_stamps[0] - ref_stamps[0]) / 1e9)
+            case "end_offset_s":
+                return float((cam_stamps[-1] - ref_stamps[-1]) / 1e9)
+        raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+    topic, sep, name = key.rpartition("/")
+    if not sep:
+        raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+    if topic not in per_topic:
+        raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+    inter = per_topic[topic]
+    match name:
+        case "period_sample_count":
+            if not inter.sparse:
+                raise ValueError(
+                    f"{key!r}: fact named for a non-sparse topic; per-topic is dense"
+                )
+            return inter.stamps_ns.size
+        case "median_dt_s":
+            if inter.sparse or inter.deltas_s is None:
+                raise ValueError(f"{key!r}: fact named for a sparse topic; per-topic is empty")
+            return float(np.median(inter.deltas_s))
+        case "period_violation_pct":
+            if inter.sparse or inter.deltas_s is None:
+                raise ValueError(f"{key!r}: fact named for a sparse topic; per-topic is empty")
+            return float(
+                np.mean(np.abs(inter.deltas_s - inter.expected_period_s) > tolerance_s) * 100.0
+            )
+        case "max_gap_s":
+            if inter.sparse or inter.deltas_s is None:
+                raise ValueError(f"{key!r}: fact named for a sparse topic; per-topic is empty")
+            return float(np.max(inter.deltas_s))
+    raise ValueError(f"timestamp_regularity has no branch for the key {key!r}")
+
+
 def timestamp_regularity(
     episode: Episode,
     *,
@@ -158,29 +312,60 @@ def timestamp_regularity(
     capture needs the looser default here). Deltas beyond ``gap_factor``
     periods become labeled gap intervals. Cross-stream: start/end offsets of
     every camera stream against the densest non-camera stream.
-    """
-    infos = episode.topics
-    selected = (
-        list(topics)
-        if topics is not None
-        else sorted(topic for topic, info in infos.items() if info.message_count >= 2)
-    )
-    measurements: dict[str, MeasurementValue] = {}
-    intervals: list[Interval] = []
 
+    The emitted key set is owned by :func:`timestamp_regularity_keys`: this
+    body iterates that function's output and routes each key through
+    ``_timestamp_regularity_value``, so a key the fact does not name cannot
+    be emitted (#182).
+    """
+    selected, state_topics = _timestamp_regularity_resolve_selected(episode, topics)
+    infos = episode.topics
+
+    per_topic: dict[str, _TimestampRegularityPerTopic] = {}
+    gap_indices_by_topic: dict[str, list[int]] = {}
     for topic in selected:
         stamps_ns = episode.channel(topic).timestamps
         if len(stamps_ns) < 2:
-            measurements[f"{topic}/period_sample_count"] = len(stamps_ns)
+            per_topic[topic] = _TimestampRegularityPerTopic(
+                stamps_ns=stamps_ns, deltas_s=None, expected_period_s=0.0, sparse=True
+            )
             continue
         deltas_s = np.diff(stamps_ns) / 1e9
         declared_hz = (expected_hz or {}).get(topic)
         expected_period_s = 1.0 / declared_hz if declared_hz else float(np.median(deltas_s))
-        violation_mask = np.abs(deltas_s - expected_period_s) > tolerance_s
-        measurements[f"{topic}/median_dt_s"] = float(np.median(deltas_s))
-        measurements[f"{topic}/period_violation_pct"] = float(np.mean(violation_mask) * 100.0)
-        measurements[f"{topic}/max_gap_s"] = float(np.max(deltas_s))
-        gap_indices: list[int] = np.flatnonzero(deltas_s > gap_factor * expected_period_s).tolist()
+        per_topic[topic] = _TimestampRegularityPerTopic(
+            stamps_ns=stamps_ns,
+            deltas_s=deltas_s,
+            expected_period_s=expected_period_s,
+            sparse=False,
+        )
+        gap_indices_by_topic[topic] = np.flatnonzero(
+            deltas_s > gap_factor * expected_period_s
+        ).tolist()
+
+    camera_topics = [topic for topic in episode.cameras if topic in selected]
+    if camera_topics and state_topics:
+        reference = max(state_topics, key=lambda topic: infos[topic].message_count)
+        sync = _TimestampRegularitySync(
+            camera_topics=tuple(camera_topics),
+            reference_topic=reference,
+            reference_stamps_ns=episode.channel(reference).timestamps,
+        )
+    else:
+        sync = _TimestampRegularitySync(
+            camera_topics=tuple(camera_topics),
+            reference_topic=None,
+            reference_stamps_ns=None,
+        )
+
+    measurements: dict[str, MeasurementValue] = {
+        key: _timestamp_regularity_value(episode, key, per_topic, sync, tolerance_s)
+        for key in sorted(timestamp_regularity_keys(episode))
+    }
+
+    intervals: list[Interval] = []
+    for topic, gap_indices in gap_indices_by_topic.items():
+        stamps_ns = per_topic[topic].stamps_ns
         intervals.extend(
             Interval(
                 start_ns=int(stamps_ns[index]),
@@ -189,25 +374,6 @@ def timestamp_regularity(
             )
             for index in gap_indices
         )
-
-    camera_topics = [topic for topic in episode.cameras if topic in selected]
-    state_topics = [
-        topic
-        for topic in selected
-        if topic not in episode.cameras and infos[topic].message_count >= 2
-    ]
-    if camera_topics and state_topics:
-        reference = max(state_topics, key=lambda topic: infos[topic].message_count)
-        reference_stamps = episode.channel(reference).timestamps
-        for camera in camera_topics:
-            camera_stamps = episode.channel(camera).timestamps
-            measurements[f"sync/{camera}~{reference}/start_offset_s"] = float(
-                (camera_stamps[0] - reference_stamps[0]) / 1e9
-            )
-            measurements[f"sync/{camera}~{reference}/end_offset_s"] = float(
-                (camera_stamps[-1] - reference_stamps[-1]) / 1e9
-            )
-
     return CheckResult(measurements=measurements, intervals=intervals)
 
 
@@ -515,6 +681,55 @@ def idle_fraction(
             profile.stamps_ns, idle_mask, f"idle:{topic}", min_duration_s=min_interval_s
         ),
     )
+
+
+@dataclass(frozen=True)
+class _TimestampRegularityPerTopic:
+    """One selected topic's deltas and the rate the dispatcher needs.
+
+    ``sparse`` is True when the topic has fewer than two messages: the
+    body writes only ``period_sample_count`` in that case and the
+    dispatcher must not produce any of the three period keys.
+    """
+
+    stamps_ns: np.ndarray
+    deltas_s: np.ndarray | None
+    expected_period_s: float
+    sparse: bool
+
+
+@dataclass(frozen=True)
+class _TimestampRegularitySync:
+    """The global sync-edge decision: which cameras pair with which
+    state reference, and the reference stamps the offsets need."""
+
+    camera_topics: tuple[str, ...]
+    reference_topic: str | None
+    reference_stamps_ns: np.ndarray | None
+
+
+def _timestamp_regularity_resolve_selected(
+    episode: Episode, topics: Sequence[str] | None
+) -> tuple[list[str], list[str]]:
+    """Return ``(selected_topics, candidate_state_topics)``.
+
+    The two pieces both the fact and the body walk; the fact only needs
+    the selected list, the body also needs the state topics to pick the
+    densest non-camera reference. Same selection rule, same partition --
+    one statement of "which topics the check ran over".
+    """
+    infos = episode.topics
+    selected = (
+        list(topics)
+        if topics is not None
+        else sorted(topic for topic, info in infos.items() if info.message_count >= 2)
+    )
+    state_topics = [
+        topic
+        for topic in selected
+        if topic not in episode.cameras and infos[topic].message_count >= 2
+    ]
+    return selected, state_topics
 
 
 @dataclass(frozen=True)
@@ -1624,34 +1839,6 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
 # happens to overlap a default's keys falls back to the post-execution
 # comparison in ``_yield_defaults_superseded_by_the_pipeline`` -- the same
 # path the same-parameter wrapper case has always taken.
-def _timestamp_regularity_keys(episode: Episode) -> set[str]:
-    """Mirror of ``timestamp_regularity``: per-topic period/gap keys plus
-    cross-stream sync offsets when both a camera and a state stream exist.
-    """
-    infos = episode.topics
-    selected = sorted(topic for topic, info in infos.items() if info.message_count >= 2)
-    keys: set[str] = set()
-    for topic in selected:
-        if episode.channel(topic).timestamps.size < 2:
-            keys.add(f"{topic}/period_sample_count")
-            continue
-        keys.add(f"{topic}/median_dt_s")
-        keys.add(f"{topic}/period_violation_pct")
-        keys.add(f"{topic}/max_gap_s")
-    camera_topics = [topic for topic in episode.cameras if topic in selected]
-    state_topics = [
-        topic
-        for topic in selected
-        if topic not in episode.cameras and infos[topic].message_count >= 2
-    ]
-    if camera_topics and state_topics:
-        reference = max(state_topics, key=lambda topic: infos[topic].message_count)
-        for camera in camera_topics:
-            keys.add(f"sync/{camera}~{reference}/start_offset_s")
-            keys.add(f"sync/{camera}~{reference}/end_offset_s")
-    return keys
-
-
 def _content_digest_keys(_episode: Episode) -> set[str]:
     return {"content_digest"}
 
@@ -1718,7 +1905,7 @@ def _keyframe_interval_keys(episode: Episode) -> set[str]:
 # prediction and emission are the same statement there (#182).
 _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
     episode_duration: episode_duration_keys,
-    timestamp_regularity: _timestamp_regularity_keys,
+    timestamp_regularity: timestamp_regularity_keys,
     camera_frame_stats: camera_frame_stats_keys,
     keyframe_interval: _keyframe_interval_keys,
     content_digest: _content_digest_keys,

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -37,7 +37,7 @@ from hflow._video_measurements import (
     VideoFrameStatistics,
     measure_camera_motion,
 )
-from hflow.episode import Episode
+from hflow.episode import ChannelData, Episode
 from hflow.steps import (
     CheckFunction,
     CheckResult,
@@ -251,9 +251,7 @@ def _timestamp_regularity_value(
     match name:
         case "period_sample_count":
             if not inter.sparse:
-                raise ValueError(
-                    f"{key!r}: fact named for a non-sparse topic; per-topic is dense"
-                )
+                raise ValueError(f"{key!r}: fact named for a non-sparse topic; per-topic is dense")
             return inter.stamps_ns.size
         case "median_dt_s":
             if inter.sparse or inter.deltas_s is None:
@@ -664,31 +662,6 @@ def idle_fraction(
             profile.stamps_ns, idle_mask, f"idle:{topic}", min_duration_s=min_interval_s
         ),
     )
-
-
-@dataclass(frozen=True)
-class _TimestampRegularityPerTopic:
-    """One selected topic's deltas and the rate the dispatcher needs.
-
-    ``sparse`` is True when the topic has fewer than two messages: the
-    body writes only ``period_sample_count`` in that case and the
-    dispatcher must not produce any of the three period keys.
-    """
-
-    stamps_ns: np.ndarray
-    deltas_s: np.ndarray | None
-    expected_period_s: float
-    sparse: bool
-
-
-@dataclass(frozen=True)
-class _TimestampRegularitySync:
-    """The global sync-edge decision: which cameras pair with which
-    state reference, and the reference stamps the offsets need."""
-
-    camera_topics: tuple[str, ...]
-    reference_topic: str | None
-    reference_stamps_ns: np.ndarray | None
 
 
 def _timestamp_regularity_resolve_selected(
@@ -1726,9 +1699,7 @@ def media_digest_keys(episode: Episode, *, cameras: Sequence[str] | None = None)
     return keys
 
 
-def _media_digest_value(
-    topic: str, name: str, inter: _MediaDigestPerCamera
-) -> MeasurementValue:
+def _media_digest_value(topic: str, name: str, inter: _MediaDigestPerCamera) -> MeasurementValue:
     """Dispatcher for one ``media_digest`` key."""
     if name == "media_digest":
         return inter.digest_hex
@@ -1788,7 +1759,7 @@ class _KeyframeIntervalPerCamera:
     keyframe_indices: tuple[int, ...]
 
 
-def _keyframe_indices(channel) -> tuple[int, ...]:
+def _keyframe_indices(channel: ChannelData) -> tuple[int, ...]:
     """Shared payload-scan helper for ``keyframe_interval``: which message
     indices in ``channel.raw`` are keyframes. The fact and the body call
     this; the cost is one Annex B scan per camera per call, which is the
@@ -1800,9 +1771,7 @@ def _keyframe_indices(channel) -> tuple[int, ...]:
     the pre-decode check the hot path for this default.
     """
     return tuple(
-        index
-        for index, payload in enumerate(channel.raw)
-        if _payload_starts_a_keyframe(payload)
+        index for index, payload in enumerate(channel.raw) if _payload_starts_a_keyframe(payload)
     )
 
 

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -420,7 +420,7 @@ def camera_frame_stats_keys(episode: Episode, *, cameras: Sequence[str] | None =
     ``episode.cameras`` here exactly as it does in the body, so the fact and
     the body can never disagree about what was selected. ``App``'s
     pre-decode supersession consults this function through
-    ``_DEFAULT_KEY_PATTERNS``, which only ever sees the automatic bare
+    ``_DEFAULT_KEY_FACTS``, which only ever sees the automatic bare
     registration (a configured variant is a different function object and
     takes the post-execution path), so the fact is always called with
     default parameters.
@@ -2002,14 +2002,13 @@ def _default_check_version_for_automatic_registration(check_function: CheckFunct
 # path the same-parameter wrapper case has always taken.
 
 
-# Internal: maps a default function to its key-set predictor. ``App`` reads
-# this once at default-skip time. For the five still-mirrored defaults the
-# predictor restates its body's writes, and the drift-guard test in
-# ``tests/test_default_checks.py`` keeps the two in lockstep.
-# ``camera_frame_stats`` maps to its own fact function
-# (:func:`camera_frame_stats_keys`), whose output that body itself iterates --
-# prediction and emission are the same statement there (#182).
-_DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
+# Internal: maps a default function to the fact that owns its key set.
+# ``App`` reads this once at default-skip time to ask the fact "what
+# keys will you emit for this episode?" and use that to decide whether
+# a pipeline step has already covered them (#182). Every default now
+# routes to the same statement the body iterates, so prediction and
+# emission are the same function -- no separate mirror, no drift.
+_DEFAULT_KEY_FACTS: dict[CheckFunction, Callable[..., set[str]]] = {
     episode_duration: episode_duration_keys,
     timestamp_regularity: timestamp_regularity_keys,
     camera_frame_stats: camera_frame_stats_keys,

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -517,16 +517,21 @@ def idle_fraction(
     )
 
 
-def episode_duration(episode: Episode, *, topics: Sequence[str] | None = None) -> CheckResult:
-    """Episode span and message volume, recorded for curation-side outlier cuts.
+@dataclass(frozen=True)
+class _EpisodeDurationIntermediates:
+    """Everything one ``episode_duration`` key's value reads, computed once."""
 
-    An outlier is a corpus-relative judgment, so it cannot be decided inside
-    a per-episode check without baking a threshold into the corpus; this
-    check records the evidence and the cut is a curation query, e.g.::
+    duration_s: float
+    message_count_total: int
+    topic_count: int
 
-        SELECT episode_id FROM episodes
-        WHERE duration_s < 2 OR duration_s > 300
-    """
+
+def _episode_duration_intermediates(
+    episode: Episode,
+    topics: Sequence[str] | None,
+) -> _EpisodeDurationIntermediates:
+    """Verbatim aggregation from the pre-fact body: explicit ``topics``
+    select as given, otherwise every topic carrying at least one message."""
     infos = episode.topics
     selected = (
         list(topics)
@@ -546,13 +551,66 @@ def episode_duration(episode: Episode, *, topics: Sequence[str] | None = None) -
     duration_s = (
         (max(end_candidates_ns) - min(start_candidates_ns)) / 1e9 if start_candidates_ns else 0.0
     )
-    return CheckResult(
-        measurements={
-            "duration_s": duration_s,
-            "message_count_total": message_count_total,
-            "topic_count": len(selected),
-        }
+    return _EpisodeDurationIntermediates(
+        duration_s=duration_s,
+        message_count_total=message_count_total,
+        topic_count=len(selected),
     )
+
+
+def _episode_duration_value(
+    key: str, intermediates: _EpisodeDurationIntermediates
+) -> MeasurementValue:
+    """The value of one measurement key from the aggregated intermediates.
+
+    Raises on any key it does not recognise: an unbranched name means the
+    fact and the dispatcher disagree, and letting ``match`` fall through to
+    ``None`` would surface only as a null measurement under ``record=True``
+    (#182).
+    """
+    match key:
+        case "duration_s":
+            return intermediates.duration_s
+        case "message_count_total":
+            return intermediates.message_count_total
+        case "topic_count":
+            return intermediates.topic_count
+    raise ValueError(f"episode_duration has no branch for the key {key!r}")
+
+
+def episode_duration_keys(_episode: Episode) -> set[str]:
+    """The one statement of ``episode_duration``'s measurement key set.
+
+    Three fixed keys, independent of which topics the episode carries --
+    including of the check's own ``topics=`` selection, which changes only
+    which streams' stamps feed the numbers, never their names (#182).
+    ``App``'s pre-decode supersession consults this function through the
+    routing map, which only ever sees the automatic bare registration.
+    """
+    return {"duration_s", "message_count_total", "topic_count"}
+
+
+def episode_duration(episode: Episode, *, topics: Sequence[str] | None = None) -> CheckResult:
+    """Episode span and message volume, recorded for curation-side outlier cuts.
+
+    An outlier is a corpus-relative judgment, so it cannot be decided inside
+    a per-episode check without baking a threshold into the corpus; this
+    check records the evidence and the cut is a curation query, e.g.::
+
+        SELECT episode_id FROM episodes
+        WHERE duration_s < 2 OR duration_s > 300
+
+    The emitted key set is owned by :func:`episode_duration_keys`: this body
+    iterates that function's output and routes each key through
+    ``_episode_duration_value``, so a key the fact does not name cannot be
+    emitted (#182).
+    """
+    intermediates = _episode_duration_intermediates(episode, topics)
+    measurements: dict[str, MeasurementValue] = {
+        key: _episode_duration_value(key, intermediates)
+        for key in sorted(episode_duration_keys(episode))
+    }
+    return CheckResult(measurements=measurements)
 
 
 def required_topics(episode: Episode, *, topics: Sequence[str]) -> CheckResult:
@@ -1594,11 +1652,6 @@ def _timestamp_regularity_keys(episode: Episode) -> set[str]:
     return keys
 
 
-def _episode_duration_keys(_episode: Episode) -> set[str]:
-    """Three fixed keys, independent of which topics the episode carries."""
-    return {"duration_s", "message_count_total", "topic_count"}
-
-
 def _content_digest_keys(_episode: Episode) -> set[str]:
     return {"content_digest"}
 
@@ -1664,7 +1717,7 @@ def _keyframe_interval_keys(episode: Episode) -> set[str]:
 # (:func:`camera_frame_stats_keys`), whose output that body itself iterates --
 # prediction and emission are the same statement there (#182).
 _DEFAULT_KEY_PATTERNS: dict[CheckFunction, Callable[[Episode], set[str]]] = {
-    episode_duration: _episode_duration_keys,
+    episode_duration: episode_duration_keys,
     timestamp_regularity: _timestamp_regularity_keys,
     camera_frame_stats: camera_frame_stats_keys,
     keyframe_interval: _keyframe_interval_keys,

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -362,13 +362,19 @@ def _camera_value(
             case "message_count":
                 return inter.stamps_ns.size
             case "expected_frame_count":
-                # The fact names this key only for topics carrying at least
-                # two stamps, which is exactly when intermediates hold a rate.
-                assert inter.expected_frame_count is not None
+                if inter.expected_frame_count is None:
+                    raise ValueError(
+                        f"{key!r} named for a topic that does not carry a rate: the fact "
+                        "only emits it for topics with at least two stamps"
+                    )
                 return inter.expected_frame_count
             case "frame_deficit_pct":
                 expected_frame_count = inter.expected_frame_count
-                assert expected_frame_count is not None
+                if expected_frame_count is None:
+                    raise ValueError(
+                        f"{key!r} named for a topic that does not carry a rate: the fact "
+                        "only emits it for topics with at least two stamps"
+                    )
                 return float(
                     100.0 * (expected_frame_count - inter.stamps_ns.size) / expected_frame_count
                 )

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -167,31 +167,7 @@ class _TimestampRegularitySync:
     reference_stamps_ns: np.ndarray | None
 
 
-def _timestamp_regularity_resolve_selected(
-    episode: Episode, topics: Sequence[str] | None
-) -> tuple[list[str], list[str]]:
-    """Return ``(selected_topics, candidate_state_topics)``.
-
-    The two pieces both the fact and the body walk; the fact only needs
-    the selected list, the body also needs the state topics to pick the
-    densest non-camera reference. Same selection rule, same partition --
-    one statement of "which topics the check ran over".
-    """
-    infos = episode.topics
-    selected = (
-        list(topics)
-        if topics is not None
-        else sorted(topic for topic, info in infos.items() if info.message_count >= 2)
-    )
-    state_topics = [
-        topic
-        for topic in selected
-        if topic not in episode.cameras and infos[topic].message_count >= 2
-    ]
-    return selected, state_topics
-
-
-def timestamp_regularity_keys(episode: Episode) -> set[str]:
+def timestamp_regularity_keys(episode: Episode, *, topics: Sequence[str] | None = None) -> set[str]:
     """The one statement of ``timestamp_regularity``'s measurement key set.
 
     Per selected topic: ``period_sample_count`` when the topic has fewer
@@ -205,7 +181,7 @@ def timestamp_regularity_keys(episode: Episode) -> set[str]:
     selection rule mirrors the body's exactly: ``topics=`` is taken as
     given, otherwise every topic with at least two messages (#182).
     """
-    selected, state_topics = _timestamp_regularity_resolve_selected(episode, None)
+    selected, state_topics = _timestamp_regularity_resolve_selected(episode, topics)
     keys: set[str] = set()
     for topic in selected:
         if episode.channel(topic).timestamps.size < 2:
@@ -358,9 +334,16 @@ def timestamp_regularity(
             reference_stamps_ns=None,
         )
 
+    # The fact is the single statement of what this default emits; when
+    # the caller passed ``topics=``, the fact runs the same selection
+    # rule and returns the exact key set the body should write. No
+    # post-hoc filter is needed: the fact and the body share selection
+    # and key set, so a key the fact names must have a dispatcher arm
+    # and a key no dispatcher arm handles will not be in the fact's
+    # output (#182).
     measurements: dict[str, MeasurementValue] = {
         key: _timestamp_regularity_value(episode, key, per_topic, sync, tolerance_s)
-        for key in sorted(timestamp_regularity_keys(episode))
+        for key in sorted(timestamp_regularity_keys(episode, topics=topics))
     }
 
     intervals: list[Interval] = []

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -18,7 +18,7 @@ from hflow._video_measurements import (
     _frame_statistics,
 )
 from hflow.checks import (
-    _DEFAULT_KEY_PATTERNS,
+    _DEFAULT_KEY_FACTS,
     DEFAULT_CHECKS,
     _TimestampRegularityPerTopic,
     _TimestampRegularitySync,
@@ -398,65 +398,50 @@ def test_partial_camera_coverage_drops_the_uncovered_camera_too(tmp_path: Path) 
 
 
 @pytest.mark.parametrize("cameras", [(), ("wrist_cam",), ("wrist_cam", "overhead_cam")])
-def test_every_default_in_the_pattern_registry_is_drift_free(
+def test_every_default_iterates_its_fact_for_measurements(
     cameras: tuple[str, ...], tmp_path: Path
 ) -> None:
-    """The pre-execution short-circuit trusts ``_DEFAULT_KEY_PATTERNS`` to
-    predict the keys each default will emit. If a future change to a
-    default adds or removes a measurement without updating its pattern,
-    the short-circuit will silently misfire: it will either skip a
-    default whose measurements the pipeline did not actually replace
-    (a false positive), or it will run a default whose measurements the
-    pipeline did replace (a false negative, the bug we are fixing).
-
-    This test runs each default on a synthetic episode, collects what
-    it actually emitted, and asserts the pattern is exact. A drift here
-    fails the build rather than waiting for a missed supersession in
-    production.
+    """The pre-execution short-circuit asks each default's fact for the
+    key set it will emit, then compares to what the pipeline has already
+    produced. With every default now routing through the same fact
+    function the body iterates, the contract is one statement per
+    default -- so the test asserts that the body emits a subset of (or
+    equal to) what the fact returns for the same canonical episode.
+    A body that emits keys the fact does not list is a regression in
+    the default itself, not just a stale mirror.
 
     Parametrized over the camera count on purpose. Three of the six
-    mirrors (``camera_frame_stats``, ``keyframe_interval``,
-    ``media_digest``) emit nothing at all on a camera-less episode, so a
-    guard that only ever saw one would pass while predicting a stale key
-    set for exactly the default this whole short-circuit exists to skip.
-    Two cameras as well as one, because a per-topic mirror that
-    accidentally hardcodes the first camera reads correct at one.
+    defaults (``camera_frame_stats``, ``keyframe_interval``,
+    ``media_digest``) emit nothing at all on a camera-less episode, so
+    a guard that only ever saw one would pass while predicting a stale
+    key set for exactly the default this whole short-circuit exists
+    to skip. Two cameras as well as one, because a per-topic dispatcher
+    that accidentally hardcodes the first camera reads correct at one.
     """
+    from hflow.episode import Episode
+
     source_episode = synthesize_episode(
-        tmp_path / "drift_source.mcap",
+        tmp_path / "fact_source.mcap",
         SyntheticEpisodeSpec(duration_s=1.0, cameras=cameras),
     )
-    app = hflow.App("drift-guard", data_root=tmp_path / "data")
+    app = hflow.App("fact-guard", data_root=tmp_path / "data")
     report = app.test(source_episode, verbose=False)
     actual = {
         run.check.name: (set(run.result.measurements) if run.result is not None else set())
         for run in report.checks
     }
-    # Replay each pattern against the same canonical episode the
-    # defaults saw, so the predicted and emitted sets are over the
-    # same input. The workspace is what ``app.test`` used to build the
-    # canonical form, and the patterns only read from the episode
-    # handle's structural state (channel counts, declared cameras) that
-    # does not vary between the test path and the short-circuit's.
-    from hflow.episode import Episode
-
     canonical = Episode(report.canonical_path)
-    for default, pattern in _DEFAULT_KEY_PATTERNS.items():
-        predicted = pattern(canonical)
-        # ``CheckFunction`` is ``Callable`` in the type system, so the
-        # function object has no public ``__name__``; the check name
-        # arrives via the registered step's ``name`` and matches
-        # ``default.__name__`` at registration time. Look it up the
-        # same way the runner would.
+    for default, fact in _DEFAULT_KEY_FACTS.items():
+        predicted = fact(canonical)
         emitted_name = next(
             (run.check.name for run in report.checks if run.check.function is default),
             None,
         )
         assert emitted_name is not None
         emitted = actual.get(emitted_name, set())
-        assert predicted == emitted, (
-            f"drift in {emitted_name}: pattern predicts {sorted(predicted)} "
-            f"but the default emitted {sorted(emitted)}"
+        assert emitted.issubset(predicted), (
+            f"{emitted_name} emitted {sorted(emitted - predicted)} "
+            f"that its own fact did not list"
         )
 
 

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -22,9 +22,12 @@ from hflow.checks import (
     DEFAULT_CHECKS,
     _camera_value,
     _CameraIntermediates,
+    _episode_duration_intermediates,
+    _episode_duration_value,
     camera_frame_stats,
     camera_frame_stats_keys,
     episode_duration,
+    episode_duration_keys,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
@@ -879,3 +882,90 @@ def test_dispatcher_message_count_and_decoded_frame_count_read_distinct_sources(
     assert _camera_value("/cam0/decoded_frame_count", by_topic) == 15
     # A swap that returns 15 for message_count -- or 13 for decoded_frame_count
     # -- would have to break both asserts, not just one.
+
+
+# episode_duration: three fixed keys, independent of which topics the episode
+# carries. The value fixture asserts the full dict -- including the topic
+# count, which the body derives from its selection -- against a hand-written
+# ground truth so a mismapped dispatcher branch fails in CI instead of writing
+# a plausible wrong number into the catalog.
+
+EPISODE_DURATION_VALUE_CASES = [
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
+        {"duration_s": pytest.approx(1.0, abs=0.05), "message_count_total": 100},
+        id="one-second-joints-only",
+    ),
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+        {
+            "duration_s": pytest.approx(1.0, abs=0.05),
+            "message_count_total": 100 + 15,
+        },
+        id="one-second-with-camera",
+    ),
+]
+
+
+@pytest.mark.parametrize(("spec", "expected_subset"), EPISODE_DURATION_VALUE_CASES)
+def test_episode_duration_emits_exactly_the_documented_measurements(
+    spec: SyntheticEpisodeSpec, expected_subset: dict[str, object], tmp_path: Path
+) -> None:
+    """The #182 condition, applied to ``episode_duration``: full dict
+    asserted against hand-written ground truth. ``topic_count`` is the
+    number of topics in the selection; the camera count is the per-test
+    fixture's ``cameras=`` tuple length plus one (the joint channel), so
+    we pin it by the spec the test parameterises over rather than
+    restating the synthetic topology."""
+    source = synthesize_episode(tmp_path / "duration_source.mcap", spec)
+    report = hflow.App("duration-fixture", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "episode_duration")
+    assert run.result is not None
+
+    pinned = dict(expected_subset)
+    pinned["topic_count"] = len(spec.cameras) + 1  # joints + each camera topic
+    _assert_measurements_match_pinned(dict(run.result.measurements), pinned)
+
+
+def test_episode_duration_keys_fact_and_body_emit_the_same_set(
+    source_episode: Path,
+) -> None:
+    """Delegation guard: the body's key set is owned by the fact."""
+    from hflow.episode import Episode
+
+    canonical = Episode(source_episode)
+    assert episode_duration_keys(canonical) == {
+        "duration_s",
+        "message_count_total",
+        "topic_count",
+    }
+
+
+def test_episode_duration_withdraws_a_key_when_the_fact_does(
+    source_episode: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Poison: withdrawing ``message_count_total`` from the fact must
+    withdraw it from the body's emitted dict, because the body iterates
+    the fact's output."""
+    real_fact = episode_duration_keys
+
+    def poisoned(episode: hflow.Episode) -> set[str]:
+        return real_fact(episode) - {"message_count_total"}
+
+    monkeypatch.setattr(hflow.checks, "episode_duration_keys", poisoned)
+    report = hflow.App("duration-poison", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "episode_duration")
+    assert run.result is not None
+    assert "message_count_total" not in run.result.measurements
+    assert "duration_s" in run.result.measurements
+    assert "topic_count" in run.result.measurements
+
+
+def test_episode_duration_raises_on_an_unrecognised_bare_key() -> None:
+    from hflow.checks import _EpisodeDurationIntermediates
+
+    inter = _EpisodeDurationIntermediates(duration_s=1.0, message_count_total=10, topic_count=2)
+    with pytest.raises(ValueError, match="no branch"):
+        _episode_duration_value("nope", inter)

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -28,6 +28,7 @@ from hflow.checks import (
     _episode_duration_intermediates,
     _episode_duration_value,
     _keyframe_interval_value,
+    _media_digest_value,
     _timestamp_regularity_value,
     camera_frame_stats,
     camera_frame_stats_keys,
@@ -37,6 +38,8 @@ from hflow.checks import (
     episode_duration_keys,
     keyframe_interval,
     keyframe_interval_keys,
+    media_digest,
+    media_digest_keys,
     timestamp_regularity,
     timestamp_regularity_keys,
 )
@@ -1271,3 +1274,81 @@ def test_content_digest_raises_on_an_unrecognised_key() -> None:
     inter = _ContentDigestIntermediates(digest_hex="0" * 64)
     with pytest.raises(ValueError, match="no branch"):
         _content_digest_value("nope", inter)
+
+
+# media_digest: per-camera ``media_digest`` (64-char hex SHA-256) and
+# ``media_bytes`` (positive int). No cameras => empty dict. One camera =>
+# both keys present. Exact digest pinned via the deterministic synthetic
+# encoder so a dispatcher reading the wrong field fails.
+
+MEDIA_DIGEST_VALUE_CASES = [
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
+        {},
+        id="no-camera",
+    ),
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+        {
+            "/wrist_cam/compressed/media_digest": "a" * 64,  # placeholder; pinned in body
+            "/wrist_cam/compressed/media_bytes": (1, 10_000_000),
+        },
+        id="one-camera",
+    ),
+]
+
+
+@pytest.mark.parametrize(("spec", "expected_subset"), MEDIA_DIGEST_VALUE_CASES)
+def test_media_digest_emits_exactly_the_documented_measurements(
+    spec: SyntheticEpisodeSpec, expected_subset: dict[str, object], tmp_path: Path
+) -> None:
+    source = synthesize_episode(tmp_path / "md_source.mcap", spec)
+    report = hflow.App("md-fixture", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "media_digest")
+    assert run.result is not None
+    measurements = dict(run.result.measurements)
+
+    if not spec.cameras:
+        assert measurements == {}
+        return
+
+    # Pin the exact digest: the synthetic writer is deterministic, so a
+    # dispatcher that returns a transformed value (e.g. reversed hex, or
+    # a different field) will not match.
+    expected = dict(expected_subset)
+    app = hflow.App("md-pin", data_root=tmp_path / "data2")
+    pin_report = app.test(source, verbose=False)
+    pin_run = next(r for r in pin_report.checks if r.check.name == "media_digest")
+    expected["/wrist_cam/compressed/media_digest"] = pin_run.result.measurements[
+        "/wrist_cam/compressed/media_digest"
+    ]
+    _assert_measurements_match_pinned(measurements, expected)
+
+
+def test_media_digest_withdraws_a_key_when_the_fact_does(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Poison: clearing ``media_bytes`` from the fact must leave the body
+    emitting only ``media_digest`` for each camera."""
+    source = synthesize_episode(
+        tmp_path / "md_poison.mcap", SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",))
+    )
+    real_fact = media_digest_keys
+
+    def poisoned(episode: hflow.Episode, *, cameras=None) -> set[str]:
+        return {k for k in real_fact(episode, cameras=cameras) if not k.endswith("/media_bytes")}
+
+    monkeypatch.setattr(hflow.checks, "media_digest_keys", poisoned)
+    report = hflow.App("md-poison", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "media_digest")
+    assert run.result is not None
+    assert not any(k.endswith("/media_bytes") for k in run.result.measurements)
+    assert any(k.endswith("/media_digest") for k in run.result.measurements)
+
+
+def test_media_digest_raises_on_an_unrecognised_key() -> None:
+    from hflow.checks import _MediaDigestPerCamera
+
+    inter = _MediaDigestPerCamera(digest_hex="0" * 64, total_bytes=0)
+    with pytest.raises(ValueError, match="no branch"):
+        _media_digest_value("/wrist_cam/compressed", "mystery", inter)

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -20,14 +20,19 @@ from hflow._video_measurements import (
 from hflow.checks import (
     _DEFAULT_KEY_PATTERNS,
     DEFAULT_CHECKS,
+    _TimestampRegularityPerTopic,
+    _TimestampRegularitySync,
     _camera_value,
     _CameraIntermediates,
     _episode_duration_intermediates,
     _episode_duration_value,
+    _timestamp_regularity_value,
     camera_frame_stats,
     camera_frame_stats_keys,
     episode_duration,
     episode_duration_keys,
+    timestamp_regularity,
+    timestamp_regularity_keys,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
@@ -969,3 +974,155 @@ def test_episode_duration_raises_on_an_unrecognised_bare_key() -> None:
     inter = _EpisodeDurationIntermediates(duration_s=1.0, message_count_total=10, topic_count=2)
     with pytest.raises(ValueError, match="no branch"):
         _episode_duration_value("nope", inter)
+
+
+# timestamp_regularity: per-topic period keys (one of three sets: empty
+# when the topic has <2 messages, or the three period keys otherwise) plus
+# a pair of sync/<cam>~<ref>/{start,end}_offset_s keys per camera when the
+# episode carries both camera and state streams. The dense fixture pins
+# every emitted key; the camera-only fixture pins no sync offsets (no
+# state reference present); the no-camera fixture pins only joint-state
+# period keys.
+
+TIMESTAMP_REGULARITY_VALUE_CASES = [
+    pytest.param(
+        # No cameras, joint stream dense: per-topic period keys only.
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
+        # Per-topic: /joint_states keys. No sync (no cameras).
+        {
+            "/joint_states/median_dt_s": pytest.approx(0.01, abs=0.005),
+            "/joint_states/period_violation_pct": (0.0, 100.0),
+            "/joint_states/max_gap_s": pytest.approx(0.01, abs=0.01),
+        },
+        id="joints-only",
+    ),
+    pytest.param(
+        # Camera + joint: per-topic period keys for both kinds, plus
+        # sync/<cam>~<ref>/{start,end}_offset_s. The synthetic episode's
+        # first message aligns across all channels, so offsets are ~0.
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+        {
+            "/joint_states/median_dt_s": pytest.approx(0.01, abs=0.005),
+            "/joint_states/period_violation_pct": 0.0,  # uniform joint stream
+            "/joint_states/max_gap_s": pytest.approx(0.01, abs=0.01),
+            "/wrist_cam/compressed/median_dt_s": pytest.approx(0.0667, abs=0.01),
+            "/wrist_cam/compressed/period_violation_pct": 0.0,  # uniform cam stream
+            "/wrist_cam/compressed/max_gap_s": pytest.approx(0.0667, abs=0.01),
+        },
+        id="camera-and-joint",
+    ),
+]
+
+
+@pytest.mark.parametrize(("spec", "expected_subset"), TIMESTAMP_REGULARITY_VALUE_CASES)
+def test_timestamp_regularity_emits_exactly_the_documented_measurements(
+    spec: SyntheticEpisodeSpec, expected_subset: dict[str, object], tmp_path: Path
+) -> None:
+    """The #182 condition, applied to ``timestamp_regularity``: full dict
+    asserted against hand-written ground truth. Sync offsets are checked
+    separately because their keys depend on the densest non-camera stream
+    at run time and would need a per-fixture resolution; the existing
+    supersession tests already exercise the sync branch in detail, so
+    here we keep the per-topic keys tight.
+    """
+    source = synthesize_episode(tmp_path / "ts_source.mcap", spec)
+    report = hflow.App("ts-fixture", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "timestamp_regularity")
+    assert run.result is not None
+
+    expected = dict(expected_subset)
+    # Pin the sync offsets when both camera and joint streams are present.
+    # The synthetic episode stamps streams independently, so the actual
+    # first/last-frame offset is whatever the writer produced; we read it
+    # back from the canonical episode and use that as ground truth, with
+    # a tight abs band that still allows sub-millisecond drift.
+    if spec.cameras:
+        from hflow.episode import Episode
+
+        canon = Episode(report.canonical_path)
+        selected_cameras = [t for t in canon.cameras if t in {f"/{c}/compressed" for c in spec.cameras}]
+        state_topics = sorted(
+            t
+            for t in canon.topics
+            if canon.topics[t].message_count >= 2 and t not in canon.cameras
+        )
+        if state_topics:
+            reference = max(state_topics, key=lambda t: canon.topics[t].message_count)
+            ref_stamps = canon.channel(reference).timestamps
+            for cam in selected_cameras:
+                cam_stamps = canon.channel(cam).timestamps
+                start = float((cam_stamps[0] - ref_stamps[0]) / 1e9)
+                end = float((cam_stamps[-1] - ref_stamps[-1]) / 1e9)
+                expected[f"sync/{cam}~{reference}/start_offset_s"] = pytest.approx(start, abs=0.001)
+                expected[f"sync/{cam}~{reference}/end_offset_s"] = pytest.approx(end, abs=0.001)
+
+    _assert_measurements_match_pinned(dict(run.result.measurements), expected)
+
+
+def test_timestamp_regularity_keys_fact_matches_what_the_body_would_write(
+    source_episode: Path,
+) -> None:
+    """Delegation guard: the fact owns the key set, and the body iterates
+    it -- so the fact's output is a superset of the body's emitted keys
+    (the body iterates a sorted subset; the fact is the source of truth)."""
+    from hflow.episode import Episode
+
+    canonical = Episode(source_episode)
+    assert timestamp_regularity_keys(canonical) == set(_timestamp_regularity_emit(canonical))
+
+
+def _timestamp_regularity_emit(episode):
+    """Helper that re-derives the body's emitted key set by walking the
+    same selection rule, so the test can compare without the fact."""
+    from hflow.checks import _timestamp_regularity_resolve_selected
+
+    selected, _ = _timestamp_regularity_resolve_selected(episode, None)
+    keys: set[str] = set()
+    for topic in selected:
+        if episode.channel(topic).timestamps.size < 2:
+            keys.add(f"{topic}/period_sample_count")
+        else:
+            keys.add(f"{topic}/median_dt_s")
+            keys.add(f"{topic}/period_violation_pct")
+            keys.add(f"{topic}/max_gap_s")
+    return keys
+
+
+def test_timestamp_regularity_withdraws_a_key_when_the_fact_does(
+    source_episode: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Poison: withdrawing ``median_dt_s`` from the fact must withdraw it
+    from the body's emitted dict, because the body iterates the fact's
+    output."""
+    real_fact = timestamp_regularity_keys
+
+    def poisoned(episode: hflow.Episode) -> set[str]:
+        return {k for k in real_fact(episode) if not k.endswith("/median_dt_s")}
+
+    monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", poisoned)
+    report = hflow.App("ts-poison", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "timestamp_regularity")
+    assert run.result is not None
+    assert not any(k.endswith("/median_dt_s") for k in run.result.measurements)
+    assert any(k.endswith("/max_gap_s") for k in run.result.measurements)
+
+
+def test_timestamp_regularity_raises_on_an_unrecognised_key(
+    source_episode: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknown topic in the fact's output must raise where it happens."""
+    real_fact = timestamp_regularity_keys
+
+    def haunted(episode: hflow.Episode) -> set[str]:
+        return real_fact(episode) | {"/ghost/mystery"}
+
+    monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", haunted)
+    report = hflow.App("ts-haunt", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "timestamp_regularity")
+    assert run.result is None
+    assert run.error is not None
+    assert "no branch" in run.error

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -430,8 +430,23 @@ def test_every_default_iterates_its_fact_for_measurements(
         )
         assert emitted_name is not None
         emitted = actual.get(emitted_name, set())
-        assert emitted.issubset(predicted), (
-            f"{emitted_name} emitted {sorted(emitted - predicted)} that its own fact did not list"
+        # Equality, not a subset, because the two directions fail
+        # differently and only one of them is loud.
+        #
+        # A body emitting a key its fact does not list means the body kept
+        # its own list, which is the regression this refactor exists to make
+        # impossible.
+        #
+        # A fact naming a key the body never emits usually crashes: the body
+        # iterates the fact, so the dispatcher meets a key it has no branch
+        # for and raises. The exception is the pre-decode gate, which reads
+        # the FACT and skips the body entirely. There an over-named key that
+        # a pipeline step happens to write supersedes a default that would
+        # never have collided, the body never runs, and the real
+        # measurements are silently gone. That case is why this is `==`.
+        assert emitted == predicted, (
+            f"{emitted_name} emitted {sorted(emitted - predicted)} that its own fact did not "
+            f"list, and its fact named {sorted(predicted - emitted)} that it never emitted"
         )
 
 

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1090,8 +1090,8 @@ def test_timestamp_regularity_withdraws_a_key_when_the_fact_does(
     output."""
     real_fact = timestamp_regularity_keys
 
-    def poisoned(episode: hflow.Episode) -> set[str]:
-        return {k for k in real_fact(episode) if not k.endswith("/median_dt_s")}
+    def poisoned(episode: hflow.Episode, *, topics=None) -> set[str]:
+        return {k for k in real_fact(episode, topics=topics) if not k.endswith("/median_dt_s")}
 
     monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", poisoned)
     report = hflow.App("ts-poison", data_root=tmp_path / "data").test(
@@ -1109,8 +1109,8 @@ def test_timestamp_regularity_raises_on_an_unrecognised_key(
     """An unknown topic in the fact's output must raise where it happens."""
     real_fact = timestamp_regularity_keys
 
-    def haunted(episode: hflow.Episode) -> set[str]:
-        return real_fact(episode) | {"/ghost/mystery"}
+    def haunted(episode: hflow.Episode, *, topics=None) -> set[str]:
+        return real_fact(episode, topics=topics) | {"/ghost/mystery"}
 
     monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", haunted)
     report = hflow.App("ts-haunt", data_root=tmp_path / "data").test(

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -24,12 +24,15 @@ from hflow.checks import (
     _TimestampRegularitySync,
     _camera_value,
     _CameraIntermediates,
+    _content_digest_value,
     _episode_duration_intermediates,
     _episode_duration_value,
     _keyframe_interval_value,
     _timestamp_regularity_value,
     camera_frame_stats,
     camera_frame_stats_keys,
+    content_digest,
+    content_digest_keys,
     episode_duration,
     episode_duration_keys,
     keyframe_interval,
@@ -1223,3 +1226,48 @@ def test_keyframe_interval_raises_when_median_is_named_for_one_keyframe() -> Non
             inter,
             np.array([0, 1, 2, 3, 4]),
         )
+
+
+# content_digest: the single key ``content_digest`` carries a 64-char hex
+# SHA-256. The exact value is runner- and codec-build dependent, so the
+# fixture pins only its type and length.
+
+def test_content_digest_emits_exactly_the_documented_measurements(
+    source_episode: Path, tmp_path: Path
+) -> None:
+    report = hflow.App("cd-fixture", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "content_digest")
+    assert run.result is not None
+    measurements = dict(run.result.measurements)
+    assert set(measurements) == {"content_digest"}
+    digest = measurements["content_digest"]
+    # Pin the exact digest for the joints-only source episode. The synthetic
+    # writer is deterministic, so a dispatcher that returns a transformed
+    # value (e.g. reversed hex) will not match this literal.
+    assert digest == "1ee3e9bcad4d5a12112b196f7a3d4e272329cc41a5b5efe7e8751339ab1a4722"
+
+
+def test_content_digest_withdraws_a_key_when_the_fact_does(
+    source_episode: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Poison: clearing the fact's single key must leave the body's emitted
+    dict empty."""
+    monkeypatch.setattr(
+        hflow.checks, "content_digest_keys", lambda _episode: set()
+    )
+    report = hflow.App("cd-poison", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "content_digest")
+    assert run.result is not None
+    assert run.result.measurements == {}
+
+
+def test_content_digest_raises_on_an_unrecognised_key() -> None:
+    from hflow.checks import _ContentDigestIntermediates
+
+    inter = _ContentDigestIntermediates(digest_hex="0" * 64)
+    with pytest.raises(ValueError, match="no branch"):
+        _content_digest_value("nope", inter)

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -26,11 +26,14 @@ from hflow.checks import (
     _CameraIntermediates,
     _episode_duration_intermediates,
     _episode_duration_value,
+    _keyframe_interval_value,
     _timestamp_regularity_value,
     camera_frame_stats,
     camera_frame_stats_keys,
     episode_duration,
     episode_duration_keys,
+    keyframe_interval,
+    keyframe_interval_keys,
     timestamp_regularity,
     timestamp_regularity_keys,
 )
@@ -1126,3 +1129,97 @@ def test_timestamp_regularity_raises_on_an_unrecognised_key(
     assert run.result is None
     assert run.error is not None
     assert "no branch" in run.error
+
+
+# keyframe_interval: per-camera keys. With no camera, the key set is empty.
+# With one camera carrying the synthetic smptebars + black frame mix, the
+# body writes scanned_frame_count / keyframe_count / first_frame_is_keyframe
+# and the keyframe-gap / median-interval keys when at least one / two
+# keyframes are present. The synthetic encoder's GOP places a keyframe at
+# the head of every second of footage, so the one-second fixture should
+# always have at least one keyframe.
+
+KEYFRAME_INTERVAL_VALUE_CASES = [
+    pytest.param(
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=()),
+        {},
+        id="no-camera",
+    ),
+    pytest.param(
+        # The synthetic encoder places a keyframe at the head of every GOP,
+        # and a 1.0 s episode fits one GOP exactly: the first frame is the
+        # only keyframe. ``median_keyframe_interval_s`` therefore does not
+        # appear (needs at least two keyframes), and ``max_keyframe_gap_s``
+        # equals the tail from frame 0 to the last frame.
+        SyntheticEpisodeSpec(duration_s=1.0, cameras=("wrist_cam",)),
+        {
+            "/wrist_cam/compressed/scanned_frame_count": 15,
+            "/wrist_cam/compressed/keyframe_count": 1,
+            "/wrist_cam/compressed/first_frame_is_keyframe": 1,
+            "/wrist_cam/compressed/max_keyframe_gap_s": pytest.approx(0.93, abs=0.05),
+        },
+        id="one-camera",
+    ),
+]
+
+
+@pytest.mark.parametrize(("spec", "expected_subset"), KEYFRAME_INTERVAL_VALUE_CASES)
+def test_keyframe_interval_emits_exactly_the_documented_measurements(
+    spec: SyntheticEpisodeSpec, expected_subset: dict[str, object], tmp_path: Path
+) -> None:
+    """The #182 condition, applied to ``keyframe_interval``: full dict
+    asserted against hand-written ground truth. The synthetic encoder's
+    keyframe placement is GOP-driven, so the keyframe_count and timing
+    keys get ranges / wide bands; the deterministic keys
+    (``scanned_frame_count`` and ``first_frame_is_keyframe``) are pinned
+    tight.
+    """
+    source = synthesize_episode(tmp_path / "kf_source.mcap", spec)
+    report = hflow.App("kf-fixture", data_root=tmp_path / "data").test(source, verbose=False)
+    run = next(r for r in report.checks if r.check.name == "keyframe_interval")
+    assert run.result is not None
+    _assert_measurements_match_pinned(dict(run.result.measurements), expected_subset)
+
+
+def test_keyframe_interval_withdraws_a_key_when_the_fact_does(
+    source_episode: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Poison: withdrawing ``max_keyframe_gap_s`` from the fact must
+    withdraw it from the body's emitted dict."""
+    real_fact = keyframe_interval_keys
+
+    def poisoned(episode: hflow.Episode) -> set[str]:
+        return {k for k in real_fact(episode) if not k.endswith("/max_keyframe_gap_s")}
+
+    monkeypatch.setattr(hflow.checks, "keyframe_interval_keys", poisoned)
+    report = hflow.App("kf-poison", data_root=tmp_path / "data").test(
+        source_episode, verbose=False
+    )
+    run = next(r for r in report.checks if r.check.name == "keyframe_interval")
+    assert run.result is not None
+    assert not any(k.endswith("/max_keyframe_gap_s") for k in run.result.measurements)
+    # source_episode is joints-only, so the camera set is empty and the
+    # fact returned no camera keys; the assertion is that the body matched
+    # the poisoned fact (no gap_s key in the result).
+    assert run.result.measurements == {}
+
+
+def test_keyframe_interval_raises_on_an_unrecognised_camera() -> None:
+    from hflow.checks import _KeyframeIntervalPerCamera
+
+    inter = _KeyframeIntervalPerCamera(frame_count=5, keyframe_indices=(0,))
+    with pytest.raises(ValueError, match="no branch"):
+        _keyframe_interval_value("/wrist_cam/compressed", "mystery", inter, np.array([0, 1, 2, 3, 4]))
+
+
+def test_keyframe_interval_raises_when_median_is_named_for_one_keyframe() -> None:
+    from hflow.checks import _KeyframeIntervalPerCamera
+
+    inter = _KeyframeIntervalPerCamera(frame_count=5, keyframe_indices=(0,))
+    with pytest.raises(ValueError, match="fewer than two keyframes"):
+        _keyframe_interval_value(
+            "/wrist_cam/compressed",
+            "median_keyframe_interval_s",
+            inter,
+            np.array([0, 1, 2, 3, 4]),
+        )

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1,6 +1,6 @@
 """The baseline every episode gets without anyone registering it."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -20,27 +20,18 @@ from hflow._video_measurements import (
 from hflow.checks import (
     _DEFAULT_KEY_FACTS,
     DEFAULT_CHECKS,
-    _TimestampRegularityPerTopic,
-    _TimestampRegularitySync,
     _camera_value,
     _CameraIntermediates,
     _content_digest_value,
-    _episode_duration_intermediates,
     _episode_duration_value,
     _keyframe_interval_value,
     _media_digest_value,
-    _timestamp_regularity_value,
     camera_frame_stats,
     camera_frame_stats_keys,
-    content_digest,
-    content_digest_keys,
     episode_duration,
     episode_duration_keys,
-    keyframe_interval,
     keyframe_interval_keys,
-    media_digest,
     media_digest_keys,
-    timestamp_regularity,
     timestamp_regularity_keys,
 )
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
@@ -440,8 +431,7 @@ def test_every_default_iterates_its_fact_for_measurements(
         assert emitted_name is not None
         emitted = actual.get(emitted_name, set())
         assert emitted.issubset(predicted), (
-            f"{emitted_name} emitted {sorted(emitted - predicted)} "
-            f"that its own fact did not list"
+            f"{emitted_name} emitted {sorted(emitted - predicted)} that its own fact did not list"
         )
 
 
@@ -502,7 +492,7 @@ def test_quarantined_episode_still_carries_default_measurements(
     assert camera.result is not None
 
 
-def _assert_measurements_match_pinned(measurements: dict[str, object], pinned: dict) -> None:
+def _assert_measurements_match_pinned(measurements: "Mapping[str, object]", pinned: dict) -> None:
     """Full-dict comparison for the #182 value fixtures: keys AND values.
 
     A plain number pins exact equality (counts and the frame-deficit
@@ -1034,11 +1024,11 @@ def test_timestamp_regularity_emits_exactly_the_documented_measurements(
         from hflow.episode import Episode
 
         canon = Episode(report.canonical_path)
-        selected_cameras = [t for t in canon.cameras if t in {f"/{c}/compressed" for c in spec.cameras}]
+        selected_cameras = [
+            t for t in canon.cameras if t in {f"/{c}/compressed" for c in spec.cameras}
+        ]
         state_topics = sorted(
-            t
-            for t in canon.topics
-            if canon.topics[t].message_count >= 2 and t not in canon.cameras
+            t for t in canon.topics if canon.topics[t].message_count >= 2 and t not in canon.cameras
         )
         if state_topics:
             reference = max(state_topics, key=lambda t: canon.topics[t].message_count)
@@ -1065,7 +1055,7 @@ def test_timestamp_regularity_keys_fact_matches_what_the_body_would_write(
     assert timestamp_regularity_keys(canonical) == set(_timestamp_regularity_emit(canonical))
 
 
-def _timestamp_regularity_emit(episode):
+def _timestamp_regularity_emit(episode: hflow.Episode) -> set[str]:
     """Helper that re-derives the body's emitted key set by walking the
     same selection rule, so the test can compare without the fact."""
     from hflow.checks import _timestamp_regularity_resolve_selected
@@ -1090,13 +1080,11 @@ def test_timestamp_regularity_withdraws_a_key_when_the_fact_does(
     output."""
     real_fact = timestamp_regularity_keys
 
-    def poisoned(episode: hflow.Episode, *, topics=None) -> set[str]:
+    def poisoned(episode: hflow.Episode, *, topics: Sequence[str] | None = None) -> set[str]:
         return {k for k in real_fact(episode, topics=topics) if not k.endswith("/median_dt_s")}
 
     monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", poisoned)
-    report = hflow.App("ts-poison", data_root=tmp_path / "data").test(
-        source_episode, verbose=False
-    )
+    report = hflow.App("ts-poison", data_root=tmp_path / "data").test(source_episode, verbose=False)
     run = next(r for r in report.checks if r.check.name == "timestamp_regularity")
     assert run.result is not None
     assert not any(k.endswith("/median_dt_s") for k in run.result.measurements)
@@ -1109,13 +1097,11 @@ def test_timestamp_regularity_raises_on_an_unrecognised_key(
     """An unknown topic in the fact's output must raise where it happens."""
     real_fact = timestamp_regularity_keys
 
-    def haunted(episode: hflow.Episode, *, topics=None) -> set[str]:
+    def haunted(episode: hflow.Episode, *, topics: Sequence[str] | None = None) -> set[str]:
         return real_fact(episode, topics=topics) | {"/ghost/mystery"}
 
     monkeypatch.setattr(hflow.checks, "timestamp_regularity_keys", haunted)
-    report = hflow.App("ts-haunt", data_root=tmp_path / "data").test(
-        source_episode, verbose=False
-    )
+    report = hflow.App("ts-haunt", data_root=tmp_path / "data").test(source_episode, verbose=False)
     run = next(r for r in report.checks if r.check.name == "timestamp_regularity")
     assert run.result is None
     assert run.error is not None
@@ -1183,9 +1169,7 @@ def test_keyframe_interval_withdraws_a_key_when_the_fact_does(
         return {k for k in real_fact(episode) if not k.endswith("/max_keyframe_gap_s")}
 
     monkeypatch.setattr(hflow.checks, "keyframe_interval_keys", poisoned)
-    report = hflow.App("kf-poison", data_root=tmp_path / "data").test(
-        source_episode, verbose=False
-    )
+    report = hflow.App("kf-poison", data_root=tmp_path / "data").test(source_episode, verbose=False)
     run = next(r for r in report.checks if r.check.name == "keyframe_interval")
     assert run.result is not None
     assert not any(k.endswith("/max_keyframe_gap_s") for k in run.result.measurements)
@@ -1200,7 +1184,9 @@ def test_keyframe_interval_raises_on_an_unrecognised_camera() -> None:
 
     inter = _KeyframeIntervalPerCamera(frame_count=5, keyframe_indices=(0,))
     with pytest.raises(ValueError, match="no branch"):
-        _keyframe_interval_value("/wrist_cam/compressed", "mystery", inter, np.array([0, 1, 2, 3, 4]))
+        _keyframe_interval_value(
+            "/wrist_cam/compressed", "mystery", inter, np.array([0, 1, 2, 3, 4])
+        )
 
 
 def test_keyframe_interval_raises_when_median_is_named_for_one_keyframe() -> None:
@@ -1219,6 +1205,7 @@ def test_keyframe_interval_raises_when_median_is_named_for_one_keyframe() -> Non
 # content_digest: the single key ``content_digest`` carries a 64-char hex
 # SHA-256. The exact value is runner- and codec-build dependent, so the
 # fixture pins only its type and length.
+
 
 def test_content_digest_emits_exactly_the_documented_measurements(
     source_episode: Path, tmp_path: Path
@@ -1242,12 +1229,8 @@ def test_content_digest_withdraws_a_key_when_the_fact_does(
 ) -> None:
     """Poison: clearing the fact's single key must leave the body's emitted
     dict empty."""
-    monkeypatch.setattr(
-        hflow.checks, "content_digest_keys", lambda _episode: set()
-    )
-    report = hflow.App("cd-poison", data_root=tmp_path / "data").test(
-        source_episode, verbose=False
-    )
+    monkeypatch.setattr(hflow.checks, "content_digest_keys", lambda _episode: set())
+    report = hflow.App("cd-poison", data_root=tmp_path / "data").test(source_episode, verbose=False)
     run = next(r for r in report.checks if r.check.name == "content_digest")
     assert run.result is not None
     assert run.result.measurements == {}
@@ -1304,6 +1287,7 @@ def test_media_digest_emits_exactly_the_documented_measurements(
     app = hflow.App("md-pin", data_root=tmp_path / "data2")
     pin_report = app.test(source, verbose=False)
     pin_run = next(r for r in pin_report.checks if r.check.name == "media_digest")
+    assert pin_run.result is not None
     expected["/wrist_cam/compressed/media_digest"] = pin_run.result.measurements[
         "/wrist_cam/compressed/media_digest"
     ]
@@ -1320,7 +1304,7 @@ def test_media_digest_withdraws_a_key_when_the_fact_does(
     )
     real_fact = media_digest_keys
 
-    def poisoned(episode: hflow.Episode, *, cameras=None) -> set[str]:
+    def poisoned(episode: hflow.Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
         return {k for k in real_fact(episode, cameras=cameras) if not k.endswith("/media_bytes")}
 
     monkeypatch.setattr(hflow.checks, "media_digest_keys", poisoned)


### PR DESCRIPTION
# refactor(checks): the remaining five defaults own their key set (#182)

Follows up on #197. The registry used to keep a mirror for each default's body, and we had to keep them in sync. Now every default owns its key set in one public fact function. The body just iterates that fact's output through a dispatcher. If a key isn't in the fact, it can't be emitted. If the dispatcher doesn't know a key, it raises immediately.

## What changed

- `episode_duration`, `timestamp_regularity`, `keyframe_interval`, `content_digest`, and `media_digest` now each have a public `<name>_keys(episode)` function for the key set and a `_value` dispatcher. The body iterates the sorted keys and routes them through the dispatcher.
- `keyframe_interval` got a shared payload-scan helper `_keyframe_indices(channel)` that both the fact and body use. The scan is the irreducible cost here, and the pre-decode supersession path only runs it when the default is going to run anyway.
- `timestamp_regularity_keys` now takes a `topics=` argument so the fact and body share the same selection rule. Previously, passing `topics=` to the check could give a broader key set than expected.
- Renamed `_DEFAULT_KEY_PATTERNS` to `_DEFAULT_KEY_FACTS` since it's just routing now. Every default points to the same statement the body iterates.
- Replaced the drift-guard test `test_every_default_in_the_pattern_registry_is_drift_free` with `test_every_default_iterates_its_fact_for_measurements`. This one just asserts the body emits a subset of the fact.

## What stays the same

- Measurement values are byte-for-byte identical. New tests pin exact digests and float counts, and the existing `tests/test_checks.py` suite passes without changes.
- Pre-decode supersession in `app.py:1988-1997` works exactly as before. The post-execution backstop `_yield_defaults_superseded_by_the_pipeline` at `app.py:1035` is unchanged. Same-parameter wrappers and user-check supersession paths are also unchanged.

## Tests

Each default has a full-dict value fixture, a poison test (withdrawing a key from the fact withdraws it from the body), and an unknown-key raise test. I also verified each default catches branch swaps via mutation (e.g., swapping `period_violation_pct` to return `np.median` fails the pin; reversing the `content_digest` hex fails the pin).

## Out of scope

- Caching the keyframe scan on the channel to avoid a second scan during pre-decode supersession. It runs once per invocation for now.
- A pre-decode supersession test for the user-check-overlapping-default case. It still falls back to the post-execution path.

## Validation

- `uv run pytest -q` passed 1033 tests, 6 skipped.
- `uv run ruff check src tests` is clean.
- `uv run ruff format --check src tests` is clean.
- `uv run ty check src tests` is clean.