### PR TITLE
fix(ffmpeg): validate contact sheet sizing arguments

### DIFF
--- a/src/hflow/ffmpeg/_contact_sheet.py
+++ b/src/hflow/ffmpeg/_contact_sheet.py
@@ -142,8 +142,16 @@ def contact_sheet(
     """Composite ``frames`` (from ``Episode.frames()``) into one JPEG grid."""
     if not frames:
         raise ValueError("contact_sheet needs at least one frame")
+    if not isinstance(columns, int) or isinstance(columns, bool):
+        raise ValueError(f"columns must be an int, got {columns!r}")
     if columns < 1:
         raise ValueError(f"columns must be >= 1, got {columns}")
+    if not isinstance(tile_width, int) or isinstance(tile_width, bool):
+        raise ValueError(f"tile_width must be an int, got {tile_width!r}")
+    if tile_width < 1:
+        raise ValueError(f"tile_width must be >= 1, got {tile_width}")
+    if not isinstance(max_tiles, int) or isinstance(max_tiles, bool):
+        raise ValueError(f"max_tiles must be an int, got {max_tiles!r}")
     if max_tiles < 1:
         raise ValueError(f"max_tiles must be >= 1, got {max_tiles}")
     selected_frames = [frames[index] for index in _evenly_sampled_indices(len(frames), max_tiles)]

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -960,6 +960,54 @@ def test_contact_sheet_rejects_empty_input(tmp_path: Path) -> None:
         contact_sheet([], tmp_path / "never.jpg")
 
 
+def _refuse_ffmpeg_for_invalid_contact_sheet_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_contact_sheet, "_find_usable_font_file", lambda: None)
+
+    def fail_if_ffmpeg_runs(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("invalid contact_sheet arguments must be refused before ffmpeg runs")
+
+    monkeypatch.setattr(_contact_sheet.subprocess, "run", fail_if_ffmpeg_runs)
+
+
+def _unreadable_frame(tmp_path: Path) -> ExtractedFrame:
+    return ExtractedFrame(path=tmp_path / "must-not-be-read.jpg", log_time_ns=0)
+
+
+@pytest.mark.parametrize("tile_width", [0, -320])
+def test_contact_sheet_rejects_non_positive_tile_width_before_ffmpeg(
+    tile_width: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
+    with pytest.raises(ValueError, match=rf"tile_width must be >= 1, got {tile_width}"):
+        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", tile_width=tile_width)
+
+
+def test_contact_sheet_rejects_boolean_columns_before_ffmpeg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
+    with pytest.raises(ValueError, match=r"columns must be an int, got True"):
+        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", columns=True)
+
+
+def test_contact_sheet_rejects_boolean_tile_width_before_ffmpeg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
+    with pytest.raises(ValueError, match=r"tile_width must be an int, got True"):
+        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", tile_width=True)
+
+
+def test_contact_sheet_rejects_boolean_max_tiles_before_ffmpeg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
+    with pytest.raises(ValueError, match=r"max_tiles must be an int, got True"):
+        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", max_tiles=True)
+
+
 def test_coding_range_is_derived_from_luma_and_selects_the_exposure_gates() -> None:
     """Trusting a container's declared range published a defect share off by a
     factor of hundreds on real footage, so the range is measured from the pixels.


### PR DESCRIPTION
## Summary

Make `contact_sheet` fail fast on invalid sizing arguments:

* require `tile_width` to be a positive integer
* reject booleans for `columns`, `tile_width`, and `max_tiles`
* add regression coverage proving that validation happens before FFmpeg is invoked

Valid inputs continue through the existing rendering path unchanged.

## Why

FFmpeg interprets zero and negative scale widths as “keep the source width.” As a result, an invalid `tile_width` can appear to succeed while quietly producing a much larger sheet than the caller requested.

Python’s `bool`-is-an-`int` relationship creates a second trap: `True` can leak into an FFmpeg filter or silently reduce `max_tiles` to one. Validating these arguments at the API boundary turns those surprises into immediate, actionable `ValueError`s without changing valid rendering behavior.

Closes #221

## Validation

* `uv sync --locked --all-extras` — resolved 63 packages; checked 60 packages
* `uv run ruff check --fix` — all checks passed
* `uv run ruff format` — 175 files left unchanged
* `uv run ty check` — all checks passed
* `uv run pytest tests/test_ffmpeg.py -q` — 62 passed, 1 skipped
* `uv run pytest -q` — 1,158 passed, 6 skipped

## Checklist

* [x] I added or updated outcome-focused tests for changed business logic.
* [x] Documentation was reviewed; no update is needed because this fix only changes invalid-argument handling.
* [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
* [x] I ran the relevant pytest suite.
* [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
* [x] I preserved stored-data compatibility.
