### PR TITLE
refactor(app): type step and transform kinds

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -26,6 +26,7 @@ import time
 import traceback
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType, ModuleType
 from typing import TYPE_CHECKING
@@ -236,6 +237,13 @@ _MEDIA_CONTACT_SHEET_FPS = 0.5
 _SYNC_COMPLETION_MARKER_NAME = ".sync-complete.json"
 
 
+class _TransformKind(StrEnum):
+    """Transform implementations recorded in sync-reuse witnesses."""
+
+    DEFAULT = "default"
+    OVERRIDE = "override"
+
+
 @dataclass(frozen=True)
 class _SyncCompletion:
     """Proof that sync completed for one source path and canonical version.
@@ -259,11 +267,11 @@ class _SyncCompletion:
     # The transform is stamped with an ffmpeg version that does NOT reach
     # pipeline_version, and different builds genuinely encode differently.
     ffmpeg_version: str | None = None
-    # "default" or "override". An @app.transform override is contractually
-    # required to end in write_canonical_episode, so it stamps the SAME
-    # pipeline_version the default transform would: without this, REMOVING an
-    # override would reuse a canonical the current pipeline cannot produce.
-    transform_kind: str | None = None
+    # An @app.transform override is contractually required to end in
+    # write_canonical_episode, so it stamps the SAME pipeline_version the
+    # default transform would: without this, REMOVING an override would reuse
+    # a canonical the current pipeline cannot produce.
+    transform_kind: _TransformKind | None = None
 
 
 def _source_identity(source_reference: Path | str, storage_root: StorageRoot) -> str:
@@ -372,10 +380,24 @@ def _read_sync_completion_marker(marker_path: Path) -> _SyncCompletion:
     # the non-sync stages, which never needed a witness at all.
     optional_values = {
         field_name: value
-        for field_name in ("source_digest", "ffmpeg_version", "transform_kind")
+        for field_name in ("source_digest", "ffmpeg_version")
         if isinstance(value := marker_payload.get(field_name), str) and value
     }
-    return _SyncCompletion(**required_values, **optional_values)
+    raw_transform_kind = marker_payload.get("transform_kind")
+    transform_kind: _TransformKind | None = None
+    if isinstance(raw_transform_kind, str) and raw_transform_kind:
+        try:
+            transform_kind = _TransformKind(raw_transform_kind)
+        except ValueError:
+            transform_kind = None
+    return _SyncCompletion(
+        source_path=required_values["source_path"],
+        schema_version=required_values["schema_version"],
+        pipeline_version=required_values["pipeline_version"],
+        source_digest=optional_values.get("source_digest"),
+        ffmpeg_version=optional_values.get("ffmpeg_version"),
+        transform_kind=transform_kind,
+    )
 
 
 def _file_digest(path: Path) -> str:
@@ -588,22 +610,34 @@ def _unsatisfiable_check_parameters(
     return unsatisfiable, seen_episode or sees_varargs
 
 
+class _RegistrationStepKind(StrEnum):
+    """Registration diagnostics vocabulary, separate from manifest step kinds.
+
+    Derived channels appear here but are not manifest steps. Keep this private
+    type distinct from ``manifest.StepKind`` even though two values overlap.
+    """
+
+    CHECK = "check"
+    ENRICHMENT = "enrichment"
+    DERIVED_CHANNEL = "derived channel"
+
+
 # Every step below is invoked with exactly one positional argument, an Episode:
 # checks and enrichments with the canonical episode, derived-signal functions
 # with the source episode. So all three share one satisfiability rule, and the
 # only thing that differs is what the example in the message should say.
-_STEP_EXAMPLE_BY_KIND = {
+_STEP_EXAMPLE_BY_KIND: dict[_RegistrationStepKind, tuple[str, str]] = {
     # step kind -> (return annotation, wrapper-name suffix)
-    "check": ("hflow.CheckResult", "check"),
-    "enrichment": ("hflow.EnrichmentResult", "enrichment"),
-    "derived channel": ("hflow.DerivedSeries", "series"),
+    _RegistrationStepKind.CHECK: ("hflow.CheckResult", "check"),
+    _RegistrationStepKind.ENRICHMENT: ("hflow.EnrichmentResult", "enrichment"),
+    _RegistrationStepKind.DERIVED_CHANNEL: ("hflow.DerivedSeries", "series"),
 }
 
 
 def _raise_if_step_cannot_take_only_an_episode(
     function: Callable[..., object],
     *,
-    step_kind: str,
+    step_kind: _RegistrationStepKind,
     step_name: str,
     decorator: str,
 ) -> None:
@@ -626,7 +660,7 @@ def _raise_if_step_cannot_take_only_an_episode(
         sorted_names = sorted(unsatisfiable)
         bindings = ", ".join(f"{parameter_name}=..." for parameter_name in sorted_names)
         raise ValueError(
-            f"{step_kind} {step_name!r} cannot be called with only an episode: "
+            f"{step_kind.value} {step_name!r} cannot be called with only an episode: "
             f"required parameter(s) without defaults: {', '.join(sorted_names)}. "
             "Wrap it in a function that binds them, e.g.\n\n"
             f"    {decorator}\n"
@@ -635,7 +669,7 @@ def _raise_if_step_cannot_take_only_an_episode(
         )
     if not accepts_episode:
         raise ValueError(
-            f"{step_kind} {step_name!r} cannot accept the episode: it must take "
+            f"{step_kind.value} {step_name!r} cannot accept the episode: it must take "
             "the episode as its first positional parameter, e.g.\n\n"
             f"    {decorator}\n"
             f"    def {wrapper_name}(ep: hflow.Episode) -> {return_type}:\n"
@@ -1121,7 +1155,7 @@ class App:
             completion = _read_sync_completion_marker(marker_path)
         except (FileNotFoundError, ValueError, OSError):
             return None
-        if completion.transform_kind != "default":
+        if completion.transform_kind is not _TransformKind.DEFAULT:
             return None
         if completion.source_path != source_identifier:
             # Two sources can share a run directory when output_dir= names one.
@@ -1382,7 +1416,7 @@ class App:
                 raise ValueError(f"a step named {check_name!r} is already registered")
             _raise_if_step_cannot_take_only_an_episode(
                 function,
-                step_kind="check",
+                step_kind=_RegistrationStepKind.CHECK,
                 step_name=check_name,
                 decorator='@app.check(version="1")',
             )
@@ -1436,7 +1470,7 @@ class App:
                 raise ValueError(f"a step named {enrichment_name!r} is already registered")
             _raise_if_step_cannot_take_only_an_episode(
                 function,
-                step_kind="enrichment",
+                step_kind=_RegistrationStepKind.ENRICHMENT,
                 step_name=enrichment_name,
                 decorator='@app.enrich(version="1")',
             )
@@ -1474,7 +1508,7 @@ class App:
                 raise ValueError(f"a derived channel for topic {topic!r} is already registered")
             _raise_if_step_cannot_take_only_an_episode(
                 function,
-                step_kind="derived channel",
+                step_kind=_RegistrationStepKind.DERIVED_CHANNEL,
                 step_name=topic,
                 decorator=f'@app.derive("{topic}", version="1")',
             )
@@ -1935,7 +1969,9 @@ class App:
                         source_digest=source_digest,
                         ffmpeg_version=stamps.ffmpeg_version,
                         transform_kind=(
-                            "override" if self.transform_override is not None else "default"
+                            _TransformKind.OVERRIDE
+                            if self.transform_override is not None
+                            else _TransformKind.DEFAULT
                         ),
                     ),
                 )

--- a/tests/test_sync_reuse.py
+++ b/tests/test_sync_reuse.py
@@ -7,6 +7,8 @@ out, because a wrong reuse silently publishes stale bytes under a current
 version stamp.
 """
 
