### PR TITLE
fix: avoid replanning camera-less media

### DIFF
--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from hflow.steps import SETTLED_STATUSES, Stage
+from hflow.steps import RAN_STATUSES, SETTLED_STATUSES, Stage
 
 if TYPE_CHECKING:
     import duckdb
@@ -179,6 +179,50 @@ def _settled_step_names(
     return settled
 
 
+def _camera_presence_by_episode(
+    connection: "duckdb.DuckDBPyConnection",
+    application: "App",
+    episode_ids: Sequence[str],
+) -> dict[str, bool]:
+    """Whether the default camera check measured at least one camera."""
+    from hflow.checks import (
+        _default_check_version_for_automatic_registration,
+        camera_frame_stats,
+    )
+
+    check_name = camera_frame_stats.__name__
+    check_version = _default_check_version_for_automatic_registration(camera_frame_stats)
+    if not episode_ids or not any(
+        registered.function is camera_frame_stats
+        and registered.name == check_name
+        and registered.version == check_version
+        for registered in application.checks
+    ):
+        return {}
+
+    episode_placeholders = ", ".join("?" for _ in episode_ids)
+    statuses = ", ".join(_quote_sql_string(status.value) for status in RAN_STATUSES)
+    rows = connection.execute(
+        f"""
+        SELECT runs.episode_id, count(measurements.key) > 0
+        FROM check_runs AS runs
+        LEFT JOIN measurements
+          ON measurements.episode_id = runs.episode_id
+         AND measurements.run_fingerprint = runs.run_fingerprint
+         AND measurements.check_name = runs.check_name
+         AND measurements.check_version = runs.check_version
+         AND ends_with(measurements.key, '/message_count')
+        WHERE runs.status IN ({statuses})
+          AND runs.episode_id IN ({episode_placeholders})
+          AND runs.check_name = ?
+          AND runs.check_version = ?
+        GROUP BY runs.episode_id
+        """,
+        [*episode_ids, check_name, check_version],
+    ).fetchall()
+    return {str(episode_id): bool(has_camera) for episode_id, has_camera in rows}
+
+
 def plan_outstanding_stages(
     application: "App",
     source_identities: Sequence[str],
@@ -203,13 +247,12 @@ def plan_outstanding_stages(
     ``source-unreadable``. The real failure is counted and classified in
     ``ingest_failures`` by the stage that hit it.
 
-    Known limitation, stated because it costs work rather than correctness: the
-    media stage records nothing at all on a camera-less episode (there is no
-    contact sheet to render), so "no row" cannot be told from "nothing to
-    render" and such an episode is planned for ``media`` on every pass. The
-    stage is a no-op for it beyond opening the canonical, and the alternative
-    -- treating a missing row as done -- would silently never render a sheet
-    for an episode that wanted one.
+    The automatic ``camera_frame_stats`` check lets the planner distinguish a
+    camera-less episode from one whose contact sheet has not been rendered: a
+    completed current-version check with no per-camera measurements means
+    ``media`` has no work. If that exact default check is not registered or its
+    result is missing, the planner preserves the safe fallback and schedules
+    ``media`` rather than risk omitting a contact sheet.
     """
     from hflow.curation import open_catalog_connection
 
@@ -244,9 +287,13 @@ def plan_outstanding_stages(
                 list(source_identities),
             ).fetchall()
         }
+        episode_ids = sorted(set(episode_by_source.values()))
         identity_pairs = sorted({pair for pairs in required_by_stage.values() for pair in pairs})
-        settled_by_episode = _settled_step_names(
-            connection, sorted(set(episode_by_source.values())), identity_pairs
+        settled_by_episode = _settled_step_names(connection, episode_ids, identity_pairs)
+        camera_presence_by_episode = (
+            _camera_presence_by_episode(connection, application, episode_ids)
+            if Stage.MEDIA in required_by_stage
+            else {}
         )
     finally:
         connection.close()
@@ -261,6 +308,8 @@ def plan_outstanding_stages(
         outstanding_stages: set[Stage] = set()
         outstanding_steps: list[str] = []
         for stage, pairs in required_by_stage.items():
+            if stage is Stage.MEDIA and camera_presence_by_episode.get(episode_id) is False:
+                continue
             missing = [name for name, _version in pairs if name not in settled]
             if missing:
                 outstanding_stages.add(stage)

--- a/tests/test_stage_planning.py
+++ b/tests/test_stage_planning.py
@@ -45,6 +45,12 @@ def my_duration(ep: hflow.Episode) -> hflow.CheckResult:
     return episode_duration(ep)
 """
 
+PIPELINE_WITHOUT_DEFAULT_CHECKS = """
+import hflow
+
+app = hflow.App("planning-demo", default_checks=())
+"""
+
 
 @pytest.fixture(scope="module")
 def source_episode(tmp_path_factory: pytest.TempPathFactory) -> Path:
@@ -412,16 +418,47 @@ class TestMediaPlanning:
         assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 0
         assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 1
 
-    def test_a_camera_less_episode_is_planned_every_time(self, project: Path) -> None:
-        """The stated limitation. A camera-less episode records no
-        `media/contact_sheet` row at all, so "no row" cannot be told from
-        "nothing to render" -- and the alternative reading would silently never
-        render a sheet for an episode that wanted one. The stage is a no-op for
-        it, so the cost is one canonical open."""
+    def test_a_camera_bearing_episode_without_a_contact_sheet_is_planned(
+        self, project: Path, camera_source: Path
+    ) -> None:
+        (project / "data" / EPISODE_URI).write_bytes(camera_source.read_bytes())
+        application = hflow.import_pipeline_application(str(project / "pipeline.py"))
+        run_stages_directly(
+            application,
+            [EPISODE_URI],
+            {hflow.Stage.SYNC, hflow.Stage.META},
+        )
+
+        second = _ingest(project)
+
+        assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 1
+        assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 0
+
+    def test_a_camera_less_episode_is_not_planned_again(self, project: Path) -> None:
         _ingest(project)
 
         second = _ingest(project)
 
+        assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 0
+        assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 1
+
+    def test_disabling_default_checks_keeps_planning_camera_less_media(self, project: Path) -> None:
+        (project / "pipeline.py").write_text(PIPELINE_WITHOUT_DEFAULT_CHECKS)
+        _ingest(project)
+
+        second = _ingest(project)
+
+        assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 1
+        assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 0
+
+    def test_an_episode_without_camera_frame_stats_is_still_planned(self, project: Path) -> None:
+        (project / "pipeline.py").write_text(PIPELINE_WITHOUT_DEFAULT_CHECKS)
+        _ingest(project)
+        (project / "pipeline.py").write_text(PIPELINE_SOURCE)
+
+        second = _ingest(project)
+
+        assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 1
         assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 0
 
 

--- a/tests/test_stage_planning.py
+++ b/tests/test_stage_planning.py
@@ -51,6 +51,21 @@ import hflow
 app = hflow.App("planning-demo", default_checks=())
 """
 
+# Supersedes the check the media planner reads. The auto-registered copy stands
+# down and emits no per-camera keys, so anything that counts a superseded row as
+# an answer reads a camera-bearing episode as camera-less.
+PIPELINE_THAT_SUPERSEDES_CAMERA_FRAME_STATS = """
+import hflow
+from hflow.checks import camera_frame_stats
+
+app = hflow.App("planning-demo")
+
+
+@app.check(version="1")
+def my_camera_frame_stats(ep: hflow.Episode) -> hflow.CheckResult:
+    return camera_frame_stats(ep)
+"""
+
 
 @pytest.fixture(scope="module")
 def source_episode(tmp_path_factory: pytest.TempPathFactory) -> Path:
@@ -450,6 +465,26 @@ class TestMediaPlanning:
 
         assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 1
         assert _stage(second, hflow.Stage.MEDIA).skipped_as_current == 0
+
+    def test_a_superseded_camera_check_is_not_an_answer(
+        self, project: Path, camera_source: Path
+    ) -> None:
+        """A superseded row is the reason this reads RAN_STATUSES and not
+        SETTLED_STATUSES. The auto-registered copy stood down, so it emitted no
+        per-camera keys, and counting it would read this camera-bearing episode
+        as camera-less and never render its contact sheet."""
+        (project / "data" / EPISODE_URI).write_bytes(camera_source.read_bytes())
+        (project / "pipeline.py").write_text(PIPELINE_THAT_SUPERSEDES_CAMERA_FRAME_STATS)
+        application = hflow.import_pipeline_application(str(project / "pipeline.py"))
+        run_stages_directly(
+            application,
+            [EPISODE_URI],
+            {hflow.Stage.SYNC, hflow.Stage.META},
+        )
+
+        second = _ingest(project)
+
+        assert _stage(second, hflow.Stage.MEDIA).counts["processed"] == 1
 
     def test_an_episode_without_camera_frame_stats_is_still_planned(self, project: Path) -> None:
         (project / "pipeline.py").write_text(PIPELINE_WITHOUT_DEFAULT_CHECKS)


### PR DESCRIPTION
## Summary

- Use the current default `camera_frame_stats` catalog result to identify camera-less episodes before media planning.
- Keep media planning unchanged when camera presence is unknown or a camera-bearing episode still lacks a contact sheet.

## Why

Camera-less episodes never record `media/contact_sheet`, so every re-ingest currently schedules a media stage that cannot produce output. The default camera check already records enough evidence to skip that work without changing the catalog schema, while preserving the existing fallback when the evidence is unavailable.

Closes #171.

## Validation

- `uv sync --locked --all-extras` — completed successfully.
- `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` — passed.
- `uv run pytest -q tests/test_stage_planning.py` — 37 passed.
- `uv run pytest -q` — 1,117 passed and 6 skipped; one unrelated local ffmpeg test failed because the installed ffmpeg rejects an apostrophe in a drawtext font path. The same `main` commit passes upstream CI.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
