### PR TITLE
fix(video-measurements): refuse bool and wrong types in settings dataclasses

### DIFF
--- a/src/hflow/_video_measurements/_camera_motion.py
+++ b/src/hflow/_video_measurements/_camera_motion.py
@@ -7,6 +7,7 @@ from types import ModuleType
 
 import numpy as np
 
+from ._field_guards import require_float
 from ._raw_frames import LUMA_FRAME_FILTER_GRAPH, luma_frames
 from ._toolchain import VideoMeasurementToolchain
 
@@ -51,6 +52,8 @@ class CameraMotionSettings:
     horizontal_field_of_view_degrees: float = DEFAULT_HORIZONTAL_FIELD_OF_VIEW_DEGREES
 
     def __post_init__(self) -> None:
+        require_float(self.frames_per_second, "frames_per_second")
+        require_float(self.horizontal_field_of_view_degrees, "horizontal_field_of_view_degrees")
         if not math.isfinite(self.frames_per_second) or self.frames_per_second <= 0:
             raise ValueError(
                 f"frames_per_second must be finite and positive, got {self.frames_per_second}"

--- a/src/hflow/_video_measurements/_field_guards.py
+++ b/src/hflow/_video_measurements/_field_guards.py
@@ -1,0 +1,30 @@
+"""Shared numeric-field validation for the video-measurement settings dataclasses.
+
+Range checks alone (``0 <= x <= 100``) do not reject the wrong *type*: ``bool``
+subclasses ``int``, so ``True``/``False`` satisfy every numeric comparison and
+range test the settings below already run, and a ``str``/``None`` would raise
+a bare ``TypeError`` from the comparison itself instead of a clear message
+naming the field. This closes that hole the same way ``catalog.py`` already
+does for interval bounds and measurement values.
+
+These settings are caller-constructed configuration, not measurement-pipeline
+output, so unlike ``catalog.py``'s NumPy-scalar coercion, no NumPy handling is
+added here: a caller building a ``np.float64`` threshold can call ``.item()``
+itself, the same way any other non-native-Python value would need to.
+"""
+
+
+def require_int(value: object, name: str) -> None:
+    """Refuse anything but a plain ``int`` - ``bool`` included."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an int, got {type(value).__name__}")
+
+
+def require_float(value: object, name: str) -> None:
+    """Refuse anything but a plain ``int`` or ``float`` - ``bool`` included.
+
+    An ``int`` is accepted for a float-declared field: it is a perfectly good
+    float value (``0`` is a real, falsy value that must still pass).
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be an int or float, got {type(value).__name__}")

--- a/src/hflow/_video_measurements/_field_guards.py
+++ b/src/hflow/_video_measurements/_field_guards.py
@@ -15,13 +15,13 @@ itself, the same way any other non-native-Python value would need to.
 
 
 def require_int(value: object, name: str) -> None:
-    """Refuse anything but a plain ``int`` - ``bool`` included."""
+    """Refuse anything but a plain ``int``, ``bool`` included."""
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"{name} must be an int, got {type(value).__name__}")
 
 
 def require_float(value: object, name: str) -> None:
-    """Refuse anything but a plain ``int`` or ``float`` - ``bool`` included.
+    """Refuse anything but a plain ``int`` or ``float``, ``bool`` included.
 
     An ``int`` is accepted for a float-declared field: it is a perfectly good
     float value (``0`` is a real, falsy value that must still pass).

--- a/src/hflow/_video_measurements/_frame_statistics.py
+++ b/src/hflow/_video_measurements/_frame_statistics.py
@@ -14,6 +14,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Protocol
 
+from ._field_guards import require_float, require_int
 from ._toolchain import VideoMeasurementToolchain
 
 FRAME_STATISTICS_DEFINITION_VERSION = "video-frame-statistics/v1"
@@ -54,6 +55,8 @@ class VideoTimeInterval:
     end_seconds: float
 
     def __post_init__(self) -> None:
+        require_float(self.start_seconds, "start_seconds")
+        require_float(self.end_seconds, "end_seconds")
         if not math.isfinite(self.start_seconds) or self.start_seconds < 0:
             raise ValueError(f"start_seconds must be finite and nonnegative: {self.start_seconds}")
         if not math.isfinite(self.end_seconds) or self.end_seconds < self.start_seconds:
@@ -74,6 +77,14 @@ class FrameStatisticsSettings:
     overexposed_average_luma_threshold: float = 235.0
 
     def __post_init__(self) -> None:
