### PR TITLE
docs: document input MCAP converter contract

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -143,6 +143,8 @@ Stored-data identifiers (metadata record names, their keys, group names) are **n
 
 ## Conformance
 
+These rules describe the canonical output written by HFlow. A converter should follow the separate [input MCAP contract](./how-to/write-a-converter.md) instead of implementing these guarantees before ingest.
+
 A file claiming this convention must satisfy, in increasing strictness:
 
 1. **It is valid MCAP**: readable by the stock [`mcap` package](https://mcap.dev/docs/python/) with CRC validation on, with a complete summary section.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ the whole workflow before adapting it.
 Use these when you already know the outcome you need.
 
 - [Enable the built-in quality checks](./how-to/enable-built-in-checks.md)
+- [Write an input MCAP converter](./how-to/write-a-converter.md)
 - [Port existing processing and quality-check code](./PORTING.md)
 - [Serve a workspace over HTTP](./SERVE.md)
 - [Call an OpenAI vision endpoint from a step](./how-to/call-openai-vision.md)

--- a/docs/how-to/write-a-converter.md
+++ b/docs/how-to/write-a-converter.md
@@ -1,0 +1,42 @@
+# Write an input MCAP converter
+
+A converter only needs to produce a source MCAP that the built-in transform can read. It does not need to produce a [canonical episode](../FORMAT.md): HFlow establishes that output contract during ingest.
+
+## Required input contract
+
+The source must be a valid MCAP file with a summary section. HFlow opens it with the stock Python `mcap` reader and reads channels from the summary; an unindexed or truncated file is rejected. Finishing the file with a conforming MCAP writer normally supplies the required summary. See [`PythonMcapEpisodeReader`](../../src/hflow/reader.py).
+
+Non-camera channels have no HFlow-specific payload contract. Their topic, schema when present, message encoding, payload bytes, log time, and publish time pass through unchanged. A schema-less channel is allowed, as are multiple channels sharing one topic. The transform operates on channel IDs rather than assuming that a topic identifies one channel. See [`write_canonical_episode`](../../src/hflow/transform.py).
+
+Camera handling is selected by exact schema name. A custom schema name that happens to contain images is treated as an ordinary pass-through channel, so it will not appear in `Episode.cameras` and camera checks will not inspect it. The accepted camera inputs are:
+
+- `sensor_msgs/msg/CompressedImage` or `foxglove.CompressedImage`: the message encoding and schema must be decodable by the installed ROS 2 or protobuf MCAP decoder. Every message on one channel must use the same image format, and that format string must contain `jpeg`, `jpg`, or `png`. The payloads must contain valid images of that format. For a channel with at least two messages, the median difference between consecutive log times must be positive so HFlow can infer a frame rate. HFlow accepts a one-message channel using a 1 fps fallback and drops an empty camera channel with a warning. See [`_decode_compressed_images`](../../src/hflow/transform.py), [`_input_codec_for_image_format`](../../src/hflow/transform.py), and [`estimate_fps_from_log_times`](../../src/hflow/video.py).
+- `foxglove.CompressedVideo` or `foxglove_msgs/msg/CompressedVideo`: the message encoding and schema must be decodable. Each message must declare `format="h264"` and contain one Annex B access unit. Every keyframe must include SPS and PPS, and the first message on a channel must be a keyframe. HFlow inserts a missing access-unit delimiter without re-encoding when the message can also be serialized by its protobuf or ROS 2 CDR encoder; it rejects other stream repairs. The current validator does not inspect whether an otherwise accepted stream uses B-frames, so a converter passing through H.264 must still disable them to satisfy the canonical output convention. See [`_resolve_decoder`, `_resolve_encoder`, and `_validate_passthrough_video_payload`](../../src/hflow/transform.py).
+
+Raw `sensor_msgs/msg/Image` and `foxglove.RawImage` channels are not supported. Record compressed JPEG or PNG images instead. Any derived topic configured by the pipeline must also be absent from the source because HFlow refuses to create a second channel with that topic; this is normally a pipeline-author concern rather than converter logic. These refusals are in [`write_canonical_episode`](../../src/hflow/transform.py).
+
+Those are the HFlow-specific acceptance rules. Other malformed records or payloads can still be rejected by the MCAP decoder, the selected message decoder, or ffmpeg. HFlow does not require source provenance metadata, canonical chunk layout, globally sorted messages, or canonical identifiers before ingest.
+
+When ingest cannot create an episode, inspect both `error_type` and `message` in the [`ingest_failures` table](../CATALOG.md), not only `failure_kind`. MCAP parse exceptions are classified as `source-unreadable`, but transform-level `ValueError` and `NotImplementedError` exceptions currently fall under the fallback `infrastructure` classification even when their messages identify an unsupported converter output. The classification logic is in [`classify_ingest_failure`](../../src/hflow/ingest_ledger.py).
+
+## What HFlow adds
+
+The transform turns supported compressed-image channels into `foxglove.CompressedVideo` H.264, or validates and minimally repairs already encoded H.264. It globally orders output messages, preserves other channels, source metadata, and attachments, and replaces any source `provenance/v1` record with its own.
+
+HFlow also assigns topics to `cameras`, `bulk`, and `state` chunk groups, derives per-group chunk targets from the episode's byte rates unless configured otherwise, and records both decisions in `provenance/v1`. It adds the canonical schema and pipeline versions, ffmpeg and GOP facts, transform provenance, and the identifiers derived from the canonical bytes. A converter should not pre-group or pre-chunk data to imitate this layout.
+
+The [canonical format conformance rules](../FORMAT.md#conformance) describe this output. `hflow doctor` checks those rules, so a source file can be a valid converter output even when `doctor` reports that it is not canonical yet.
+
+## Conventions that improve the result
+
+Use stable, descriptive topic names such as `/joint_states`, `/action`, `/imu`, and camera-specific names, and keep units consistent with the schema. HFlow does not require those spellings for ingest, but pipeline-authored checks and downstream queries need predictable names.
+
+Use nanosecond timestamps from one clock, keep log times increasing within each channel, and align streams that describe the same event. The six checks registered by default are `episode_duration`, `timestamp_regularity`, `camera_frame_stats`, `keyframe_interval`, `content_digest`, and `media_digest`. The duration and timestamp checks can inspect any populated topic; the three camera-specific checks only produce camera evidence for the recognized schema names above. Clean timestamps and correct camera schemas therefore determine how much baseline evidence an otherwise accepted file produces. See [`DEFAULT_CHECKS`](../../src/hflow/checks.py).
+
+Put stable episode semantics such as task, operator, success, embodiment, and robot software version in an `episode/v1` metadata record when they are available. Record converter and source-dataset details under a separate name such as `source-provenance/v1`; do not write `provenance/v1`, because the transform owns and replaces that record.
+
+## Follow the LeRobot example
+
+[`examples/lerobot/prepare.py`](../../examples/lerobot/prepare.py) demonstrates the boundary: it opens a standard MCAP writer, registers schemas and channels, writes timestamped messages and source metadata, finishes the source file, and then calls `hflow.write_canonical_episode`. That sequence is the reusable converter pattern.
+
+Its Hugging Face download, Parquet column mapping, Pusht state and action schemas, topic names, metadata values, and video timestamp checks are specific to that dataset. It also arrives with encoded H.264, so it prepares a pass-through video stream that already meets the constraints above. A converter whose source contains JPEG or PNG frames can write `CompressedImage` messages instead and leave H.264 encoding, GOP structure, grouping, chunk sizing, and canonical provenance to HFlow.


### PR DESCRIPTION
## Summary

Add a converter guide that separates the source MCAP accepted by ingest from the canonical MCAP that HFlow writes. The guide covers the required input, transform-owned output work, useful source conventions, ingest-failure diagnostics, and the reusable boundary in the LeRobot example.

Link the guide from the documentation index and from the canonical format's Conformance section so converter authors do not implement output guarantees before ingest.

## Why

Fixes #166.

The documented requirements follow the current implementation:

- `src/hflow/reader.py:119-150` requires a readable MCAP with a summary and permits schema-less channels.
- `src/hflow/transform.py:210-224` and `:336-458` define the supported compressed-image formats, camera decoder/encoder paths, and pass-through video constraints.
- `src/hflow/transform.py:495-514` rejects raw-image schemas and derived-topic collisions, while `:595-635` defines empty, single-frame, and multi-frame compressed-image behavior.
- `src/hflow/transform.py:670-835` shows global ordering, data-derived grouping and chunk sizing, source record handling, and canonical provenance.
- `src/hflow/ingest_ledger.py:80-100` explains why converter-facing transform errors currently appear under the fallback `infrastructure` failure kind.
- `src/hflow/checks.py:1885-1922` is the source for the six automatic checks described in the conventions section.

## Validation

- `lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .` — 327 total, 324 OK, 3 excluded, 0 errors.
- `git diff --check`

## Checklist

- [x] Outcome-focused tests are not applicable because this is a Markdown-only change.
- [x] I added documentation for the converter input contract.
- [x] Python formatting and type checks are not applicable because no Python changed.
- [x] I ran the repository's required Markdown link check.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data behavior and compatibility are unchanged.
