### PR TITLE
Sharpen video-measurement boundary guard to catch all hflow import forms

### DIFF
--- a/tests/test_video_measurement_boundary.py
+++ b/tests/test_video_measurement_boundary.py
@@ -6,23 +6,51 @@ from pathlib import Path
 import hflow._video_measurements as video_measurements
 import hflow.ffmpeg as hflow_ffmpeg
 
+_PACKAGE_MUST_STAY_STANDALONE = (
+    "The video-measurements package must not import hflow or any hflow.* "
+    "submodule. It is designed to be extracted into a standalone package, and "
+    "one import in the other direction -- reaching for an Episode or a catalog "
+    "key from a measurement module -- would break that extraction. Import the "
+    "HFlow domain from core into this package, never from this package back "
+    "into core."
+)
+
+
+def _forbidden_imports(source_path: Path) -> list[str]:
+    syntax_tree = ast.parse(source_path.read_text(), filename=str(source_path))
+    forbidden: list[str] = []
+    for syntax_node in ast.walk(syntax_tree):
+        if isinstance(syntax_node, ast.Import):
+            for imported_alias in syntax_node.names:
+                if imported_alias.name == "hflow" or imported_alias.name.startswith("hflow."):
+                    forbidden.append(f"import {imported_alias.name}")
+        elif isinstance(syntax_node, ast.ImportFrom):
+            if syntax_node.level > 0:
+                continue
+            imported_module = syntax_node.module
+            if imported_module is not None and (
+                imported_module == "hflow" or imported_module.startswith("hflow.")
+            ):
+                forbidden.append(f"from {imported_module} import ...")
+    return forbidden
+
 
 def test_video_measurements_do_not_import_hflow_domain_modules() -> None:
     package_directory = Path(video_measurements.__file__).parent
     forbidden_imports_by_source: dict[str, list[str]] = {}
-    for source_path in package_directory.glob("*.py"):
-        syntax_tree = ast.parse(source_path.read_text(), filename=str(source_path))
-        forbidden_imports = [
-            imported_module
-            for syntax_node in ast.walk(syntax_tree)
-            if isinstance(syntax_node, ast.ImportFrom)
-            and (imported_module := syntax_node.module) is not None
-            and (imported_module == "hflow" or imported_module.startswith("hflow."))
-        ]
-        if forbidden_imports:
-            forbidden_imports_by_source[source_path.name] = forbidden_imports
+    for source_path in package_directory.rglob("*.py"):
+        forbidden = _forbidden_imports(source_path)
+        if forbidden:
+            forbidden_imports_by_source[source_path.name] = forbidden
 
-    assert forbidden_imports_by_source == {}
+    assert forbidden_imports_by_source == {}, (
+        f"{_PACKAGE_MUST_STAY_STANDALONE}\n"
+        "Offending imports: "
+        + ", ".join(
+            f"{source}: {', '.join(imports)}"
+            for source, imports in forbidden_imports_by_source.items()
+        )
+    )
 
 
 def test_ffmpeg_namespace_no_longer_exposes_the_incubating_measurements() -> None:


### PR DESCRIPTION
fixes #240 

# Video Measurement Boundary Guard

## What this is

`tests/test_video_measurement_boundary.py` enforces an architectural invariant for
`src/hflow/_video_measurements/`: this package must have **zero dependency** on
`hflow` core (episodes, checks, catalog keys, gates, or binary-download policy),
so that it can eventually be split out as a standalone package. The package's own
`__init__.py` docstring already makes this claim — this test is what actually
checks it.

There is no user-visible runtime change. This PR only sharpens the existing guard.

## What changed

Previously the guard only caught `ImportFrom`-style imports (e.g.
`from hflow import Ep`). It now parses every file in the package with `ast` and
catches **any** form of an `hflow` import from inside the package, including:

- `import hflow`
- `import hflow.episode`
- `import hflow.episode as ep`
- `from hflow import Ep`
- `from hflow.episode import Ep`

### What stays green (by design)

- Docstring/comment/string mentions of `HFlow` (e.g. the package's own
  `__init__.py` docstring) — the check is AST-based, not text-based, so prose
  never trips it.
- Relative imports within the package, e.g. `from ._frame_statistics import ...`
  — this is the normal, expected pattern and remains allowed.
- Recursive discovery via `rglob` covers nested modules, so new files added
  under the package are automatically checked.

### Failure message

When the guard trips, the failure names the offending file and the exact
import statement, and restates why the rule exists — since whoever hits this
is likely seeing the constraint for the first time.

## Why

The one-way dependency (core → package, never package → core) has been a
recurring review point:

- [[#219](https://github.com/Hebbian-Robotics/hflow/issues/219)](https://github.com/Hebbian-Robotics/hflow/issues/219)
- [[#220](https://github.com/Hebbian-Robotics/hflow/issues/220)](https://github.com/Hebbian-Robotics/hflow/issues/220)
- [[#226](https://github.com/Hebbian-Robotics/hflow/pull/226)](https://github.com/Hebbian-Robotics/hflow/pull/226)

A single import in the wrong direction would quietly break the extractability
of this package and reads as an innocuous line in review. Encoding the
invariant as a test means it's enforced automatically instead of re-checked by
hand on every PR.

Closes #240.

## Scope

Limited to the guard test itself. Core importing from the package is untouched
— that direction is not what this invariant is about.

## Validation

Run from the repo root on the feature branch:

```bash
uv run ruff check --fix        # passed — All checks passed!
uv run ruff format --check     # 1 file already formatted
uv run ty check tests/test_video_measurement_boundary.py   # All checks passed!
```

**Tripwire proof:**
1. Temporarily added `import hflow` to `src/hflow/_video_measurements/_toolchain.py`
   → guard failed, naming `_toolchain.py: import hflow`.
2. Removed it → guard passed again.
3. Probed all five forbidden import forms (`import hflow`, `import hflow.foo`,
   `import hflow.foo as a`, `from hflow import Ep`, `from hflow.episode import Ep`)
   — all caught.
4. Confirmed `from ._frame_statistics import ...` stays allowed and the
   `__init__.py` docstring mention of "HFlow" stays green.

**Full suite:** could not be run natively on this checkout (Windows). `import hflow`
fails there due to the missing `fcntl` module (per `CONTRIBUTING.md`), so
`uv run pytest -q` errors at collection. The guard itself is a pure-`ast` check
that never imports `hflow`, and was validated with a standalone harness that
reads the package files directly. CI (Linux) runs the full suite, including
this guard.

## Checklist

- [x] Added/updated outcome-focused tests for changed business logic.
- [x] Updated documentation for changed behavior, flags, formats, or requirements.
- [x] Ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] Ran the relevant pytest suite.
- [x] No recordings, generated media, credentials, private URLs, or runtime artifacts added.
- [x] Preserved stored-data compatibility (test-only change; no stored-data impact).