### PR TITLE
Fix doctor chunk purity proxy to check provenance group map (#237)

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -156,8 +156,9 @@ A file claiming this convention must satisfy, in increasing strictness:
 `hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
-stamps, chunk purity (using the file's group map or a video-versus-state approximation), per-topic time order, and the H.264 access-unit properties listed
-below. It does not currently classify H.264 picture coding types to detect
+stamps, chunk purity (against the file's own group map, or a video-versus-state
+approximation when it has none), per-topic time order, and the H.264
+access-unit properties listed below. It does not currently classify H.264 picture coding types to detect
 B-frames, so a clean report is not proof of the unchecked no-B-frame
 constraint. The doctor also does not reject non-VCL NAL units before the first
 AUD, so a clean report does not prove the canonical AUD-first constraint. An
@@ -177,8 +178,8 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `no-statistics` | error | The summary has no `Statistics` record. |
 | `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
 | `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
-| chunk-mixes-groups | warning | One chunk contains channels assigned to different groups; custom grouping can make this intentional. |
-| chunk-mixes-video-and-state | warning | One chunk contains both video and state channels (reported when the file lacks a group map); custom grouping can make this intentional. |
+| `chunk-mixes-groups` | warning | One chunk contains channels assigned to different groups; custom grouping can make this intentional. |
+| `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels, reported only when the file has no group map; custom grouping can make this intentional. |
 | `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
 | `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |
 | `missing-episode-record` | warning | The optional `episode/v1` semantics record is absent. |

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -156,7 +156,7 @@ A file claiming this convention must satisfy, in increasing strictness:
 `hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
-stamps, per-topic time order, and the H.264 access-unit properties listed
+stamps, chunk purity (using the file's group map or a video-versus-state approximation), per-topic time order, and the H.264 access-unit properties listed
 below. It does not currently classify H.264 picture coding types to detect
 B-frames, so a clean report is not proof of the unchecked no-B-frame
 constraint. The doctor also does not reject non-VCL NAL units before the first
@@ -177,7 +177,8 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `no-statistics` | error | The summary has no `Statistics` record. |
 | `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
 | `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
-| `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels; custom grouping can make this intentional. |
+| chunk-mixes-groups | warning | One chunk contains channels assigned to different groups; custom grouping can make this intentional. |
+| chunk-mixes-video-and-state | warning | One chunk contains both video and state channels (reported when the file lacks a group map); custom grouping can make this intentional. |
 | `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
 | `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |
 | `missing-episode-record` | warning | The optional `episode/v1` semantics record is absent. |

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -216,10 +216,10 @@ def diagnose(path: Path | str) -> DoctorReport:
 
         group_by_topic = {}
         if provenance:
-            for k, v in provenance.items():
-                if k.startswith("group/"):
-                    topic_name = k[len("group/") :]
-                    group_by_topic[topic_name] = v
+            for provenance_key, provenance_value in provenance.items():
+                if provenance_key.startswith("group/"):
+                    topic_name = provenance_key[len("group/") :]
+                    group_by_topic[topic_name] = provenance_value
 
         if summary.statistics is None:
             collector.add(

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -211,6 +211,16 @@ def diagnose(path: Path | str) -> DoctorReport:
             if schema_name in PASSTHROUGH_VIDEO_SCHEMA_NAMES
         }
 
+        metadata_records = {record.name: dict(record.metadata) for record in reader.iter_metadata()}
+        provenance = metadata_records.get(METADATA_RECORD_PROVENANCE)
+
+        group_by_topic = {}
+        if provenance:
+            for k, v in provenance.items():
+                if k.startswith("group/"):
+                    topic_name = k[len("group/") :]
+                    group_by_topic[topic_name] = v
+
         if summary.statistics is None:
             collector.add(
                 DiagnosticLevel.ERROR, "no-statistics", "summary has no Statistics record"
@@ -230,23 +240,42 @@ def diagnose(path: Path | str) -> DoctorReport:
                     f"chunk {chunk_number} has no MessageIndex records",
                 )
                 continue
-            has_video = any(channel_id in video_channel_ids for channel_id in chunk_channel_ids)
-            has_state = any(channel_id not in video_channel_ids for channel_id in chunk_channel_ids)
-            if has_video and has_state:
-                mixed_topics = sorted(
-                    topics_by_channel_id[channel_id] for channel_id in chunk_channel_ids
-                )
-                collector.add(
-                    # A custom topic-group assignment could legally do this;
-                    # the file alone cannot distinguish that from a writer bug.
-                    DiagnosticLevel.WARNING,
-                    "chunk-mixes-video-and-state",
-                    f"chunk {chunk_number} mixes video and state channels {mixed_topics}; "
-                    "the default convention separates them",
-                )
 
-        metadata_records = {record.name: dict(record.metadata) for record in reader.iter_metadata()}
-        provenance = metadata_records.get(METADATA_RECORD_PROVENANCE)
+            if group_by_topic:
+                chunk_groups = set()
+                for channel_id in chunk_channel_ids:
+                    topic = topics_by_channel_id[channel_id]
+                    if topic in group_by_topic:
+                        chunk_groups.add(group_by_topic[topic])
+
+                if len(chunk_groups) > 1:
+                    mixed_topics = sorted(
+                        topics_by_channel_id[channel_id] for channel_id in chunk_channel_ids
+                    )
+                    collector.add(
+                        DiagnosticLevel.WARNING,
+                        "chunk-mixes-groups",
+                        f"chunk {chunk_number} mixes groups {sorted(chunk_groups)} (channels {mixed_topics}); "
+                        "the default convention separates them",
+                    )
+            else:
+                has_video = any(channel_id in video_channel_ids for channel_id in chunk_channel_ids)
+                has_state = any(
+                    channel_id not in video_channel_ids for channel_id in chunk_channel_ids
+                )
+                if has_video and has_state:
+                    mixed_topics = sorted(
+                        topics_by_channel_id[channel_id] for channel_id in chunk_channel_ids
+                    )
+                    collector.add(
+                        # A custom topic-group assignment could legally do this;
+                        # the file alone cannot distinguish that from a writer bug.
+                        DiagnosticLevel.WARNING,
+                        "chunk-mixes-video-and-state",
+                        f"chunk {chunk_number} mixes video and state channels {mixed_topics}; "
+                        "the default convention separates them",
+                    )
+
         if provenance is None:
             collector.add(
                 DiagnosticLevel.ERROR,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -219,3 +219,99 @@ def test_cli_curate_bad_catalog_prints_one_line(
     captured = capsys.readouterr()
     assert "curate:" in captured.err
     assert "Traceback" not in captured.err
+
+def test_chunk_mixes_groups_with_map(tmp_path: Path) -> None:
+    path = tmp_path / "mixed.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            metadata={
+                "group//joint_states": "state",
+                "group//lidar_points": "bulk",
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(
+            topic="/joint_states", message_encoding="json", schema_id=schema_id
+        )
+        ch2 = writer.register_channel(
+            topic="/lidar_points", message_encoding="json", schema_id=schema_id
+        )
+        writer.add_message(ch1, log_time=1000, data=b"{}", publish_time=1000)
+        writer.add_message(ch2, log_time=1000, data=b"{}", publish_time=1000)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-mixes-groups" in codes
+
+
+def test_chunk_no_mix_with_map(tmp_path: Path) -> None:
+    path = tmp_path / "nomix.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            metadata={
+                "group//joint_states": "state",
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(
+            topic="/joint_states", message_encoding="json", schema_id=schema_id
+        )
+        writer.add_message(ch1, log_time=1000, data=b"{}", publish_time=1000)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-mixes-groups" not in codes
+
+
+def test_chunk_mix_without_map(tmp_path: Path) -> None:
+    path = tmp_path / "nomap.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1", metadata={"schema_version": "1", "pipeline_version": "1"}
+        )
+        video_schema = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        state_schema = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+
+        ch_vid = writer.register_channel(
+            topic="/cam", message_encoding="protobuf", schema_id=video_schema
+        )
+        ch_state = writer.register_channel(
+            topic="/joint_states", message_encoding="json", schema_id=state_schema
+        )
+
+        # We also have to supply valid video otherwise read-failed or other things might mask or spam
+        # But even if it does, chunk-mixes-video-and-state should be there.
+        message = CompressedVideo()
+        message.timestamp.FromNanoseconds(10**9)
+        message.frame_id = "cam"
+        message.data = b"\x00\x00\x00\x01\x41not-aud-delimited"
+        message.format = "h264"
+
+        writer.add_message(
+            ch_vid, log_time=1000, data=message.SerializeToString(), publish_time=1000
+        )
+        writer.add_message(ch_state, log_time=1000, data=b"{}", publish_time=1000)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "chunk-mixes-video-and-state" in codes
+    assert "chunk-mixes-groups" not in codes

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -220,6 +220,7 @@ def test_cli_curate_bad_catalog_prints_one_line(
     assert "curate:" in captured.err
     assert "Traceback" not in captured.err
 
+
 def test_chunk_mixes_groups_with_map(tmp_path: Path) -> None:
     path = tmp_path / "mixed.mcap"
     with path.open("wb") as stream:
@@ -227,7 +228,7 @@ def test_chunk_mixes_groups_with_map(tmp_path: Path) -> None:
         writer.start(profile="", library="test")
         writer.add_metadata(
             name="provenance/v1",
-            metadata={
+            data={
                 "group//joint_states": "state",
                 "group//lidar_points": "bulk",
                 "schema_version": "1",
@@ -257,7 +258,7 @@ def test_chunk_no_mix_with_map(tmp_path: Path) -> None:
         writer.start(profile="", library="test")
         writer.add_metadata(
             name="provenance/v1",
-            metadata={
+            data={
                 "group//joint_states": "state",
                 "schema_version": "1",
                 "pipeline_version": "1",
@@ -281,7 +282,7 @@ def test_chunk_mix_without_map(tmp_path: Path) -> None:
         writer = StockWriter(stream)
         writer.start(profile="", library="test")
         writer.add_metadata(
-            name="provenance/v1", metadata={"schema_version": "1", "pipeline_version": "1"}
+            name="provenance/v1", data={"schema_version": "1", "pipeline_version": "1"}
         )
         video_schema = writer.register_schema(
             name="foxglove.CompressedVideo",


### PR DESCRIPTION
Resolves #237. Updates the doctor's chunk purity check to read the \group/\ namespace keys from \provenance/v1\ metadata and assert that each chunk spans no more than one group (throwing \chunk-mixes-groups\). Falls back to the legacy video-versus-state approximation for files lacking a group map.