### PR TITLE
fix(steps): reject non-finite and boolean threshold values

### DIFF
--- a/src/hflow/steps.py
+++ b/src/hflow/steps.py
@@ -227,11 +227,27 @@ class Threshold:
                 "threshold key_pattern must not be empty; it is a glob over "
                 "measurement keys, e.g. '*/black_frame_pct'"
             )
-        if math.isnan(self.value):
+        if isinstance(self.value, bool):
+            raise ValueError(f"threshold value for {self.key_pattern!r} must be a number, not bool")
+        value_is_integer = isinstance(self.value, int)
+        if not value_is_integer and math.isnan(self.value):
             raise ValueError(
                 f"threshold value for {self.key_pattern!r} must be a number, not NaN: "
                 "every comparison against NaN is False, so this gate would reject "
                 "every episode it evaluated"
+            )
+        if not value_is_integer and math.isinf(self.value):
+            accepts_every_finite_measurement = (
+                self.comparison is Comparison.AT_MOST and self.value > 0
+            ) or (self.comparison is Comparison.AT_LEAST and self.value < 0)
+            outcome = (
+                "accept every finite measurement"
+                if accepts_every_finite_measurement
+                else "reject every finite measurement"
+            )
+            raise ValueError(
+                f"threshold value for {self.key_pattern!r} must be finite, not "
+                f"{self.value}: this comparison would {outcome}"
             )
 
     def holds(self, measurement: float) -> bool:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -250,3 +250,27 @@ def test_an_empty_gate_is_refused_at_construction() -> None:
 def test_a_nan_threshold_is_refused_at_construction() -> None:
     with pytest.raises(ValueError, match="not NaN"):
         hflow.Threshold("v", hflow.Comparison.AT_MOST, math.nan)
+
+
+@pytest.mark.parametrize(
+    ("comparison", "value", "outcome"),
+    [
+        (hflow.Comparison.AT_MOST, math.inf, "accept every finite measurement"),
+        (hflow.Comparison.AT_LEAST, -math.inf, "accept every finite measurement"),
+        (hflow.Comparison.AT_LEAST, math.inf, "reject every finite measurement"),
+        (hflow.Comparison.AT_MOST, -math.inf, "reject every finite measurement"),
+    ],
+)
+def test_an_infinite_threshold_is_refused_at_construction(
+    comparison: hflow.Comparison, value: float, outcome: str
+) -> None:
+    with pytest.raises(ValueError, match=rf"threshold value.*{outcome}"):
+        hflow.Threshold("v", comparison, value)
+
+
+def test_a_boolean_threshold_is_refused_but_an_integer_is_accepted() -> None:
+    with pytest.raises(ValueError, match=r"threshold value.*not bool"):
+        hflow.Threshold("v", hflow.Comparison.AT_MOST, True)
+
+    assert hflow.Threshold("v", hflow.Comparison.AT_MOST, 0).value == 0
+    assert hflow.Threshold("v", hflow.Comparison.AT_MOST, 2**1024).value == 2**1024


### PR DESCRIPTION
## Summary

- reject boolean threshold values before numeric validation
- reject positive and negative infinity with outcome-specific errors
- keep finite integer thresholds, including `0`, working unchanged

Closes #222

## Validation

- `uv run ruff check --fix`
- `uv run ruff format --check`
- `uv run ty check`
- `uv run pytest -q` — 1171 passed, 6 skipped