### PR TITLE
fix(lerobot): disable B-frames so the converter output decodes in full

### DIFF
--- a/examples/lerobot/prepare.py
+++ b/examples/lerobot/prepare.py
@@ -161,7 +161,9 @@ def _transcode_mp4_to_h264(mp4_path: Path, gop_seconds: float, fps: float) -> li
         "-sc_threshold",
         "0",
         "-x264-params",
-        "aud=1",
+        # bframes=0: B-frame streams lose their reorder-buffer tail through
+        # the raw Annex B -> MP4 remux, undercounting decoded_frame_count (#250).
+        "aud=1:bframes=0",
         "-f",
         "h264",
         "pipe:1",

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -7,6 +7,9 @@ implementation details or touching the network.
 
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -18,6 +21,14 @@ prep = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(prep)
 _DERIVE = prep._derive_numeric_schema
 _ENCODE = prep._encode_cdr_float32_array
+
+_FFMPEG = shutil.which("ffmpeg")
+_FFPROBE = shutil.which("ffprobe")
+
+pytestmark = pytest.mark.skipif(
+    _FFMPEG is None or _FFPROBE is None,
+    reason="system ffmpeg/ffprobe required",
+)
 
 
 def _build_fake_corpus(tmp_path: Path) -> dict:
@@ -245,3 +256,74 @@ def test_camera_selection_validates_keys(tmp_path: Path, monkeypatch: pytest.Mon
             output_dir=tmp_path / "out",
             camera_key="observation.nope",
         )
+
+
+def test_converter_output_remuxes_without_tail_loss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The converter's stream must decode in full through the hflow remux.
+
+    B-frame H.264 loses its reorder-buffer tail when remuxed from raw Annex
+    B to MP4, so decoded_frame_count undercounts healthy episodes (#250).
+    The converter encodes with bframes=0; prove the full chain decodes
+    every source frame.
+    """
+
+    assert _FFMPEG is not None and _FFPROBE is not None
+    # prepare.py shells out to bare "ffmpeg"/"ffprobe"; make sure it
+    # resolves to the system binary this test found.
+    monkeypatch.setenv(
+        "PATH",
+        str(Path(_FFMPEG).resolve().parent) + os.pathsep + os.environ.get("PATH", ""),
+    )
+
+    source = tmp_path / "source.mp4"
+    subprocess.run(
+        [
+            _FFMPEG,
+            "-hide_banner",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x120:rate=30:duration=3,format=yuv420p",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-g",
+            "30",
+            "-keyint_min",
+            "30",
+            "-sc_threshold",
+            "0",
+            str(source),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+    from hflow.video import write_access_units_to_mp4
+
+    units = prep._transcode_mp4_to_h264(source, gop_seconds=1.0, fps=30.0)
+    muxed = write_access_units_to_mp4(units, fps=30.0, output=tmp_path / "remux.mp4")
+
+    probe = subprocess.run(
+        [
+            _FFPROBE,
+            "-v",
+            "error",
+            "-count_frames",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(muxed),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "nb_read_frames=90" in probe.stdout, probe.stdout

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -25,9 +25,11 @@ _ENCODE = prep._encode_cdr_float32_array
 _FFMPEG = shutil.which("ffmpeg")
 _FFPROBE = shutil.which("ffprobe")
 
-pytestmark = pytest.mark.skipif(
+# Only the remux test below shells out. Scoping this to the module would skip
+# the five metadata tests too, and none of those touch ffmpeg at all.
+_requires_system_ffmpeg = pytest.mark.skipif(
     _FFMPEG is None or _FFPROBE is None,
-    reason="system ffmpeg/ffprobe required",
+    reason="system ffmpeg/ffprobe required: prepare.py shells out to bare 'ffmpeg'",
 )
 
 
@@ -258,6 +260,7 @@ def test_camera_selection_validates_keys(tmp_path: Path, monkeypatch: pytest.Mon
         )
 
 
+@_requires_system_ffmpeg
 def test_converter_output_remuxes_without_tail_loss(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What

One-line converter change: `_transcode_mp4_to_h264` now encodes with `bframes=0` (was libx264 medium default, which enables B-frames).

## Why

Fixes #250. The raw Annex B -> MP4 `-c copy` remux in `write_access_units_to_mp4` drops the B-frame reorder-buffer tail at decode: the muxed file carries all 303 samples but only 301 decode, so `camera_frame_stats` undercounts `decoded_frame_count` on every healthy episode converted from a B-frame stream. `frame_deficit_pct` cannot see it (no messages are missing).

Evidence chain (svla_so101_pickplace @ f641879, ep0, plain ffmpeg):
- source slices decode 303/303, full chunks 11939/11939, zero errors
- converter emits 303 access units; raw Annex B decodes 303/303
- remuxed via the exact `write_access_units_to_mp4` command: 303 samples, 301 decoded (last two frames; reproduced under -muxdelay 0, genpts, max_interleave_delta 0, and a two-step remux)
- control: same encode with `bframes=0` decodes 303/303 through the identical remux

## Validation

- Regression test added: converter output remuxed through `write_access_units_to_mp4` must decode every source frame (fails on the old encode, passes now). `pytest tests/test_lerobot_converter.py` -> 6/6 passed.
- Full pipeline on the pinned corpus with the fixed converter: `hflow.App(...).process(...)`, then the catalog measurements parquet reads `decoded_frame_count` 303/303 on both `/observation.images.up` and `/observation.images.side` (was 301/303).
- `ruff check` + `ruff format --check` + `ty check` on both changed files: clean.

Fixes #250