### PR TITLE
fix(checks): remove dead type check in trajectory_metrics and document conditional key

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1042,6 +1042,13 @@ def trajectory_metrics(
     dividing by it would inflate its own sensor jitter into apparent motion --
     inverting the metric on exactly the episodes worth catching.
 
+    ``{topic}/final_pose_unsettled_ratio`` is emitted only when
+    ``{topic}/mean_velocity`` is above zero. For a fully motionless episode the
+    ratio is undefined (zero denominator), so only ``{topic}/final_pose_speed``
+    appears. Curation queries joining on ``final_pose_unsettled_ratio`` will
+    silently exclude motionless episodes; use ``final_pose_speed`` when you need
+    all episodes regardless of mean motion.
+
     Evidence only, and this one ships no recommended gate at all: these are
     motion-smoothness metrics, which are known to invert on real defects
     (Voxel51's audit scored an early-gripper-release defect better than clean
@@ -1076,9 +1083,8 @@ def trajectory_metrics(
     valid_velocity_s = float(np.sum(measured_durations_s))
     measurements[f"{topic}/valid_velocity_s"] = valid_velocity_s
     measurements[f"{topic}/peak_velocity"] = float(np.max(measured_speeds))
-    measurements[f"{topic}/mean_velocity"] = float(
-        np.sum(measured_speeds * measured_durations_s) / valid_velocity_s
-    )
+    mean_velocity = float(np.sum(measured_speeds * measured_durations_s) / valid_velocity_s)
+    measurements[f"{topic}/mean_velocity"] = mean_velocity
     if valid_velocity_s > 0:
         motionless_s = float(
             np.sum(measured_durations_s[measured_speeds < motionless_speed_epsilon])
@@ -1100,11 +1106,12 @@ def trajectory_metrics(
         (profile.stamps_ns[-1] - profile.stamps_ns[:-1]) / 1e9 <= final_pose_window_s
     )
     if np.any(final_window_mask):
-        mean_speed = measurements[f"{topic}/mean_velocity"]
         final_speed = float(np.mean(profile.speeds[final_window_mask]))
         measurements[f"{topic}/final_pose_speed"] = final_speed
-        if isinstance(mean_speed, float) and mean_speed > 0:
-            measurements[f"{topic}/final_pose_unsettled_ratio"] = final_speed / mean_speed
+        if mean_velocity > 0:
+            # Omitted when mean_velocity == 0.0: the ratio is undefined for a
+            # fully motionless episode.
+            measurements[f"{topic}/final_pose_unsettled_ratio"] = final_speed / mean_velocity
     return CheckResult(measurements=measurements)
 
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -761,3 +761,44 @@ def test_trajectory_change_threshold_uses_a_true_weighted_median(tmp_path: Path)
     assert _duration_weighted_median(values, weights) == 2.0
     # Weight concentrated on the smallest value moves the median onto it.
     assert _duration_weighted_median(values, np.array([10.0, 1.0, 1.0])) == 1.0
+
+
+def test_trajectory_metrics_emits_unsettled_ratio_for_a_moving_episode(
+    tmp_path: Path,
+) -> None:
+    """A moving episode has mean_velocity > 0, so the unsettled ratio is
+    defined and must be emitted alongside final_pose_speed.
+    """
+    source = synthesize_episode(
+        tmp_path / "moving.mcap",
+        SyntheticEpisodeSpec(duration_s=3.0, cameras=(), joint_jump_at_s=None),
+    )
+    with hflow.Episode(source) as episode:
+        result = trajectory_metrics(episode)
+
+    assert "/joint_states/final_pose_speed" in result.measurements
+    assert "/joint_states/final_pose_unsettled_ratio" in result.measurements
+    ratio = result.measurements["/joint_states/final_pose_unsettled_ratio"]
+    assert isinstance(ratio, float)
+
+
+def test_trajectory_metrics_omits_unsettled_ratio_for_a_motionless_episode(
+    tmp_path: Path,
+) -> None:
+    """A fully frozen episode has mean_velocity == 0.0, so dividing by it
+    is undefined. final_pose_speed is still recorded; the ratio is not.
+    """
+    source = synthesize_episode(
+        tmp_path / "frozen.mcap",
+        SyntheticEpisodeSpec(
+            duration_s=3.0,
+            cameras=(),
+            joint_jump_at_s=None,
+            joint_freeze_segment=(0.0, 3.0),
+        ),
+    )
+    with hflow.Episode(source) as episode:
+        result = trajectory_metrics(episode)
+
+    assert "/joint_states/final_pose_speed" in result.measurements
+    assert "/joint_states/final_pose_unsettled_ratio" not in result.measurements


### PR DESCRIPTION
## What this PR does

Fixes a dead code issue in `trajectory_metrics` inside `src/hflow/checks.py` and adds a missing explanation in the docstring about a measurement key that is not always emitted.

## The problem

In `trajectory_metrics`, there was this condition:

```python
if isinstance(mean_speed, float) and mean_speed > 0:
    measurements[".../final_pose_unsettled_ratio"] = final_speed / mean_speed
```

The `isinstance(mean_speed, float)` check was **always True** — it could never be False. `mean_velocity` is computed and stored as `float(...)` just 26 lines earlier in the same function, so by the time we read it back, it is always a float. Having a dead check like this confuses anyone reading the code, and the type checker also warns because reading from the measurements dict gives a wider type than `float`.

The second part — `mean_speed > 0` — is the **real and necessary check**: when a robot arm is completely frozen throughout a recording, `mean_velocity` is `0.0`, and dividing by it would be undefined. So this part correctly prevents the `final_pose_unsettled_ratio` key from being emitted for motionless episodes.

The problem is this behavior was **completely undocumented**. If you wrote a curation SQL query joining on `final_pose_unsettled_ratio`, you would silently lose all motionless episodes from your results — exactly the group you might be looking for.

## What was changed

1. **Removed the dead `isinstance` check** — the condition now simply reads `if mean_velocity > 0:`, which is what it always meant.
2. **Stored `mean_velocity` in a named local variable** instead of reading it back from the measurements dict. This makes the type clear, fixes the type checker warning, and removes the unnecessary dict lookup.
3. **Updated the docstring** to clearly explain that `final_pose_unsettled_ratio` is only emitted when `mean_velocity > 0`, because the ratio is mathematically undefined when the arm never moved. Curation authors are now warned about this.
4. **Added two tests** that prove both cases:
   - A moving robot episode → both `final_pose_speed` and `final_pose_unsettled_ratio` are emitted
   - A fully frozen robot episode (`joint_freeze_segment=(0.0, 3.0)`) → only `final_pose_speed` is emitted, ratio is absent

## No behavior changes

The values emitted for any episode that already produced the ratio are **100% identical**. Nothing in the computation changed — only the dead code was removed and the variable was given a clearer name.

## Validation

```bash
uv sync --locked --all-extras
uv run ruff check --fix   # All checks passed
uv run ruff format        # 175 files left unchanged
uv run ty check           # All checks passed
uv run pytest -q          # 1163 passed, 6 skipped
```

Fixes #223
