### PR TITLE
refactor(runtime): parse the conf flag where mode is parsed

### DIFF
--- a/src/hflow/runtime/_templates.py
+++ b/src/hflow/runtime/_templates.py
@@ -522,15 +522,13 @@ def ingest_stage():
         catalog cannot see -- an artifact deleted out from under a step whose
         rows still say it ran.
         """
-        from hflow.stage_execution import plan_stage_batches
+        from hflow.stage_execution import parse_conf_flag, plan_stage_batches
 
         if not uris:
             return []
-        # Conf values arrive rendered; a native bool passes straight through
-        # and a hand-typed string is read the way every other flag in the
-        # project reads one.
-        if isinstance(all_stages, str):
-            all_stages = all_stages.strip().lower() in {"1", "true", "yes", "on"}
+        # The conf vocabulary is parsed at the library boundary, like mode --
+        # this task only feeds it what Airflow rendered.
+        all_stages = parse_conf_flag(all_stages)
 $stage_plan_filter        return plan_stage_batches(
             [str(uri) for uri in uris],
             mode=mode,

--- a/src/hflow/runtime/_templates.py
+++ b/src/hflow/runtime/_templates.py
@@ -526,8 +526,8 @@ def ingest_stage():
 
         if not uris:
             return []
-        # The conf vocabulary is parsed at the library boundary, like mode --
-        # this task only feeds it what Airflow rendered.
+        # The conf vocabulary is parsed at the library boundary, like mode.
+        # This task only feeds it what Airflow rendered.
         all_stages = parse_conf_flag(all_stages)
 $stage_plan_filter        return plan_stage_batches(
             [str(uri) for uri in uris],

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -128,6 +128,33 @@ def resolve_episode_reference(data_root: str, uri: str) -> "Path | str":
     return Path(data_root) / uri
 
 
+# The spellings a conf flag counts as true. Anything else, including the empty
+# string a cleared trigger-form field sends, is false.
+_TRUE_CONF_SPELLINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def parse_conf_flag(value: object) -> bool:
+    """One trigger-conf boolean, however Airflow happened to render it.
+
+    Lives here for the reason ``mode`` is parsed here: the conf vocabulary has
+    one owner, shared by every execution backend, and a rendered DAG should
+    only be feeding it values. It matters more than it looks, because the two
+    directions fail differently. Reading a true spelling as false costs one
+    wasted run and is obvious. Reading a false spelling as true silently
+    disables whatever the flag was gating, and for ``all_stages`` that means a
+    scheduled re-ingest quietly goes on costing what it cost before there was
+    a filter.
+
+    ``bool()`` on the raw value is the wrong implementation and the reason this
+    is a function: with ``render_template_as_native_obj`` a native bool arrives
+    as itself, but a hand-typed conf value arrives as text, and every non-empty
+    string is truthy -- ``"false"`` included.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUE_CONF_SPELLINGS
+    return bool(value)
+
+
 def plan_stage_batches(
     uris: Sequence[str],
     *,

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -137,18 +137,17 @@ def parse_conf_flag(value: object) -> bool:
     """One trigger-conf boolean, however Airflow happened to render it.
 
     Lives here for the reason ``mode`` is parsed here: the conf vocabulary has
-    one owner, shared by every execution backend, and a rendered DAG should
-    only be feeding it values. It matters more than it looks, because the two
-    directions fail differently. Reading a true spelling as false costs one
-    wasted run and is obvious. Reading a false spelling as true silently
-    disables whatever the flag was gating, and for ``all_stages`` that means a
-    scheduled re-ingest quietly goes on costing what it cost before there was
-    a filter.
+    one owner, shared by every execution backend, and a rendered DAG only
+    feeds it values. The two directions fail differently. Reading a true
+    spelling as false costs one wasted run and is obvious. Reading a false
+    spelling as true silently disables whatever the flag was gating, and for
+    ``all_stages`` that means a scheduled re-ingest goes on costing what it
+    cost before there was a filter.
 
-    ``bool()`` on the raw value is the wrong implementation and the reason this
-    is a function: with ``render_template_as_native_obj`` a native bool arrives
-    as itself, but a hand-typed conf value arrives as text, and every non-empty
-    string is truthy -- ``"false"`` included.
+    ``bool()`` on the raw value gets that wrong, which is why this is a
+    function: with ``render_template_as_native_obj`` a native bool arrives as
+    itself, but a hand-typed conf value arrives as text, and every non-empty
+    string is truthy, ``"false"`` included.
     """
     if isinstance(value, str):
         return value.strip().lower() in _TRUE_CONF_SPELLINGS

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -452,7 +452,10 @@ def test_sub_dag_sources_compile_and_encode_contract(config: RuntimeConfig, tmp_
         # survive. The tasks are thin callers into hflow.stage_execution (one
         # owner of the run semantics; see tests/test_stage_execution.py for
         # the semantics themselves).
-        assert "\n        from hflow.stage_execution import plan_stage_batches" in dag_source
+        assert (
+            "\n        from hflow.stage_execution import parse_conf_flag, plan_stage_batches"
+            in dag_source
+        )
         assert "\n        from hflow.stage_execution import (" in dag_source
         assert "load_pipeline_application" in dag_source
         assert "resolve_user_pipeline_path('my_pipeline.py')" in dag_source

--- a/tests/test_stage_execution.py
+++ b/tests/test_stage_execution.py
@@ -13,6 +13,7 @@ from hflow import stage_execution
 from hflow.stage_execution import (
     StageBatchCounts,
     load_pipeline_application,
+    parse_conf_flag,
     plan_stage_batches,
     process_stage_batch,
     require_application_data_root,
@@ -90,6 +91,28 @@ class TestLanePlanning:
     def test_unknown_mode_is_refused_loudly(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="unknown mode"):
             plan_stage_batches(["a.mcap"], mode="turbo", batch_count=None, data_root=str(tmp_path))
+
+
+class TestConfFlags:
+    """The conf vocabulary's booleans, parsed where mode is parsed."""
+
+    @pytest.mark.parametrize("spelling", ["1", "true", "TRUE", " yes ", "on"])
+    def test_the_spellings_that_mean_yes(self, spelling: str) -> None:
+        assert parse_conf_flag(spelling) is True
+
+    @pytest.mark.parametrize("spelling", ["0", "false", "FALSE", "no", "off", "", "   "])
+    def test_every_other_string_means_no(self, spelling: str) -> None:
+        """The direction where a regression is silent. ``bool()`` on the raw
+        string reads all of these as true, and a flag that gates a filter then
+        turns the filter off without anything failing."""
+        assert parse_conf_flag(spelling) is False
+
+    def test_a_native_value_is_taken_as_it_stands(self) -> None:
+        """render_template_as_native_obj hands a real bool straight through,
+        and an unset param arrives as None."""
+        assert parse_conf_flag(True) is True
+        assert parse_conf_flag(False) is False
+        assert parse_conf_flag(None) is False
 
 
 class TestEpisodeReferences:


### PR DESCRIPTION
Follow-up to #195, on the `all_stages` conf flag it added.

The string coercion lived inside the sub-DAG template. `plan`'s own docstring says the lane semantics live in `hflow.stage_execution`, one owner for every execution backend, and this was the one piece of conf parsing that did not. It moves next to where `mode` is parsed, and the template calls it.

That also makes it directly testable. The coercion was only reachable by extracting the rendered `plan` body and calling it, which works but is a heavy way to cover four spellings.

The direction that matters is false, not true, which is the point #195 made when it pinned that side. Reading a true spelling as false costs one wasted run and is obvious. Reading a false spelling as true turns the filter off silently: the corpus stays correct and the re-ingest just keeps costing what it cost before the filter existed. `bool()` on the raw value gets that wrong for every non-empty string, `"false"` included.

`tests/test_stage_execution.py` covers the yes spellings, the no spellings including the empty and whitespace forms a cleared trigger-form field sends, and native values, since `render_template_as_native_obj` hands a real bool straight through and an unset param arrives as `None`.

No behaviour change. The rendered DAGs do what they did after #195.

Validation:

```
uv run pytest -q          1111 passed, 9 skipped, 1 failed
uv run ruff check         All checks passed
uv run ruff format --check  174 files already formatted
uv run ty check           All checks passed
```

The failure is `tests/test_default_checks.py::test_content_digest_emits_exactly_the_documented_measurements`. It fails on a clean checkout of `c81a48e` too, so it is not from this branch and I have left it alone.