### PR TITLE
refactor(transform): type pass-through video messages

### DIFF
--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -400,26 +400,26 @@ def _resolve_encoder(topic: str, info: TopicInfo) -> Callable[[Any, bytes], byte
 
 
 @dataclass(frozen=True)
-class PassthroughVideoMessage:
+class _PassthroughVideoMessage:
     """The H.264 payload parsed at the codec boundary, independent of its encoding."""
 
     format: Literal["h264"]
     data: bytes
 
 
-def _parse_passthrough_video_message(topic: str, decoded_message: Any) -> PassthroughVideoMessage:
+def _parse_passthrough_video_message(topic: str, decoded_message: Any) -> _PassthroughVideoMessage:
     if decoded_message.format != "h264":
         raise ValueError(
             f"pass-through video topic {topic!r} carries format "
             f"{decoded_message.format!r}; the canonical convention requires 'h264' "
             "(re-encode upstream -- v1 does not transcode CompressedVideo)"
         )
-    return PassthroughVideoMessage(format="h264", data=bytes(decoded_message.data))
+    return _PassthroughVideoMessage(format="h264", data=bytes(decoded_message.data))
 
 
 def _insert_missing_passthrough_video_aud(
-    topic: str, message: PassthroughVideoMessage
-) -> PassthroughVideoMessage:
+    topic: str, message: _PassthroughVideoMessage
+) -> _PassthroughVideoMessage:
     """Repair the one canonical constraint that is lossless to bridge."""
     try:
         canonical_data = video_module.ensure_access_unit_delimiter(message.data)