+        require_int(
+            self.black_frame_minimum_pixel_share_percent,
+            "black_frame_minimum_pixel_share_percent",
+        )
+        require_int(self.black_pixel_luma_threshold, "black_pixel_luma_threshold")
+        require_float(self.freeze_noise_tolerance_decibels, "freeze_noise_tolerance_decibels")
+        require_float(self.freeze_minimum_duration_seconds, "freeze_minimum_duration_seconds")
+        require_float(self.overexposed_average_luma_threshold, "overexposed_average_luma_threshold")
         if not 0 <= self.black_frame_minimum_pixel_share_percent <= 100:
             raise ValueError("black_frame_minimum_pixel_share_percent must be between 0 and 100")
         if not 0 <= self.black_pixel_luma_threshold <= 255:

--- a/tests/test_video_measurement_settings_types.py
+++ b/tests/test_video_measurement_settings_types.py
@@ -1,0 +1,130 @@
+"""Type guards on the video-measurement settings dataclasses (#199).
+
+Range checks alone (``0 <= x <= 100``) do not reject the wrong *type*: ``bool``
+subclasses ``int``, so ``True``/``False`` satisfy every numeric comparison
+these settings already run, and a value of the wrong type entirely (``str``,
+``None``) previously raised a bare ``TypeError`` from the comparison rather
+than a clear message naming the field. These tests are dependency-free
+(no ffmpeg, no video fixtures, no ``cv2`` extra) since they only exercise
+dataclass construction.
+"""
+
+import pytest
+
+from hflow._video_measurements._camera_motion import CameraMotionSettings
+from hflow._video_measurements._frame_statistics import (
+    FrameStatisticsSettings,
+    VideoTimeInterval,
+)
+
+# (constructor kwargs, expected error text) for every bool-typed refusal.
+_BOOL_REFUSALS = [
+    pytest.param(
+        FrameStatisticsSettings,
+        {"black_frame_minimum_pixel_share_percent": True},
+        "black_frame_minimum_pixel_share_percent",
+        id="frame_statistics-black_frame_minimum_pixel_share_percent",
+    ),
+    pytest.param(
+        FrameStatisticsSettings,
+        {"black_pixel_luma_threshold": True},
+        "black_pixel_luma_threshold",
+        id="frame_statistics-black_pixel_luma_threshold",
+    ),
+    pytest.param(
+        FrameStatisticsSettings,
+        {"freeze_noise_tolerance_decibels": True},
+        "freeze_noise_tolerance_decibels",
+        id="frame_statistics-freeze_noise_tolerance_decibels",
+    ),
+    pytest.param(
+        FrameStatisticsSettings,
+        {"freeze_minimum_duration_seconds": True},
+        "freeze_minimum_duration_seconds",
+        id="frame_statistics-freeze_minimum_duration_seconds",
+    ),
+    pytest.param(
+        FrameStatisticsSettings,
+        {"overexposed_average_luma_threshold": True},
+        "overexposed_average_luma_threshold",
+        id="frame_statistics-overexposed_average_luma_threshold",
+    ),
+    pytest.param(
+        VideoTimeInterval,
+        {"start_seconds": True, "end_seconds": 1.0},
+        "start_seconds",
+        id="video_time_interval-start_seconds",
+    ),
+    pytest.param(
+        VideoTimeInterval,
+        {"start_seconds": 0.0, "end_seconds": True},
+        "end_seconds",
+        id="video_time_interval-end_seconds",
+    ),
+    pytest.param(
+        CameraMotionSettings,
+        {"frames_per_second": True},
+        "frames_per_second",
+        id="camera_motion-frames_per_second",
+    ),
+    pytest.param(
+        CameraMotionSettings,
+        {"frames_per_second": 30.0, "horizontal_field_of_view_degrees": True},
+        "horizontal_field_of_view_degrees",
+        id="camera_motion-horizontal_field_of_view_degrees",
+    ),
+]
+
+
+@pytest.mark.parametrize(("settings_cls", "kwargs", "field_name"), _BOOL_REFUSALS)
+def test_bool_is_refused_for_every_field(
+    settings_cls: type, kwargs: dict[str, object], field_name: str
+) -> None:
+    with pytest.raises(ValueError, match=rf"{field_name}.*bool"):
+        settings_cls(**kwargs)
+
+
+def test_int_field_refuses_a_float() -> None:
+    with pytest.raises(ValueError, match=r"black_pixel_luma_threshold.*float"):
+        FrameStatisticsSettings(black_pixel_luma_threshold=17.5)  # ty: ignore
+
+
+def test_int_field_refuses_a_str() -> None:
+    with pytest.raises(ValueError, match=r"black_frame_minimum_pixel_share_percent.*str"):
+        FrameStatisticsSettings(black_frame_minimum_pixel_share_percent="98")  # ty: ignore
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "kwargs"),
+    [
+        pytest.param(CameraMotionSettings, {"frames_per_second": "30"}, id="camera_motion-str"),
+        pytest.param(CameraMotionSettings, {"frames_per_second": None}, id="camera_motion-none"),
+    ],
+)
+def test_float_field_refuses_non_numeric_types(
+    settings_cls: type, kwargs: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError, match="frames_per_second"):
+        settings_cls(**kwargs)
+
+
+def test_float_field_accepts_a_plain_int() -> None:
+    # An int is a perfectly good float value here; it must not be coerced or
+    # rejected, and 0 (falsy but real) must still be accepted where in range.
+    settings = FrameStatisticsSettings(freeze_minimum_duration_seconds=2)
+    assert settings.freeze_minimum_duration_seconds == 2
+
+    interval = VideoTimeInterval(start_seconds=0, end_seconds=1)
+    assert interval.start_seconds == 0
+
+
+def test_int_field_accepts_zero() -> None:
+    settings = FrameStatisticsSettings(black_pixel_luma_threshold=0)
+    assert settings.black_pixel_luma_threshold == 0
+
+
+def test_defaults_are_unaffected() -> None:
+    # No behavior change for the values every caller already relies on.
+    assert FrameStatisticsSettings() == FrameStatisticsSettings()
+    assert VideoTimeInterval(start_seconds=0.0, end_seconds=1.0).end_seconds == 1.0
+    assert CameraMotionSettings(frames_per_second=30.0).frames_per_second == 30.0


