### PR TITLE
fix(testing): refuse invalid SyntheticEpisodeSpec in synthesize_episode

### DIFF
--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -409,6 +409,12 @@ def _validate_synthetic_episode_spec(spec: "SyntheticEpisodeSpec") -> None:
         segment = getattr(spec, segment_name)
         if segment is None:
             continue
+        # A segment still holding its class default is exempt when it runs past
+        # a shortened duration. The defaults are sized for duration_s=8.0, and
+        # most callers shorten the episode without clearing them, so enforcing
+        # this on defaults refuses specs that have always worked: removing this
+        # branch fails 78 tests and errors 112 more. An explicitly chosen
+        # segment is checked, which is the case the caller can act on.
         default = SyntheticEpisodeSpec.__dataclass_fields__[segment_name].default
         if segment == default and segment[1] > spec.duration_s:
             continue

--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -31,6 +31,9 @@ Implementation notes:
   ``MSG: pkg/msg/Type`` headers) so any ROS 2-aware reader decodes them.
 - Everything is deterministic: fixed ``start_time_ns``, seeded noise, no
   wall-clock reads.
+- ``_require_int`` / ``_require_float`` are copied here rather than imported
+  from ``hflow._video_measurements`` so that incubating package can stay
+  dependency-free and extractable (see ``src/hflow/_video_measurements/__init__.py``).
 """
 
 import errno
@@ -52,6 +55,17 @@ from hflow.format import (
     METADATA_RECORD_EPISODE,
     NANOSECONDS_PER_SECOND,
 )
+
+
+def _require_int(value: object, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an int, got {type(value).__name__}")
+
+
+def _require_float(value: object, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be an int or float, got {type(value).__name__}")
+
 
 JOINT_STATES_TOPIC = "/joint_states"
 JOINT_STATE_SCHEMA_NAME = "sensor_msgs/msg/JointState"
@@ -365,6 +379,42 @@ def _validate_video_episode_spec(spec: VideoEpisodeSpec) -> None:
             )
 
 
+def _validate_synthetic_episode_spec(spec: "SyntheticEpisodeSpec") -> None:
+    _require_float(spec.duration_s, "duration_s")
+    _require_float(spec.image_hz, "image_hz")
+    _require_float(spec.joint_hz, "joint_hz")
+    _require_int(spec.image_width, "image_width")
+    _require_int(spec.image_height, "image_height")
+    _require_int(spec.joint_count, "joint_count")
+
+    for field_name in ("duration_s", "image_hz", "joint_hz"):
+        value = getattr(spec, field_name)
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{field_name} must be finite, got {value!r}")
+
+    if spec.duration_s <= 0.0:
+        raise ValueError(f"duration_s must be > 0, got {spec.duration_s}")
+    if spec.image_hz <= 0.0:
+        raise ValueError(f"image_hz must be > 0, got {spec.image_hz}")
+    if spec.joint_hz <= 0.0:
+        raise ValueError(f"joint_hz must be > 0, got {spec.joint_hz}")
+    if spec.image_width <= 0 or spec.image_height <= 0:
+        raise ValueError(
+            f"image dimensions must be positive, got {spec.image_width}x{spec.image_height}"
+        )
+    if spec.joint_count <= 0:
+        raise ValueError(f"joint_count must be > 0, got {spec.joint_count}")
+
+    for segment_name in ("black_segment", "joint_freeze_segment", "timestamp_offset_segment"):
+        segment = getattr(spec, segment_name)
+        if segment is None:
+            continue
+        default = SyntheticEpisodeSpec.__dataclass_fields__[segment_name].default
+        if segment == default and segment[1] > spec.duration_s:
+            continue
+        _validate_video_fault_segment(segment_name, segment, spec.duration_s)
+
+
 def _render_source_video_frames(
     source_video_path: Path,
     spec: VideoEpisodeSpec,
@@ -646,6 +696,7 @@ def _calibration_attachment_json(spec: SyntheticEpisodeSpec) -> bytes:
 def synthesize_episode(output: Path | str, spec: SyntheticEpisodeSpec | None = None) -> Path:
     """Write a synthetic input episode to ``output`` and return its path."""
     resolved_spec = spec if spec is not None else SyntheticEpisodeSpec()
+    _validate_synthetic_episode_spec(resolved_spec)
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -337,3 +337,32 @@ def test_synthesize_episode_refuses_invalid_spec(
             tmp_path / "refused.mcap",
             SyntheticEpisodeSpec(cameras=(), **spec_kwargs),  # ty: ignore
         )
+
+
+def test_a_default_fault_segment_past_a_shortened_duration_still_writes(tmp_path: Path) -> None:
+    """The exemption the rest of the suite stands on.
+
+    ``black_segment`` and ``timestamp_offset_segment`` default to spans sized
+    for ``duration_s=8.0``, and most callers shorten the episode without
+    clearing them. Validating defaults the way an explicit segment is validated
+    refuses specs that have always worked: it fails 78 tests and errors 112
+    more. This pins the exemption so tightening it is a deliberate choice with
+    a red test, not a tidy-up.
+    """
+    spec = SyntheticEpisodeSpec(duration_s=1.0, cameras=())
+
+    assert spec.black_segment == (2.0, 3.0)
+    assert spec.timestamp_offset_segment == (6.0, 7.0)
+
+    written = synthesize_episode(tmp_path / "short.mcap", spec)
+
+    assert written.is_file()
+
+
+def test_an_explicit_fault_segment_past_the_end_is_still_refused(tmp_path: Path) -> None:
+    """The exemption is scoped to defaults, so a chosen segment stays checked."""
+    with pytest.raises(ValueError, match=r"black_segment must satisfy"):
+        synthesize_episode(
+            tmp_path / "refused.mcap",
+            SyntheticEpisodeSpec(duration_s=1.0, cameras=(), black_segment=(2.0, 4.0)),
+        )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -280,3 +280,60 @@ def test_video_episode_missing_source_names_the_path_with_errno(tmp_path: Path) 
     assert excinfo.value.filename == str(missing_source)
     assert "No such file or directory" in str(excinfo.value)
     assert str(missing_source) in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("spec_kwargs", "match"),
+    [
+        pytest.param({"duration_s": 0.0}, r"duration_s must be > 0", id="duration_s-zero"),
+        pytest.param({"duration_s": -1.0}, r"duration_s must be > 0", id="duration_s-negative"),
+        pytest.param({"joint_hz": 0.0}, r"joint_hz must be > 0", id="joint_hz-zero"),
+        pytest.param({"image_hz": 0.0}, r"image_hz must be > 0", id="image_hz-zero"),
+        pytest.param(
+            {"duration_s": float("nan")}, r"duration_s must be finite", id="duration_s-nan"
+        ),
+        pytest.param({"image_hz": float("inf")}, r"image_hz must be finite", id="image_hz-inf"),
+        pytest.param({"joint_hz": float("nan")}, r"joint_hz must be finite", id="joint_hz-nan"),
+        pytest.param(
+            {"joint_count": True}, r"joint_count must be an int, got bool", id="joint_count-bool"
+        ),
+        pytest.param(
+            {"duration_s": True},
+            r"duration_s must be an int or float, got bool",
+            id="duration_s-bool",
+        ),
+        pytest.param(
+            {"image_width": True}, r"image_width must be an int, got bool", id="image_width-bool"
+        ),
+        pytest.param(
+            {"image_width": 0}, r"image dimensions must be positive", id="image_width-zero"
+        ),
+        pytest.param(
+            {"image_height": 0}, r"image dimensions must be positive", id="image_height-zero"
+        ),
+        pytest.param({"joint_count": 0}, r"joint_count must be > 0", id="joint_count-zero"),
+        pytest.param(
+            {"duration_s": 1.0, "black_segment": (5.0, 9.0)},
+            r"black_segment must satisfy 0 <= start < end <= duration_s",
+            id="black_segment-past-end",
+        ),
+        pytest.param(
+            {"duration_s": 1.0, "joint_freeze_segment": (5.0, 9.0)},
+            r"joint_freeze_segment must satisfy 0 <= start < end <= duration_s",
+            id="joint_freeze_segment-past-end",
+        ),
+        pytest.param(
+            {"duration_s": 1.0, "timestamp_offset_segment": (5.0, 9.0)},
+            r"timestamp_offset_segment must satisfy 0 <= start < end <= duration_s",
+            id="timestamp_offset_segment-past-end",
+        ),
+    ],
+)
+def test_synthesize_episode_refuses_invalid_spec(
+    tmp_path: Path, spec_kwargs: dict[str, object], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        synthesize_episode(
+            tmp_path / "refused.mcap",
+            SyntheticEpisodeSpec(cameras=(), **spec_kwargs),  # ty: ignore
+        )


### PR DESCRIPTION
## Summary

- `synthesize_episode` refuses bad `SyntheticEpisodeSpec` values before it writes an episode.
- It refuses non-positive `duration_s`, `image_hz`, `joint_hz`, image dimensions, and `joint_count`.
- It refuses bools and non-finite floats.
- The `ValueError` names the field.
- It also refuses `black_segment`, `joint_freeze_segment`, and `timestamp_offset_segment` past `duration_s`.
- Default fault segments past a short `duration_s` still write, so current call sites keep working.
- Valid specs and episode contents stay the same.

## Why

- A typo in duration or rate wrote a syntactically valid episode with no messages.
- Later steps then failed with a weak error about missing data.
- `VideoEpisodeSpec` already refuses bad values at write time.
- This change applies the same rule to `synthesize_episode`.
- Checks run in `synthesize_episode`, not in `SyntheticEpisodeSpec.__post_init__`.
- Odd image dimensions stay allowed. The synthetic path does not need the yuv420p even-size rule.

## Validation

- `uv sync --locked --all-extras`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest -q` (1118 passed, 6 skipped)

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
