### PR TITLE
fix: validate transform config numeric settings

### DIFF
--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -56,6 +56,7 @@ v1 behavior:
 import hashlib
 import json
 import logging
+import math
 from collections.abc import Callable, Mapping, Sequence
 from copy import copy
 from dataclasses import dataclass, field
@@ -132,6 +133,31 @@ class TransformConfig:
     # topic -> group name, beating the defaults; topics not listed go to
     # ``cameras`` by schema, ``bulk`` by mean message size, else ``state``.
     topic_groups: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject invalid settings before they become a pipeline identity."""
+        if isinstance(self.crf, bool) or not isinstance(self.crf, int):
+            raise ValueError(f"crf must be an int, got {type(self.crf).__name__}")
+        if not 0 <= self.crf <= 51:
+            raise ValueError(f"crf must be between 0 and 51, got {self.crf}")
+
+        if self.gop_seconds is not None:
+            if isinstance(self.gop_seconds, bool) or not isinstance(self.gop_seconds, int | float):
+                raise ValueError(
+                    f"gop_seconds must be an int or float, got {type(self.gop_seconds).__name__}"
+                )
+            if not math.isfinite(self.gop_seconds) or self.gop_seconds <= 0:
+                raise ValueError(f"gop_seconds must be positive and finite, got {self.gop_seconds}")
+
+        if self.chunk_size_bytes is not None:
+            if isinstance(self.chunk_size_bytes, bool) or not isinstance(
+                self.chunk_size_bytes, int
+            ):
+                raise ValueError(
+                    f"chunk_size_bytes must be an int, got {type(self.chunk_size_bytes).__name__}"
+                )
+            if self.chunk_size_bytes <= 0:
+                raise ValueError(f"chunk_size_bytes must be positive, got {self.chunk_size_bytes}")
 
 
 @dataclass(frozen=True)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
 """Transform: synthetic input MCAP -> canonical episode."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -45,6 +46,36 @@ def test_pipeline_version_is_a_content_hash() -> None:
     changed = TransformConfig(gop_preset=GopPreset.WORLD_MODEL)
     assert compute_pipeline_version(base) != compute_pipeline_version(changed)
     assert len(compute_pipeline_version(base)) == 12
+
+
+@pytest.mark.parametrize(
+    ("construct", "field"),
+    [
+        (lambda: TransformConfig(crf=True), "crf"),
+        (lambda: TransformConfig(crf=-1), "crf"),
+        (lambda: TransformConfig(crf=52), "crf"),
+        (lambda: TransformConfig(gop_seconds=True), "gop_seconds"),
+        (lambda: TransformConfig(gop_seconds=0), "gop_seconds"),
+        (lambda: TransformConfig(gop_seconds=float("nan")), "gop_seconds"),
+        (lambda: TransformConfig(gop_seconds=float("inf")), "gop_seconds"),
+        (lambda: TransformConfig(chunk_size_bytes=True), "chunk_size_bytes"),
+        (lambda: TransformConfig(chunk_size_bytes=0), "chunk_size_bytes"),
+        (lambda: TransformConfig(chunk_size_bytes=-1), "chunk_size_bytes"),
+    ],
+)
+def test_transform_config_rejects_invalid_numeric_settings(
+    construct: Callable[[], TransformConfig], field: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        construct()
+
+
+def test_transform_config_accepts_valid_numeric_settings() -> None:
+    config = TransformConfig(crf=0, gop_seconds=1, chunk_size_bytes=1)
+
+    assert config.crf == 0
+    assert config.gop_seconds == 1
+    assert config.chunk_size_bytes == 1
 
 
 def test_stamps_carry_source_robot_software_version(source_episode: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Reject booleans, invalid CRF values, non-positive or non-finite GOP durations, and non-positive chunk sizes when `TransformConfig` is constructed
- Keep all valid configuration values and transform behavior unchanged
- Add focused regression coverage for each invalid boundary

Closes #220

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest tests/test_transform.py -q` (18 passed)
- `uv run pytest -q` completed; 19 ffmpeg checks initially failed only because ffmpeg was absent from WSL. After installing the documented prerequisite, `uv run pytest --lf -q` passed all 19.

<sub>Body reformatted by a maintainer: the original was submitted with literal `` `n `` in place of newlines, which a squash-merge would have carried into main. Content unchanged.</sub>