### PR DESCRIPTION
## Summary

`FrameStatisticsSettings`, `VideoTimeInterval`, and `CameraMotionSettings` now refuse a `bool` (or any wrong type) for every numeric field, instead of silently accepting it because `bool` subclasses `int` and satisfies the range checks.

## Why

Fixes #199

Range checks alone (`0 <= x <= 100`) don't reject the wrong *type*. `FrameStatisticsSettings(black_pixel_luma_threshold=True)` was accepted, then reached ffmpeg's filter graph as the literal text `True` — ffmpeg rejects it, but with no mention of which parameter was wrong. A `str`/`None` raised a bare `TypeError` from the comparison itself instead of a message naming the field.

Added `require_int`/`require_float` in a small shared `_field_guards.py`, called at the top of every affected `__post_init__` before the existing range checks. int-declared fields refuse `bool` and any non-`int`; float-declared fields refuse `bool` and accept `int` (a perfectly good float value, and `0`/`0.0` must still pass since they're real values, just falsy) but refuse `str`/`None`.

On the NumPy-coercion question the issue raises: I deliberately did **not** add NumPy-scalar coercion here, unlike `catalog.py`'s measurement/interval normalization. These are caller-constructed configuration, not measurement-pipeline output — there's no established path for a NumPy scalar to reach these constructors, so a caller building a threshold from one can call `.item()` itself.

## Validation

```
uv run ruff check --fix   # all checks passed
uv run ruff format        # 2 files reformatted (the two touched)
uv run ty check           # all checks passed (two intentional wrong-type test calls marked `# ty: ignore`, matching the existing convention in tests/test_ffmpeg.py)
uv run pytest -q          # 1045 passed, 9 skipped, 1 failed
```

The one failure (`test_content_digest_emits_exactly_the_documented_measurements`, a pinned content-digest hash) is pre-existing and unrelated — confirmed by stashing this change and re-running just that test, same failure either way.

Added `tests/test_video_measurement_settings_types.py`: a bool-refusal test for all 9 affected fields (5 on `FrameStatisticsSettings`, 2 on `VideoTimeInterval`, 2 on `CameraMotionSettings`), int-field refuses float/str, float-field refuses str/None, float-field accepts a plain int, `0`/`0.0` still accepted, and defaults are unaffected. Confirmed all 16 new tests fail against `main` (13 didn't raise `ValueError` at all, the other 3 raised an uncaught `TypeError` instead) and pass with this fix.

Kept this scoped to the type guards only (issue #199) — the sibling coverage issue for the pre-existing range refusals (#200) is separate, per the issue's own note that whoever takes the second of the two should rebase onto the first.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements. — not applicable, no documented behavior changed (invalid inputs already failed; now they fail with a clearer error).
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.