### PR TITLE
fix(storage): refuse empty local paths and bucketless URLs (#238)

### DIFF
--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -408,7 +408,7 @@ class BucketStorageRoot:
     ) -> None:
         normalized_url = url.rstrip("/")
         _scheme, separator, remainder = normalized_url.partition("://")
-        if not separator or not remainder.partition("/")[0]:
+        if not separator or (_scheme.lower() != "file" and not remainder.partition("/")[0]):
             raise ValueError(
                 f"bucket URL {url!r} names no bucket/container -- expected e.g. gs://bucket/prefix"
             )

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -408,6 +408,11 @@ class BucketStorageRoot:
     ) -> None:
         normalized_url = url.rstrip("/")
         _scheme, separator, remainder = normalized_url.partition("://")
+        # The bucket is the remainder up to the first slash, so gs:///prefix
+        # names none and is refused the same way gs:// is. file:// is exempt
+        # because its authority is empty by construction: the tests simulate a
+        # bucket with file://<abs path> (tests/conftest.py), and requiring an
+        # authority there fails 3 tests and errors 19 more.
         if not separator or (_scheme.lower() != "file" and not remainder.partition("/")[0]):
             raise ValueError(
                 f"bucket URL {url!r} names no bucket/container -- expected e.g. gs://bucket/prefix"

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -408,7 +408,7 @@ class BucketStorageRoot:
     ) -> None:
         normalized_url = url.rstrip("/")
         _scheme, separator, remainder = normalized_url.partition("://")
-        if not separator or not remainder:
+        if not separator or not remainder.partition("/")[0]:
             raise ValueError(
                 f"bucket URL {url!r} names no bucket/container -- expected e.g. gs://bucket/prefix"
             )
@@ -631,6 +631,8 @@ def parse_storage_root(value: "str | Path | StorageRoot") -> StorageRoot:
         return LocalStorageRoot(value)
     scheme, separator, remainder = value.partition("://")
     if not separator:
+        if not value.strip():
+            raise ValueError(f"storage root {value!r} must be a directory path or bucket URL")
         return LocalStorageRoot(Path(value))
     normalized_scheme = scheme.lower()
     if normalized_scheme == "file":

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -34,6 +34,7 @@ class TestParseStorageRoot:
     def test_path_and_plain_string_are_local(self) -> None:
         assert parse_storage_root(Path("/tmp/x")) == LocalStorageRoot(Path("/tmp/x"))
         assert parse_storage_root("./data") == LocalStorageRoot(Path("./data"))
+        assert parse_storage_root(".") == LocalStorageRoot(Path("."))
 
     def test_existing_roots_pass_through(self) -> None:
         local_root = LocalStorageRoot(Path("/tmp/x"))
@@ -61,6 +62,16 @@ class TestParseStorageRoot:
     def test_bucketless_url_is_refused(self) -> None:
         with pytest.raises(ValueError, match="names no bucket"):
             parse_storage_root("s3://")
+        with pytest.raises(ValueError, match="names no bucket"):
+            parse_storage_root("gs:///x")
+        with pytest.raises(ValueError, match="names no bucket"):
+            parse_storage_root("gs:////x")
+
+    def test_empty_local_path_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="storage root .* must be a directory path or bucket URL"):
+            parse_storage_root("")
+        with pytest.raises(ValueError, match="storage root '   ' must be a directory path or bucket URL"):
+            parse_storage_root("   ")
 
     def test_is_bucket_url(self) -> None:
         assert is_bucket_url("gs://b/x.mcap")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -34,7 +34,7 @@ class TestParseStorageRoot:
     def test_path_and_plain_string_are_local(self) -> None:
         assert parse_storage_root(Path("/tmp/x")) == LocalStorageRoot(Path("/tmp/x"))
         assert parse_storage_root("./data") == LocalStorageRoot(Path("./data"))
-        assert parse_storage_root(".") == LocalStorageRoot(Path("."))
+        assert parse_storage_root(".") == LocalStorageRoot(Path())
 
     def test_existing_roots_pass_through(self) -> None:
         local_root = LocalStorageRoot(Path("/tmp/x"))
@@ -68,7 +68,7 @@ class TestParseStorageRoot:
             parse_storage_root("gs:////x")
 
     def test_empty_local_path_is_refused(self) -> None:
-        with pytest.raises(ValueError, match="storage root .* must be a directory path or bucket URL"):
+        with pytest.raises(ValueError, match=r"storage root .* must be a directory path or bucket URL"):
             parse_storage_root("")
         with pytest.raises(ValueError, match="storage root '   ' must be a directory path or bucket URL"):
             parse_storage_root("   ")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -68,9 +68,13 @@ class TestParseStorageRoot:
             parse_storage_root("gs:////x")
 
     def test_empty_local_path_is_refused(self) -> None:
-        with pytest.raises(ValueError, match=r"storage root .* must be a directory path or bucket URL"):
+        with pytest.raises(
+            ValueError, match=r"storage root .* must be a directory path or bucket URL"
+        ):
             parse_storage_root("")
-        with pytest.raises(ValueError, match="storage root '   ' must be a directory path or bucket URL"):
+        with pytest.raises(
+            ValueError, match="storage root '   ' must be a directory path or bucket URL"
+        ):
             parse_storage_root("   ")
 
     def test_is_bucket_url(self) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -67,6 +67,17 @@ class TestParseStorageRoot:
         with pytest.raises(ValueError, match="names no bucket"):
             parse_storage_root("gs:////x")
 
+    def test_a_file_url_still_builds_a_bucket_root_directly(self) -> None:
+        """The exemption the bucket fixtures stand on.
+
+        ``file://<abs path>`` has an empty authority by construction, so the
+        bucket check has to skip it. Every bucket test simulates its store this
+        way (see this module's docstring and ``tests/conftest.py``); requiring
+        an authority here fails 3 tests and errors 19 more, none of which name
+        the URL as the cause.
+        """
+        assert BucketStorageRoot("file:///tmp/remote").url == "file:///tmp/remote"
+
     def test_empty_local_path_is_refused(self) -> None:
         with pytest.raises(
             ValueError, match=r"storage root .* must be a directory path or bucket URL"


### PR DESCRIPTION
Fixes #238

## Summary

This change ensures that `parse_storage_root` enforces stricter input validation at the data-root boundary. It explicitly refuses empty/whitespace-only local paths and safely intercepts bucket URLs that are missing an actual bucket name (e.g., `gs:///x`).

## Why

Prior to this fix, two types of erroneous input were failing silently:

1. **Empty Local Paths**: An empty data root (like `data_root = ""`) was interpreted equally as `Path(".")`, causing canonical outputs and episode data to be silently written to the working directory (often the repository itself).
2. **Missing Buckets with Trailing Slashes**: Bucket URLs mimicking `gs:///nobucket` or `gs:////x` slipped past the `obstore` config boundary. A missed bucket generated highly obscure errors downstream during fetch/publish sequences inside `obstore` rather than during configuration validation.

Adding straightforward parameter validation ensures we catch typos transparently and safely limit unintended filesystem writes.

## Validation

- Tested empty and whitespace strings: `parse_storage_root("")` and `parse_storage_root("   ")`.
- Asserted identical functionality for purely relative representations (`.` and `./data`) and existing `Path` instances.
- Ensured standard paths like `gs://bucket/prefix` continued parsing correctly.
- Ran the core test validations in the repo via terminal:

```bash
uv sync --locked --all-extras
uv run ruff check --fix
uv run ruff format
uv run ty check
uv run pytest -q tests/test_storage.py
```

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.