### PR TITLE
test: add 5 refusal test cases for workspace and catalog (#247)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .ruff_cache/
-.vscode/
+
 # Default data root for pipelines and the quickstart example (user data,
 # never source).
 data/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .ruff_cache/
-
+.vscode/
 # Default data root for pipelines and the quickstart example (user data,
 # never source).
 data/

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -8,6 +8,7 @@ import duckdb
 import pytest
 
 import hflow
+from hflow.format import CATALOG_FORMAT_VERSION
 from hflow.catalog import (
     _EPISODES_VIEW_RESERVED_COLUMNS,
     TABLE_COLUMN_DDL,
@@ -312,6 +313,14 @@ def test_catalog_refuses_unknown_format_version(tmp_path: Path) -> None:
     (root / "format_version").write_text("999\n")
     with pytest.raises(ValueError, match="format version '999'"):
         Catalog(root)
+
+
+def test_open_catalog_connection_refuses_unknown_format_version(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    root.mkdir()
+    (root / "format_version").write_text("999\n")
+    with pytest.raises(ValueError, match=f"has format version '999'.*this build reads version '{CATALOG_FORMAT_VERSION}'"):
+        open_catalog_connection(root)
 
 
 def test_curate_on_empty_catalog(tmp_path: Path) -> None:

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -8,7 +8,6 @@ import duckdb
 import pytest
 
 import hflow
-from hflow.format import CATALOG_FORMAT_VERSION
 from hflow.catalog import (
     _EPISODES_VIEW_RESERVED_COLUMNS,
     TABLE_COLUMN_DDL,
@@ -20,6 +19,7 @@ from hflow.catalog import (
 from hflow.checks import camera_frame_stats
 from hflow.cli import main as cli_main
 from hflow.curation import CurationReport, curate, open_catalog_connection
+from hflow.format import CATALOG_FORMAT_VERSION
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import EpisodeStamps
 
@@ -319,7 +319,10 @@ def test_open_catalog_connection_refuses_unknown_format_version(tmp_path: Path) 
     root = tmp_path / "catalog"
     root.mkdir()
     (root / "format_version").write_text("999\n")
-    with pytest.raises(ValueError, match=f"has format version '999'.*this build reads version '{CATALOG_FORMAT_VERSION}'"):
+    with pytest.raises(
+        ValueError,
+        match=f"has format version '999'.*this build reads version '{CATALOG_FORMAT_VERSION}'",
+    ):
         open_catalog_connection(root)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10,7 +10,7 @@ import pytest
 import hflow
 from hflow.manifest import PIPELINE_MANIFEST_VERSION
 from hflow.storage import LocalStorageRoot
-from hflow.workspace import Workspace
+from hflow.workspace import WORKSPACE_IDENTITY_VERSION, Workspace
 
 
 class TestWorkspaceLayout:
@@ -43,6 +43,39 @@ class TestWorkspaceIdentity:
     def test_corrupt_identity_marker_is_refused_loudly(self, tmp_path: Path) -> None:
         (tmp_path / "workspace.json").write_text("not json at all")
         with pytest.raises(ValueError, match="invalid workspace identity"):
+            Workspace.parse(tmp_path).identity()
+
+    def test_identity_marker_not_dict_is_refused(self, tmp_path: Path) -> None:
+        (tmp_path / "workspace.json").write_text("[]")
+        with pytest.raises(ValueError, match="expected a JSON object"):
+            Workspace.parse(tmp_path).identity()
+
+    def test_identity_marker_version_mismatch_is_refused(self, tmp_path: Path) -> None:
+        payload = {
+            "identity_version": 99,
+            "workspace_id": "foo",
+            "created_at": "bar",
+        }
+        (tmp_path / "workspace.json").write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match=f"has identity_version 99.*this build reads version {WORKSPACE_IDENTITY_VERSION}"):
+            Workspace.parse(tmp_path).identity()
+
+    def test_identity_marker_missing_workspace_id_is_refused(self, tmp_path: Path) -> None:
+        payload = {
+            "identity_version": WORKSPACE_IDENTITY_VERSION,
+            "created_at": "bar",
+        }
+        (tmp_path / "workspace.json").write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="'workspace_id' must be a non-empty string"):
+            Workspace.parse(tmp_path).identity()
+
+    def test_identity_marker_missing_created_at_is_refused(self, tmp_path: Path) -> None:
+        payload = {
+            "identity_version": WORKSPACE_IDENTITY_VERSION,
+            "workspace_id": "foo",
+        }
+        (tmp_path / "workspace.json").write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="'created_at' must be a non-empty string"):
             Workspace.parse(tmp_path).identity()
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -57,7 +57,10 @@ class TestWorkspaceIdentity:
             "created_at": "bar",
         }
         (tmp_path / "workspace.json").write_text(json.dumps(payload))
-        with pytest.raises(ValueError, match=f"has identity_version 99.*this build reads version {WORKSPACE_IDENTITY_VERSION}"):
+        with pytest.raises(
+            ValueError,
+            match=f"has identity_version 99.*this build reads version {WORKSPACE_IDENTITY_VERSION}",
+        ):
             Workspace.parse(tmp_path).identity()
 
     def test_identity_marker_missing_workspace_id_is_refused(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

<!-- What user-visible outcome does this change produce? -->
Adds missing test coverage for five validation paths related to workspace identity and catalog version checking to prevent silent regressions. Closes #247.

## Why

<!-- What problem does it solve, and why is this the appropriate scope? -->
These error-handling conditions fire when a user upgrades HFlow and points it at state written by an incompatible version. Previously, these checks had zero test coverage, meaning they could be accidentally deleted or bypassed while the test suite remained green.

This PR pins down these specific validations by asserting ValueError with match= on the distinctive message strings for the following scenarios:

- Workspace identity payload is not a dictionary
- Workspace identity_version mismatch
- Workspace payload missing workspace_id
- Workspace payload missing created_at
- Catalog format_version mismatch

The tests strictly use the WORKSPACE_IDENTITY_VERSION and CATALOG_FORMAT_VERSION constants instead of hardcoded literals so deliberate version bumps will smoothly pass, but accidental changes will be caught.

## Validation

<!-- List the exact commands you ran and their results. -->
Ran the standard validation suite successfully:
```bash
uv sync --locked --all-extras
uv run ruff check --fix
uv run ruff format
uv run ty check
uv run pytest -q
```
<img width="816" height="36" alt="image" src="https://github.com/user-attachments/assets/07e5cdec-d153-440d-9f99-5eeb8c10d9a6" />
Not all test cases passed but the failed test cases were in test_ffmpeg.py.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [] I preserved stored-data compatibility or documented an explicit version change.
