### PR TITLE
docs: document doctor finding codes

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -153,11 +153,45 @@ A file claiming this convention must satisfy, in increasing strictness:
 4. **Video constraints**: every `foxglove.CompressedVideo` message is one Annex B access unit beginning with an AUD; every IDR access unit contains SPS and PPS; no B-frames; `format="h264"`.
 5. **Stamps**: `provenance/v1` present with `schema_version` and `pipeline_version`.
 
-`hflow doctor <file.mcap> [more.mcap ...]` executes these checks against every
-file given, printing one report each in argument order, and exits with status 0
-when all files conform or 1 when any reports violations. An unreadable or
-unparseable path is reported in place, in the same per-file shape (`[error]
-unreadable: ...`), and the run continues with the remaining files.
+`hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
+one report each in argument order; its aggregate result follows the
+[exit code rules](#exit-codes). It validates the container, summary, indexes,
+stamps, per-topic time order, and the H.264 access-unit properties listed
+below. It does not currently classify H.264 picture coding types to detect
+B-frames, so a clean report is not proof of the unchecked no-B-frame
+constraint. The doctor also does not reject non-VCL NAL units before the first
+AUD, so a clean report does not prove the canonical AUD-first constraint. An
+unreadable or unparseable path is reported in place, in the same per-file shape
+(`[error] unreadable: ...`), and the run continues with the remaining files.
+
+### Doctor finding codes
+
+Finding codes are stable, kebab-case identifiers suitable for matching in
+automation. An `error` breaks the canonical convention (or the MCAP spec); a
+`warning` is legal but differs from the layout HFlow writes by default.
+
+| Code | Level | Reported when |
+|---|---|---|
+| `unreadable` | error | The path cannot be opened or parsed as an MCAP file. |
+| `no-summary` | error | The file has no summary section. |
+| `no-statistics` | error | The summary has no `Statistics` record. |
+| `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
+| `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
+| `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels; custom grouping can make this intentional. |
+| `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
+| `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |
+| `missing-episode-record` | warning | The optional `episode/v1` semantics record is absent. |
+| `topic-time-order` | error | A channel's `log_time` decreases between messages. |
+| `video-format` | error | A supported video message does not declare `format="h264"`. |
+| `video-invalid-slice-header` | error | The H.264 payload's picture count cannot be determined from its slice headers. |
+| `video-multiple-access-units` | error | A video message contains more than one picture or access unit. |
+| `video-not-aud-delimited` | error | No AUD is present, or VCL data precedes the first AUD. |
+| `video-keyframe-missing-parameter-sets` | error | A keyframe does not carry both SPS and PPS. |
+| `video-stream-starts-mid-gop` | error | A video channel's first message is not a keyframe. |
+| `read-failed` | error | Full message reading, CRC validation, or video decoding fails. |
+
+At most three findings with the same code are printed. The report then gives
+the number of further occurrences suppressed for that code.
 
 ### Exit codes
 


### PR DESCRIPTION
## Summary

- document every finding code currently emitted by `hflow doctor`, including its severity and trigger
- clarify that a clean report does not currently prove the no-B-frame or strict AUD-first constraints
- link the doctor command description to the shared exit-code rules

## Why

`docs/FORMAT.md` currently implies that `doctor` checks every listed H.264 constraint and does not document its stable codes for automation. This closes #10 without changing runtime behavior or the canonical format.

## Validation

- `uv run ruff check --fix` — passed
- `uv run ruff format` — 176 files left unchanged
- `uv run ty check` — passed
- `uv run pytest -q` — 1176 passed, 6 skipped (with the repository's pinned ffmpeg/ffprobe prerequisites configured)
- `lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .` — 337 checked, 333 OK, 4 excluded, 0 errors
- `git diff --check FETCH_HEAD..HEAD` — passed

## Checklist

- [x] Outcome-focused tests are not applicable because this changes documentation only.
- [x] I updated documentation for the described format and command behavior.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is preserved; this changes no runtime behavior or format bytes.
