### PR TITLE
fix: validate batch planning inputs

### DIFF
--- a/src/hflow/batching.py
+++ b/src/hflow/batching.py
@@ -23,8 +23,10 @@ least as well as random jitter and reproduces exactly.
 """
 
 import heapq
+import math
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from numbers import Real
 from pathlib import Path
 
 
@@ -53,8 +55,36 @@ def plan_batches(
     if (batch_count is None) == (target_batch_bytes is None):
         raise ValueError("pass exactly one of batch_count or target_batch_bytes")
     for uri, size_bytes in item_sizes.items():
+        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool):
+            raise ValueError(
+                f"item {uri!r} has type {type(size_bytes).__name__}, expected int bytes"
+            )
         if size_bytes < 0:
             raise ValueError(f"item {uri!r} has negative size {size_bytes}")
+
+    if not isinstance(stagger_interval_s, Real) or isinstance(stagger_interval_s, bool):
+        raise ValueError(
+            f"stagger_interval_s must be a number, got {type(stagger_interval_s).__name__}"
+        )
+    if not math.isfinite(stagger_interval_s):
+        raise ValueError(f"stagger_interval_s must be finite, got {stagger_interval_s}")
+    if stagger_interval_s < 0:
+        raise ValueError(f"stagger_interval_s must be nonnegative, got {stagger_interval_s}")
+
+    if batch_count is not None:
+        if not isinstance(batch_count, int) or isinstance(batch_count, bool):
+            raise ValueError(f"batch_count must be an int, got {type(batch_count).__name__}")
+        if batch_count < 1:
+            raise ValueError(f"batch_count must be >= 1, got {batch_count}")
+    else:
+        assert target_batch_bytes is not None
+        if not isinstance(target_batch_bytes, int) or isinstance(target_batch_bytes, bool):
+            raise ValueError(
+                f"target_batch_bytes must be an int, got {type(target_batch_bytes).__name__}"
+            )
+        if target_batch_bytes < 1:
+            raise ValueError(f"target_batch_bytes must be >= 1, got {target_batch_bytes}")
+
     if not item_sizes:
         return []
 
@@ -63,8 +93,6 @@ def plan_batches(
 
     batches: list[tuple[list[str], int]]
     if batch_count is not None:
-        if batch_count < 1:
-            raise ValueError(f"batch_count must be >= 1, got {batch_count}")
         # Least-loaded assignment: push each item onto the currently-lightest
         # batch. Heap entries are (total_bytes, batch_index) so byte ties
         # break on index, deterministically.
@@ -78,8 +106,6 @@ def plan_batches(
             heapq.heappush(heap, (total + size_bytes, index))
     else:
         assert target_batch_bytes is not None
-        if target_batch_bytes < 1:
-            raise ValueError(f"target_batch_bytes must be >= 1, got {target_batch_bytes}")
         # First-fit-decreasing: first open batch with room, else a new one.
         # An item exceeding the capacity still gets (its own) batch.
         batches = []

--- a/src/hflow/batching.py
+++ b/src/hflow/batching.py
@@ -77,7 +77,6 @@ def plan_batches(
         if batch_count < 1:
             raise ValueError(f"batch_count must be >= 1, got {batch_count}")
     else:
-        assert target_batch_bytes is not None
         if not isinstance(target_batch_bytes, int) or isinstance(target_batch_bytes, bool):
             raise ValueError(
                 f"target_batch_bytes must be an int, got {type(target_batch_bytes).__name__}"

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -1,10 +1,11 @@
 """Byte-balanced bin-packing and staggered batch starts."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from hflow.batching import plan_batches, plan_batches_from_files
+from hflow.batching import PlannedBatch, plan_batches, plan_batches_from_files
 
 
 def test_fixed_count_batches_are_near_equal_bytes() -> None:
@@ -60,6 +61,59 @@ def test_argument_validation() -> None:
     with pytest.raises(ValueError, match="target_batch_bytes must be >= 1, got 0"):
         plan_batches({"a": 1}, target_batch_bytes=0)
     assert plan_batches({}, batch_count=3) == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch_count": True}, "batch_count must be an int, got bool"),
+        ({"batch_count": 1.0}, "batch_count must be an int, got float"),
+        ({"target_batch_bytes": False}, "target_batch_bytes must be an int, got bool"),
+        ({"target_batch_bytes": "100"}, "target_batch_bytes must be an int, got str"),
+    ],
+)
+def test_batch_parameters_require_real_integers(kwargs: dict[str, Any], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        plan_batches({"a": 1}, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("size", "message"),
+    [
+        (True, "item 'a' has type bool, expected int bytes"),
+        (1.0, "item 'a' has type float, expected int bytes"),
+    ],
+)
+def test_item_sizes_require_real_integers(size: Any, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        plan_batches({"a": size}, batch_count=1)  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize(
+    ("stagger", "message"),
+    [
+        (True, "stagger_interval_s must be a number, got bool"),
+        ("1.0", "stagger_interval_s must be a number, got str"),
+        (-1.0, "stagger_interval_s must be nonnegative, got -1.0"),
+        (float("nan"), "stagger_interval_s must be finite, got nan"),
+        (float("inf"), "stagger_interval_s must be finite, got inf"),
+    ],
+)
+def test_stagger_interval_requires_a_finite_nonnegative_number(stagger: Any, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        plan_batches({"a": 1}, batch_count=1, stagger_interval_s=stagger)  # type: ignore[arg-type]
+
+
+def test_zero_size_items_and_zero_stagger_remain_valid() -> None:
+    batches = plan_batches({"empty": 0}, batch_count=1, stagger_interval_s=0)
+    assert batches == [PlannedBatch(items=("empty",), total_bytes=0, start_delay_s=0)]
+
+
+def test_plan_from_files_forwards_stagger_validation(tmp_path: Path) -> None:
+    item = tmp_path / "item.mcap"
+    item.write_bytes(b"x")
+    with pytest.raises(ValueError, match="stagger_interval_s must be finite"):
+        plan_batches_from_files([item], batch_count=1, stagger_interval_s=float("nan"))
 
 
 def test_plan_from_real_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Validate all `plan_batches` inputs at the planning boundary so malformed values fail with parameter-specific errors.

## Why

Issue #204 showed that booleans pass integer checks, item sizes accept non-integers, and negative or non-finite stagger values reach runtime. This adds focused validation while preserving valid zero-byte items and zero stagger values.

## Validation

- `uv run ruff check` — passed via native Ruff 0.16.2 on the changed files.
- `uv run ruff format --check` — passed after formatting the changed files.
- Direct module checks under WSL Python 3.14 — passed for bool/non-int parameters, bool/non-int item sizes, negative/non-finite/non-number stagger values, and valid zero-byte/zero-stagger input.
- Full pytest suite was not runnable in this Windows checkout because HFlow requires POSIX `fcntl`; the upstream Ubuntu CI will run `uv sync --locked` and `uv run pytest -q`.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` (Ruff check/format completed; native full typecheck is blocked by the same platform dependency).
- [ ] I ran the relevant pytest suite (blocked by native Windows `fcntl`; covered by CI).
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.

Closes #204