+import hashlib
+import json
 import os
 from pathlib import Path
 
@@ -40,6 +42,27 @@ def test_an_unchanged_source_is_not_transcoded_twice(tmp_path: Path) -> None:
     # The canonical file was not rewritten, which is the whole point.
     assert second.canonical_path.stat().st_mtime_ns == mtime_after_first
     assert first.stamps == second.stamps
+
+
+def test_sync_completion_marker_keeps_its_existing_json_bytes(tmp_path: Path) -> None:
+    """Typing the witness must not change its persisted wire representation."""
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("marker-bytes", data_root=tmp_path / "data", default_checks=())
+
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    expected_payload = {
+        "ffmpeg_version": first.stamps.ffmpeg_version,
+        "pipeline_version": first.stamps.pipeline_version,
+        "schema_version": first.stamps.schema_version,
+        "source_digest": f"sha256:{hashlib.sha256(source.read_bytes()).hexdigest()}",
+        "source_path": str(source.resolve()),
+        "transform_kind": "default",
+    }
+
+    assert (
+        marker_path.read_bytes() == (json.dumps(expected_payload, sort_keys=True) + "\n").encode()
+    )
 
 
 def test_the_reused_run_still_records_the_same_episode(tmp_path: Path) -> None:
@@ -101,8 +124,6 @@ def test_a_changed_transform_config_is_transcoded_again(tmp_path: Path) -> None:
 
 def test_a_marker_without_a_witness_transcodes_once_and_gains_one(tmp_path: Path) -> None:
     """The whole migration for corpora written before the witness existed."""
