### PR TITLE
fix(doctor): report chunks out of time order within a group (#239)

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -156,13 +156,14 @@ A file claiming this convention must satisfy, in increasing strictness:
 `hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
-stamps, per-topic time order, and the H.264 access-unit properties listed
-below. It does not currently classify H.264 picture coding types to detect
-B-frames, so a clean report is not proof of the unchecked no-B-frame
-constraint. The doctor also does not reject non-VCL NAL units before the first
-AUD, so a clean report does not prove the canonical AUD-first constraint. An
-unreadable or unparseable path is reported in place, in the same per-file shape
-(`[error] unreadable: ...`), and the run continues with the remaining files.
+per-group chunk time order, stamps, per-topic time order, and the H.264
+access-unit properties listed below. It does not currently classify H.264
+picture coding types to detect B-frames, so a clean report is not proof of the
+unchecked no-B-frame constraint. The doctor also does not reject non-VCL NAL
+units before the first AUD, so a clean report does not prove the canonical
+AUD-first constraint. An unreadable or unparseable path is reported in place,
+in the same per-file shape (`[error] unreadable: ...`), and the run continues
+with the remaining files.
 
 ### Doctor finding codes
 
@@ -178,6 +179,7 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
 | `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
 | `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels; custom grouping can make this intentional. |
+| `chunk-group-out-of-time-order` | warning | Within one group, a later `ChunkIndex` has an earlier `message_start_time` than the group's preceding chunk; readers seeking a time range assume each group's chunk sequence is time-ordered. |
 | `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
 | `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |
 | `missing-episode-record` | warning | The optional `episode/v1` semantics record is absent. |

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -30,6 +30,7 @@ from hflow.format import (
     PASSTHROUGH_VIDEO_SCHEMA_NAMES,
     PROVENANCE_KEY_PIPELINE_VERSION,
     PROVENANCE_KEY_SCHEMA_VERSION,
+    PROVENANCE_KEY_TOPIC_GROUP_PREFIX,
 )
 from hflow.storage import fetch_uri
 
@@ -211,6 +212,40 @@ def diagnose(path: Path | str) -> DoctorReport:
             if schema_name in PASSTHROUGH_VIDEO_SCHEMA_NAMES
         }
 
+        metadata_records = {record.name: dict(record.metadata) for record in reader.iter_metadata()}
+        provenance = metadata_records.get(METADATA_RECORD_PROVENANCE)
+        if provenance is None:
+            collector.add(
+                DiagnosticLevel.ERROR,
+                "missing-provenance",
+                f"no {METADATA_RECORD_PROVENANCE!r} metadata record (version stamps)",
+            )
+        else:
+            for required_key in (PROVENANCE_KEY_SCHEMA_VERSION, PROVENANCE_KEY_PIPELINE_VERSION):
+                if required_key not in provenance:
+                    collector.add(
+                        DiagnosticLevel.ERROR,
+                        "provenance-missing-key",
+                        f"{METADATA_RECORD_PROVENANCE} lacks {required_key!r}",
+                    )
+        if METADATA_RECORD_EPISODE not in metadata_records:
+            collector.add(
+                DiagnosticLevel.WARNING,
+                "missing-episode-record",
+                f"no {METADATA_RECORD_EPISODE!r} metadata record (task/operator/success "
+                "semantics live there)",
+            )
+
+        # The resolved topic-to-group map every canonical episode records in
+        # provenance/v1. It is the map FORMAT.md's chunk-layout rules are
+        # written in terms of, so the doctor checks against what the file
+        # itself declares rather than guessing from chunk membership alone.
+        group_by_topic: dict[str, str] = {}
+        for key, group_name in (provenance or {}).items():
+            if key.startswith(PROVENANCE_KEY_TOPIC_GROUP_PREFIX):
+                topic = key[len(PROVENANCE_KEY_TOPIC_GROUP_PREFIX) :]
+                group_by_topic[topic] = group_name
+
         if summary.statistics is None:
             collector.add(
                 DiagnosticLevel.ERROR, "no-statistics", "summary has no Statistics record"
@@ -221,6 +256,14 @@ def diagnose(path: Path | str) -> DoctorReport:
                 "no-chunk-indexes",
                 "no ChunkIndex records: the file is unchunked or unindexed",
             )
+        # FORMAT.md item 3's second half: within a group, chunks must be
+        # time-ordered, because a reader seeking a time range skips chunks on
+        # the assumption that later chunks start later. Reported once per group
+        # so the finding cap cannot hide affected groups behind a suppression
+        # count. Chunks in different groups may interleave in any order; only
+        # order within one group is the rule.
+        previous_chunk_start_by_group: dict[str, int] = {}
+        groups_out_of_time_order: set[str] = set()
         for chunk_number, chunk_index in enumerate(summary.chunk_indexes):
             chunk_channel_ids = set(chunk_index.message_index_offsets.keys())
             if not chunk_channel_ids:
@@ -245,29 +288,29 @@ def diagnose(path: Path | str) -> DoctorReport:
                     "the default convention separates them",
                 )
 
-        metadata_records = {record.name: dict(record.metadata) for record in reader.iter_metadata()}
-        provenance = metadata_records.get(METADATA_RECORD_PROVENANCE)
-        if provenance is None:
-            collector.add(
-                DiagnosticLevel.ERROR,
-                "missing-provenance",
-                f"no {METADATA_RECORD_PROVENANCE!r} metadata record (version stamps)",
-            )
-        else:
-            for required_key in (PROVENANCE_KEY_SCHEMA_VERSION, PROVENANCE_KEY_PIPELINE_VERSION):
-                if required_key not in provenance:
+            chunk_groups = {
+                group_name
+                for channel_id in chunk_channel_ids
+                if (topic := topics_by_channel_id.get(channel_id)) is not None
+                and (group_name := group_by_topic.get(topic)) is not None
+            }
+            if len(chunk_groups) == 1:
+                (group_name,) = chunk_groups
+                previous_start = previous_chunk_start_by_group.get(group_name)
+                if (
+                    previous_start is not None
+                    and chunk_index.message_start_time < previous_start
+                    and group_name not in groups_out_of_time_order
+                ):
                     collector.add(
-                        DiagnosticLevel.ERROR,
-                        "provenance-missing-key",
-                        f"{METADATA_RECORD_PROVENANCE} lacks {required_key!r}",
+                        DiagnosticLevel.WARNING,
+                        "chunk-group-out-of-time-order",
+                        f"group {group_name!r}: chunk starts descend across the sequence "
+                        f"({previous_start} -> {chunk_index.message_start_time}); a reader "
+                        "seeking a time range expects each group's chunks to be time-ordered",
                     )
-        if METADATA_RECORD_EPISODE not in metadata_records:
-            collector.add(
-                DiagnosticLevel.WARNING,
-                "missing-episode-record",
-                f"no {METADATA_RECORD_EPISODE!r} metadata record (task/operator/success "
-                "semantics live there)",
-            )
+                    groups_out_of_time_order.add(group_name)
+                previous_chunk_start_by_group[group_name] = chunk_index.message_start_time
 
         # Full message pass: CRC validation happens as a side effect of
         # reading every chunk; per-topic time order and video constraints are

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -29,6 +29,43 @@ ROS2_COMPRESSED_VIDEO_SCHEMA = "\n".join(
 )
 
 
+def write_chunked_episode(
+    path: Path,
+    message_specs: list[tuple[str, int, int]],
+    groups_by_topic: dict[str, str],
+    *,
+    chunk_size_bytes: int = 1_000,
+) -> None:
+    """Write an MCAP whose chunk layout is controlled by the caller.
+
+    The stock ``mcap`` writer finalizes a chunk once the accumulated bytes
+    exceed an explicit ``chunk_size``, so varying per-message payload sizes
+    places message boundaries exactly where the test needs them. HFlow's own
+    grouped writer cannot produce chunks out of time order, so the violation
+    fixtures here are built with the stock writer instead.
+    """
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=chunk_size_bytes)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(name="test/v1", encoding="json", data=b"{}")
+        channel_ids: dict[str, int] = {}
+        for topic in sorted({topic for topic, _log_time, _size in message_specs}):
+            channel_ids[topic] = writer.register_channel(
+                topic=topic, message_encoding="json", schema_id=schema_id
+            )
+        for topic, log_time, payload_size in message_specs:
+            writer.add_message(
+                channel_ids[topic],
+                log_time=log_time,
+                data=b"\x00" * payload_size,
+                publish_time=log_time,
+            )
+        provenance = {"schema_version": "1", "pipeline_version": "0123456789ab"}
+        provenance.update({f"group/{topic}": group for topic, group in groups_by_topic.items()})
+        writer.add_metadata("provenance/v1", provenance)
+        writer.finish()
+
+
 @pytest.fixture(scope="module")
 def canonical_episode(tmp_path_factory: pytest.TempPathFactory) -> Path:
     root = tmp_path_factory.mktemp("doctor")
@@ -105,6 +142,95 @@ def test_nonconforming_ros2_video_is_reported(tmp_path: Path) -> None:
     assert not report.conforming
     codes = {finding.code for finding in report.findings}
     assert "video-not-aud-delimited" in codes
+
+
+def test_group_chunk_sequence_descending_is_reported_once(tmp_path: Path) -> None:
+    # One group, three chunks with start times [10 s, 0 s, 5 s]: two descents
+    # within the same group. Each channel's own messages still ascend, so this
+    # is only a chunk-layout deviation, not a per-topic time-order error.
+    path = tmp_path / "group_descends.mcap"
+    write_chunked_episode(
+        path,
+        [
+            ("/alpha", 10 * 10**9, 200),
+            ("/alpha", 11 * 10**9, 900),
+            ("/beta", 0 * 10**9, 200),
+            ("/beta", 1 * 10**9, 900),
+        ],
+        {"/alpha": "cameras", "/beta": "cameras"},
+    )
+
+    report = diagnose(path)
+
+    assert report.conforming  # a layout deviation is a warning, not an error
+    findings = [
+        finding for finding in report.findings if finding.code == "chunk-group-out-of-time-order"
+    ]
+    assert len(findings) == 1, report.summary()
+    finding = findings[0]
+    assert finding.level is DiagnosticLevel.WARNING
+    assert "cameras" in finding.message
+    assert "chunk" in finding.message
+
+
+def test_group_chunk_sequence_ascending_is_not_reported(tmp_path: Path) -> None:
+    path = tmp_path / "group_ascends.mcap"
+    write_chunked_episode(
+        path,
+        [
+            ("/alpha", 0 * 10**9, 200),
+            ("/alpha", 1 * 10**9, 900),
+            ("/beta", 2 * 10**9, 200),
+            ("/beta", 3 * 10**9, 900),
+        ],
+        {"/alpha": "cameras", "/beta": "cameras"},
+    )
+
+    report = diagnose(path)
+
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-group-out-of-time-order" not in codes
+
+
+def test_group_chunks_may_interleave_between_groups(tmp_path: Path) -> None:
+    # The state group's chunks surround a cameras chunk that starts earlier.
+    # Out of global order, but each group's own sequence is ascending, so the
+    # interleaving itself is not reported.
+    path = tmp_path / "groups_interleave.mcap"
+    write_chunked_episode(
+        path,
+        [
+            ("/beta", 2 * 10**9, 5_000),
+            ("/alpha", 0 * 10**9, 5_000),
+            ("/beta", 4 * 10**9, 5_000),
+        ],
+        {"/alpha": "cameras", "/beta": "state"},
+        chunk_size_bytes=1_024,
+    )
+
+    report = diagnose(path)
+
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-group-out-of-time-order" not in codes
+
+
+def test_no_group_map_skips_the_time_order_check(tmp_path: Path) -> None:
+    path = tmp_path / "no_group_map.mcap"
+    write_chunked_episode(
+        path,
+        [
+            ("/alpha", 10 * 10**9, 200),
+            ("/alpha", 11 * 10**9, 900),
+            ("/beta", 0 * 10**9, 200),
+            ("/beta", 1 * 10**9, 900),
+        ],
+        {},
+    )
+
+    report = diagnose(path)
+
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-group-out-of-time-order" not in codes
 
 
 def test_not_an_mcap_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #239 

## Summary

`hflow doctor` now enforces the second half of FORMAT.md convention item 3: a single group's chunks must be time-ordered by `message_start_time`. A file whose chunks descend within one group produces a new `warning` finding (`chunk-group-out-of-time-order`) naming the group, so readers that seek a time range and skip chunks on the assumption that later chunks start later get a heads-up. Previously the doctor reported such files as conforming with no findings.

## Why

Issue #239: the chunk-layout convention states two properties — chunk purity and per-group time ordering — but only the first was checked. In a group with two channels, the late messages of one channel could land in the first chunk and the early messages of the other in the second; each channel's own log times still ascended, so `topic-time-order` stayed silent. This is a layout deviation (the sort of file HFlow itself never writes) rather than data loss, so it is a `warning`, same level and rationale as `chunk-mixes-video-and-state`.

The finding is reported once per group, not per out-of-order pair, so a file written in a different order — where every chunk is out of place — cannot hide affected groups behind `_MAX_FINDINGS_PER_CODE` suppression. Chunks in different groups may interleave in any order and are not reported; only order within a group is the rule, and a file with no `group/` keys in `provenance/v1` is not checked (no map, no groups).

## Validation

- `docs/FORMAT.md` finding-code table gains `chunk-group-out-of-time-order` (warning) and the paragraph above it no longer lists per-group chunk time order as unchecked.
- New tests in `tests/test_doctor.py`:
  - descending chunk sequence within one group → exactly one warning naming the group (file remains `conforming`, layout deviation is not an error);
  - ascending sequence → no finding;
  - chunks interleaved across different groups → no finding;
  - no `group/` keys in provenance → check skipped.

The fixtures use the stock `mcap.writer.Writer` with a small `chunk_size`, because HFlow's own writer cannot produce the violation.

I was unable to run `uv run pytest -q`, `uv run ruff check --fix`, `uv run ruff format`, or `uv run ty check` locally (this Windows machine cannot run the project), so these still need to be verified in CI or on a compatible host.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.