### PR TITLE
fix(video-measurements): keep empty freeze totals float

### DIFF
--- a/src/hflow/_video_measurements/_frame_statistics.py
+++ b/src/hflow/_video_measurements/_frame_statistics.py
@@ -382,7 +382,11 @@ class _FrameStatisticsAccumulator:
             overexposed_frame_percent=100.0 * self.overexposed_frame_count / frame_count,
             freeze_intervals=tuple(self.freeze_intervals),
             freeze_total_seconds=sum(
-                interval.end_seconds - interval.start_seconds for interval in self.freeze_intervals
+                (
+                    interval.end_seconds - interval.start_seconds
+                    for interval in self.freeze_intervals
+                ),
+                0.0,
             ),
             average_luma_mean=self.average_luma.mean(),
             average_luma_minimum=self.average_luma.minimum(),

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -371,6 +371,7 @@ def test_synthetic_output_aggregates_exactly() -> None:
     assert stats.average_luma_maximum == pytest.approx(100.0)
     assert stats.freeze_intervals == ()
     assert stats.freeze_total_seconds == 0.0
+    assert type(stats.freeze_total_seconds) is float
     # Default threshold 235.0: none of 100, 10, 40 are >= 235
     assert stats.overexposed_frame_count == 0
     assert stats.overexposed_frame_percent == 0.0


### PR DESCRIPTION
## Summary

- Seed the empty freeze-duration sum with `0.0` so `freeze_total_seconds` always matches its declared `float` type.
- Strengthen the existing no-freeze regression to check the runtime type as well as numeric equality.

## Why

Running the documented egocentric pipeline against three healthy excerpts from a real Egocentric-10K video made `camera_health` error on each episode. With no detected freeze intervals, Python's unseeded `sum(...)` returned `int 0`; the example expects the core field's declared `float` type and rejected it. Seeding the aggregation fixes the core invariant rather than weakening the example.

Closes #214.

## Validation

- The new type assertion fails on `main` with `type(0) is float` and passes with this change.
- `uv run python examples/egocentric/pipeline.py <healthy-real-episode.mcap>` — `camera_health` changed from `error` to `passed` with 200 decoded frames and `freeze_total_s = 0`.
- The pinned 96-episode Egocentric-10K example corpus completed with `camera_health` passing 90 clean episodes and failing exactly the six injected faults; the catalog had zero check errors and zero ingest failures. Re-ingest completed in 5.02 seconds with all expensive work current.
- `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` — passed with no changes.
- `uv run pytest -q -k 'not test_contact_sheet_accepts_apostrophes_in_external_paths'` — 1,118 passed, 6 skipped, 1 deselected. The excluded test also fails unchanged on `main` with the pinned ffmpeg and is tracked separately in #215.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements. (Not applicable: this restores the field's declared `float` type.)
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