@@ -427,11 +427,11 @@ def _insert_missing_passthrough_video_aud(
         raise ValueError(
             f"pass-through video topic {topic!r} violates the canonical convention: {error}"
         ) from error
-    return PassthroughVideoMessage(format=message.format, data=canonical_data)
+    return _PassthroughVideoMessage(format=message.format, data=canonical_data)
 
 
 def _validate_passthrough_video_payload(
-    topic: str, message: PassthroughVideoMessage, *, is_first_message: bool
+    topic: str, message: _PassthroughVideoMessage, *, is_first_message: bool
 ) -> None:
     """Enforce the canonical video constraints on a pass-through message.
 

--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -57,6 +57,7 @@ import hashlib
 import json
 import logging
 from collections.abc import Callable, Mapping, Sequence
+from copy import copy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -353,12 +354,25 @@ def _resolve_decoder(topic: str, info: TopicInfo) -> Callable[[bytes], Any]:
     )
 
 
-def _resolve_encoder(topic: str, info: TopicInfo) -> Callable[[Any], bytes]:
+@dataclass(frozen=True)
+class _Ros2VideoMessageWithData:
+    """Override only the payload while forwarding every other field to its owner."""
+
+    _original: object
+    data: bytes
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._original, name)
+
+
+def _resolve_encoder(topic: str, info: TopicInfo) -> Callable[[Any, bytes], bytes]:
     """An encoder matching a decoded pass-through video message."""
     if info.message_encoding == "protobuf":
 
-        def encode_protobuf(message: Any) -> bytes:
-            serialize = getattr(message, "SerializeToString", None)
+        def encode_protobuf(message: Any, data: bytes) -> bytes:
+            repaired_message = copy(message)
+            repaired_message.data = data
+            serialize = getattr(repaired_message, "SerializeToString", None)
             if not callable(serialize):
                 raise ValueError(
                     f"camera topic {topic!r} decoded a protobuf message that cannot "
@@ -373,32 +387,51 @@ def _resolve_encoder(topic: str, info: TopicInfo) -> Callable[[Any], bytes]:
         encoders = serialize_dynamic(info.schema_name, info.schema_data.decode())
         encoder = encoders.get(info.schema_name)
         if encoder is not None:
-            return encoder
+
+            def encode_cdr(message: Any, data: bytes) -> bytes:
+                # mcap_ros2's slotted SimpleNamespace fields are lost by copy.copy.
+                return encoder(_Ros2VideoMessageWithData(_original=message, data=data))
+
+            return encode_cdr
     raise ValueError(
         f"camera topic {topic!r} has message encoding {info.message_encoding!r} "
         "that cannot be serialized after inserting an AUD"
     )
 
 
-def _insert_missing_passthrough_video_aud(topic: str, decoded_message: Any) -> bool:
-    """Repair the one canonical constraint that is lossless to bridge."""
+@dataclass(frozen=True)
+class PassthroughVideoMessage:
+    """The H.264 payload parsed at the codec boundary, independent of its encoding."""
+
+    format: Literal["h264"]
+    data: bytes
+
+
+def _parse_passthrough_video_message(topic: str, decoded_message: Any) -> PassthroughVideoMessage:
     if decoded_message.format != "h264":
-        return False
-    original_data = bytes(decoded_message.data)
+        raise ValueError(
+            f"pass-through video topic {topic!r} carries format "
+            f"{decoded_message.format!r}; the canonical convention requires 'h264' "
+            "(re-encode upstream -- v1 does not transcode CompressedVideo)"
+        )
+    return PassthroughVideoMessage(format="h264", data=bytes(decoded_message.data))
+
+
+def _insert_missing_passthrough_video_aud(
+    topic: str, message: PassthroughVideoMessage
+) -> PassthroughVideoMessage:
+    """Repair the one canonical constraint that is lossless to bridge."""
     try:
-        canonical_data = video_module.ensure_access_unit_delimiter(original_data)
+        canonical_data = video_module.ensure_access_unit_delimiter(message.data)
     except ValueError as error:
         raise ValueError(
             f"pass-through video topic {topic!r} violates the canonical convention: {error}"
         ) from error
-    if canonical_data == original_data:
-        return False
-    decoded_message.data = canonical_data
-    return True
+    return PassthroughVideoMessage(format=message.format, data=canonical_data)
 
 
 def _validate_passthrough_video_payload(
-    topic: str, decoded_message: Any, *, is_first_message: bool
+    topic: str, message: PassthroughVideoMessage, *, is_first_message: bool
 ) -> None:
     """Enforce the canonical video constraints on a pass-through message.
 
@@ -406,14 +439,8 @@ def _validate_passthrough_video_payload(
     pre-encoded video channel from another recorder must be proven
     conforming, not trusted.
     """
-    if decoded_message.format != "h264":
-        raise ValueError(
-            f"pass-through video topic {topic!r} carries format "
-            f"{decoded_message.format!r}; the canonical convention requires 'h264' "
-            "(re-encode upstream -- v1 does not transcode CompressedVideo)"
-        )
     try:
-        access_units = video_module.split_annex_b_stream(bytes(decoded_message.data))
+        access_units = video_module.split_annex_b_stream(message.data)
     except ValueError as error:
         raise ValueError(
             f"pass-through video topic {topic!r} violates the canonical convention: "
@@ -542,7 +569,7 @@ def write_canonical_episode(
             if info.schema_name in PASSTHROUGH_VIDEO_SCHEMA_NAMES
         }
         passthrough_video_decoders: dict[int, Callable[[bytes], Any]] = {}
-        passthrough_video_encoders: dict[int, Callable[[Any], bytes]] = {}
+        passthrough_video_encoders: dict[int, Callable[[Any, bytes], bytes]] = {}
         passthrough_video_channels_with_messages: set[int] = set()
         for batch in reader.iter_batches():
             if batch.channel_id in camera_payloads:
@@ -562,20 +589,25 @@ def write_canonical_episode(
                             batch.channel_id not in passthrough_video_channels_with_messages
                         )
                         decoded_message = decode(payload)
-                        inserted_aud = _insert_missing_passthrough_video_aud(
+                        video_message = _parse_passthrough_video_message(
                             batch.topic, decoded_message
+                        )
+                        repaired_video_message = _insert_missing_passthrough_video_aud(
+                            batch.topic, video_message
                         )
                         _validate_passthrough_video_payload(
                             batch.topic,
-                            decoded_message,
+                            repaired_video_message,
                             is_first_message=is_first_message,
                         )
-                        if inserted_aud:
+                        if repaired_video_message.data != video_message.data:
                             if batch.channel_id not in passthrough_video_encoders:
                                 passthrough_video_encoders[batch.channel_id] = _resolve_encoder(
                                     batch.topic, infos[batch.channel_id]
                                 )
-                            payload = passthrough_video_encoders[batch.channel_id](decoded_message)
+                            payload = passthrough_video_encoders[batch.channel_id](
+                                decoded_message, repaired_video_message.data
+                            )
                         canonical_payloads.append(payload)
                         passthrough_video_channels_with_messages.add(batch.channel_id)
                 else:

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -3,9 +3,10 @@
 import functools
 import json
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
@@ -17,9 +18,11 @@ from mcap_ros2.decoder import DecoderFactory as Ros2DecoderFactory
 from mcap_ros2.writer import Writer as Ros2Writer
 
 import hflow
+from hflow import transform
 from hflow._grouped_mcap_writer import NO_SCHEMA_ID, GroupedMcapWriter
 from hflow.doctor import diagnose
 from hflow.format import METADATA_RECORD_EPISODE
+from hflow.reader import TopicInfo
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import write_canonical_episode
 from hflow.video import estimate_fps_from_log_times
@@ -286,6 +289,71 @@ def test_transform_inserts_missing_aud_into_ros2_video(tmp_path: Path) -> None:
     assert len(repaired.data) == len(KEYFRAME_WITHOUT_AUD) + 6
     assert repaired.frame_id == "cam"
     assert repaired.format == "h264"
+
+
+@pytest.mark.parametrize("encoding", ["protobuf", "cdr"])
+@pytest.mark.parametrize(
+    "data", [KEYFRAME_ACCESS_UNIT, KEYFRAME_WITHOUT_AUD], ids=["conforming", "repaired"]
+)
+def test_transform_preserves_decoder_owned_video_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, encoding: str, data: bytes
+) -> None:
+    source = tmp_path / "decoder-owned-video.mcap"
+    if encoding == "protobuf":
+        _write_passthrough_video_source(source, [("/cam", 1, data)])
+    else:
+        writer = Ros2Writer(str(source))
+        schema = writer.register_msgdef(
+            "foxglove_msgs/msg/CompressedVideo",
+            ROS2_COMPRESSED_VIDEO_SCHEMA.replace(
+                "string frame_id", "string frame_id\nstring original"
+            ),
+        )
+        writer.write_message(
+            "/cam",
+            schema,
+            SimpleNamespace(
+                timestamp=SimpleNamespace(sec=0, nanosec=1),
+                frame_id="cam",
+                original="source-recorder",
+                data=data,
+                format="h264",
+            ),
+            log_time=1,
+            publish_time=1,
+        )
+        writer.finish()
+
+    resolve_decoder = transform._resolve_decoder
+    decoder_owned_messages: list[Any] = []
+
+    def retaining_decoder(topic: str, info: TopicInfo) -> Callable[[bytes], Any]:
+        decode = resolve_decoder(topic, info)
+
+        def decode_and_retain(payload: bytes) -> Any:
+            message = decode(payload)
+            decoder_owned_messages.append(message)
+            return message
+
+        return decode_and_retain
+
+    monkeypatch.setattr(transform, "_resolve_decoder", retaining_decoder)
+    output = tmp_path / "out.mcap"
+    write_canonical_episode(source, output)
+
+    (original,) = decoder_owned_messages
+    assert bytes(original.data) == data
+    assert original.format == "h264"
+    assert original.frame_id == "cam"
+    if encoding == "cdr":
+        with output.open("rb") as stream:
+            schema, channel, message = next(make_reader(stream).iter_messages())
+            assert schema is not None
+            decode = Ros2DecoderFactory().decoder_for(channel.message_encoding, schema)
+            assert decode is not None
+            assert decode(message.data).original == "source-recorder"
+    report = diagnose(output)
+    assert report.conforming, report.summary()
 
 
 def test_aborted_writer_does_not_publish_partial_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Parse pass-through video once at the decode boundary into a frozen `PassthroughVideoMessage` with an H.264 format type and immutable payload bytes. AUD repair returns a new value, and the validator accepts that value instead of re-reading an untyped decoded object.

The codec boundary receives the original decoded message and the repaired bytes separately. Protobuf serialization copies the message, preserving unknown fields. CDR serialization uses a read-only payload override that forwards the remaining fields: `copy.copy` is not sufficient for mcap_ros2's slotted `SimpleNamespace` messages, as the unchanged CDR regression demonstrated by losing `frame_id` and `format` during development.

There is now one `format != "h264"` check. Conforming serialized payloads still bypass re-encoding. No decoded input is mutated, no public behavior is changed, and **no `TRANSFORM_BEHAVIOR_VERSION` bump** is made.

Closes #206

## Verification

- Left the existing protobuf and CDR AUD-repair regressions unchanged, including the six-byte insertion / original-payload suffix assertions.
- Added one parameterized ownership regression for both encodings, with conforming and repaired messages. The two repaired cases fail against the original implementation because the decoder-owned input is mutated. It also pins that an additional CDR field named `original` survives serialization.
- `uv sync --locked` — complete development environment as documented in current CONTRIBUTING.md; no optional endpoint/model extras needed.
- `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` — pass. Final check-only equivalents also pass.
- `uv run pytest -q tests/test_processing_regressions.py tests/test_identity_stability.py -o tmp_path_retention_count=0` — **47 passed** on Python 3.14.7. The same 47 tests pass on Python 3.11.4 using the existing Python 3.11 environment with this checkout first on `PYTHONPATH`.
- Root suite, including `packages/hflow-server/tests`: `PYTHONUNBUFFERED=1 uv run pytest -q -o tmp_path_retention_policy=failed -o tmp_path_retention_count=0` — **1,119 passed, 9 skipped, 1 failed**. The only failure is the already tracked macOS digest literal in #209. It produces exactly the same `164675bb...468117c2` value on clean baseline `01b92a8`, reproduced separately with the same interpreter/dependencies. No tests were deselected or assertions changed. The retention options only free temporary files after passing tests on a disk-constrained machine.
- `git diff --check` — pass.
- [Hosted Linux CI](https://github.com/Hebbian-Robotics/hflow/actions/runs/33137091313) — **1,123 passed, 6 skipped on both Python 3.11 and 3.14**. Lint, format, typechecking, links, and the one-open-PR check all pass.

## Before/after byte comparison

Before editing, wrote canonical outputs at `01b92a8` for four fixed two-frame inputs (keyframe + delta). Compared **complete MCAP files**, not just decoded payloads, after the refactor. The protobuf corpus includes an unknown wire field, and the CDR corpus includes an extra `source_label` field.

| Input | Canonical bytes | Before/after |
| --- | ---: | --- |
| protobuf, conforming | 1,971 | identical |
| protobuf, missing AUD | 1,971 | identical |
| CDR, conforming | 1,560 | identical |
| CDR, missing AUD | 1,560 | identical |

The full-file SHA-256 remains `d5cba2e6f160c56bc3930b77f809d30445931b5e2c8193b2d7281d46cb17343c` for both protobuf cases and `2e9b94adc6c40227c238b0db60c9d38bf797d51caab5e29a9f5b37aebff6cc8b` for both CDR cases. Pipeline version remains `9cd5d34f513d`. The same comparisons also pass under Python 3.11.4.

## Checklist

- [x] Added outcome-focused coverage and kept the existing repair tests intact.
- [x] Ran the Python quality gates and root test suite; documented the known baseline failure.
- [x] Preserved stored bytes and identity without a behavior-version bump.
- [x] No recordings, generated media, credentials, or runtime artifacts included.
- [x] No documentation behavior change: this is an internal representation refactor.

Implemented and validated with OpenAI Codex assistance.
