### PR TITLE
fix(steps): reject infinite and bool threshold values at construction

### DIFF
--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -227,11 +227,23 @@ class Threshold:
                 "threshold key_pattern must not be empty; it is a glob over "
                 "measurement keys, e.g. '*/black_frame_pct'"
             )
+        if isinstance(self.value, bool):
+            raise ValueError(
+                f"threshold value for {self.key_pattern!r} must be a number, not "
+                f"{self.value!r}: bool is accepted by float but silently compares "
+                "against 0.0 or 1.0, not the meaning the author wrote"
+            )
         if math.isnan(self.value):
             raise ValueError(
                 f"threshold value for {self.key_pattern!r} must be a number, not NaN: "
                 "every comparison against NaN is False, so this gate would reject "
                 "every episode it evaluated"
+            )
+        if math.isinf(self.value):
+            raise ValueError(
+                f"threshold value for {self.key_pattern!r} must be finite, not "
+                f"{self.value!r}: an infinite threshold accepts or rejects every "
+                "episode unconditionally, which is the same as not checking at all"
             )
 
     def holds(self, measurement: float) -> bool:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -250,3 +250,31 @@ def test_an_empty_gate_is_refused_at_construction() -> None:
 def test_a_nan_threshold_is_refused_at_construction() -> None:
     with pytest.raises(ValueError, match="not NaN"):
         hflow.Threshold("v", hflow.Comparison.AT_MOST, math.nan)
+
+
+@pytest.mark.parametrize(
+    "value,desc",
+    [
+        pytest.param(float("inf"), "+inf", id="positive_inf"),
+        pytest.param(float("-inf"), "-inf", id="negative_inf"),
+    ],
+)
+def test_an_infinite_threshold_is_refused_at_construction(
+    value: float, desc: str
+) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        hflow.Threshold("v", hflow.Comparison.AT_MOST, value)
+
+
+@pytest.mark.parametrize(
+    "value,desc",
+    [
+        pytest.param(True, "True", id="true"),
+        pytest.param(False, "False", id="false"),
+    ],
+)
+def test_a_bool_threshold_is_refused_at_construction(
+    value: bool, desc: str
+) -> None:
+    with pytest.raises(ValueError, match="not True|not False"):
+        hflow.Threshold("v", hflow.Comparison.AT_MOST, value)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -276,5 +276,5 @@ def test_an_infinite_threshold_is_refused_at_construction(
 def test_a_bool_threshold_is_refused_at_construction(
     value: bool, desc: str
 ) -> None:
-    with pytest.raises(ValueError, match="not True|not False"):
+    with pytest.raises(ValueError, match=r"not True|not False"):
         hflow.Threshold("v", hflow.Comparison.AT_MOST, value)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -259,9 +259,7 @@ def test_a_nan_threshold_is_refused_at_construction() -> None:
         pytest.param(float("-inf"), "-inf", id="negative_inf"),
     ],
 )
-def test_an_infinite_threshold_is_refused_at_construction(
-    value: float, desc: str
-) -> None:
+def test_an_infinite_threshold_is_refused_at_construction(value: float, desc: str) -> None:
     with pytest.raises(ValueError, match="must be finite"):
         hflow.Threshold("v", hflow.Comparison.AT_MOST, value)
 
@@ -273,8 +271,6 @@ def test_an_infinite_threshold_is_refused_at_construction(
         pytest.param(False, "False", id="false"),
     ],
 )
-def test_a_bool_threshold_is_refused_at_construction(
-    value: bool, desc: str
-) -> None:
+def test_a_bool_threshold_is_refused_at_construction(value: bool, desc: str) -> None:
     with pytest.raises(ValueError, match=r"not True|not False"):
         hflow.Threshold("v", hflow.Comparison.AT_MOST, value)


### PR DESCRIPTION
## What

Reject `float('inf')`, `float('-inf')`, `True`, and `False` as `Threshold.value` at construction time, following the existing NaN rejection pattern.

## Why

An infinite threshold accepts or rejects every episode unconditionally — the same as not checking at all. The existing NaN check already argues why a vacuous verdict is worth refusing at construction; infinity produces the same outcomes.

`bool` subclasses `int` in Python, so `Threshold(v, Comparison.AT_MOST, True)` silently compares against `1.0`, not the meaning the author wrote.

## How

Add two checks to `Threshold.__post_init__` in `src/hflow/steps.py`:

1. `isinstance(self.value, bool)` — checked before `math.isnan` because `bool` is a `float` subclass
2. `math.isinf(self.value)` — checked after NaN, matching the existing pattern

Each raises `ValueError` with a message matching the project style.

## Tests

Four new parametrized test cases in `tests/test_gates.py`:

- `test_an_infinite_threshold_is_refused_at_construction` — `+inf` and `-inf`
- `test_a_bool_threshold_is_refused_at_construction` — `True` and `False`

Full suite: **947 passed, 6 skipped**.

Closes #222