-    import json
-
     source = _episode(tmp_path / "episode_0001.mcap")
     app = hflow.App("legacy", data_root=tmp_path / "data", default_checks=())
     first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
@@ -120,6 +141,32 @@ def test_a_marker_without_a_witness_transcodes_once_and_gains_one(tmp_path: Path
 
     third = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
     assert third.sync_reused is True
+
+
+@pytest.mark.parametrize(
+    "raw_transform_kind", [None, "future-transform"], ids=["missing", "unknown"]
+)
+def test_a_marker_without_a_known_transform_kind_stays_readable_but_is_not_reused(
+    tmp_path: Path, raw_transform_kind: str | None
+) -> None:
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("unknown-kind", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    marker_payload = json.loads(marker_path.read_text())
+    if raw_transform_kind is None:
+        marker_payload.pop("transform_kind")
+    else:
+        marker_payload["transform_kind"] = raw_transform_kind
+    marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    # Non-sync stages still accept old or future markers: the transform kind
+    # is a reuse witness, not part of the marker's basic readability contract.
+    metadata_only = app.process(source, record=False, stages={hflow.Stage.META}, verbose=False)
+    assert metadata_only.canonical_path == first.canonical_path
+
+    second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert second.sync_reused is False
 
 
 def test_deleting_the_marker_is_the_way_to_force_a_retranscode(tmp_path: Path) -> None:
@@ -156,7 +203,9 @@ def test_a_registered_transform_override_never_reuses(tmp_path: Path) -> None:
     def passthrough(source_path: Path, output_path: Path, config: TransformConfig) -> EpisodeStamps:
         return write_canonical_episode(source_path, output_path, config)
 
-    app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    assert json.loads(marker_path.read_text())["transform_kind"] == "override"
     second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
 
     assert second.sync_reused is False


### PR DESCRIPTION
## Summary

* replace the registration-only string literals with a private `_RegistrationStepKind` enum, deliberately kept separate from the serialized `StepKind` vocabulary
* represent sync completion transform witnesses with `_TransformKind` instead of raw strings
* preserve lenient marker parsing: missing or unrecognized transform kinds remain readable but safely disable canonical reuse

This gives each finite vocabulary one owner while turning misspellings into type-checking failures rather than runtime failures inside diagnostic handling.

## Compatibility

The sync completion marker remains byte-for-byte compatible with current `main`: the persisted values are still exactly `"default"` and `"override"`.

Markers with a missing or unknown `transform_kind` remain valid for non-sync stages and continue to fail closed for reuse. `StepKind`, `PIPELINE_MANIFEST_VERSION`, and transform behavior versions are unchanged because no serialized values or canonical episode bytes change.

## Tests

* pin the exact JSON bytes written for a default transform
* verify an override is still persisted as `"override"`
* verify missing and unknown transform kinds remain readable
* verify both cases prevent canonical reuse

## Validation

* `uv sync --locked --all-extras`
* `uv run ruff check --fix`
* `uv run ruff format`
* `uv run ty check`
* `uv run pytest -q` — 1169 passed, 6 skipped
* `uv run --python 3.11 --locked pytest -q` — 1169 passed, 6 skipped
* `uv run --python 3.14 --locked pytest -q` — 1169 passed, 6 skipped

Closes #225
