### PR TITLE
fix(examples): resolve camera explicitly in egocentric contact_sheet enrichment

### DIFF
--- a/examples/egocentric/pipeline.py
+++ b/examples/egocentric/pipeline.py
@@ -61,15 +61,23 @@ def camera_health(episode: hflow.Episode) -> hflow.CheckResult:
 
 @app.enrich(version="1")
 def contact_sheet(episode: hflow.Episode) -> hflow.EnrichmentResult:
+    # episode.cameras is sorted, so this is the alphabetically first camera and
+    # not necessarily the one the recorder considered primary. Recorded in the
+    # labels because a sheet that cannot say which camera it shows is a trap on
+    # any multi-camera corpus.
+    camera_topic = episode.cameras[0]
     artifact_path = DATA_ROOT / "artifacts" / f"{episode.path.stem}-contact-sheet.jpg"
     sheet = hflow.ffmpeg.contact_sheet(
-        episode.frames(camera=episode.cameras[0], fps=1.0),
+        episode.frames(camera=camera_topic, fps=1.0),
         artifact_path,
         columns=5,
         max_tiles=20,
     )
     return hflow.EnrichmentResult(
-        labels={"contact_sheet_frame_count": sheet.frames_sampled_from},
+        labels={
+            "contact_sheet_frame_count": sheet.frames_sampled_from,
+            "contact_sheet_camera": camera_topic,
+        },
         artifacts={"contact_sheet": sheet.path},
     )
 

--- a/examples/egocentric/pipeline.py
+++ b/examples/egocentric/pipeline.py
@@ -63,7 +63,7 @@ def camera_health(episode: hflow.Episode) -> hflow.CheckResult:
 def contact_sheet(episode: hflow.Episode) -> hflow.EnrichmentResult:
     artifact_path = DATA_ROOT / "artifacts" / f"{episode.path.stem}-contact-sheet.jpg"
     sheet = hflow.ffmpeg.contact_sheet(
-        episode.frames(fps=1.0),
+        episode.frames(camera=episode.cameras[0], fps=1.0),
         artifact_path,
         columns=5,
         max_tiles=20,

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -238,3 +238,32 @@ def test_labels_near_the_artifact_namespace_still_land_with_real_artifacts(
         assert str(artifact_row[0]).endswith("segments.json")
     finally:
         connection.close()
+
+
+def test_enrichment_resolving_camera_explicitly_succeeds_on_multi_camera_episode(
+    tmp_path: Path,
+) -> None:
+    """Regression: episode.frames() without a camera raises ValueError when the
+    episode has more than one camera track.  An enrichment that calls
+    episode.frames(camera=episode.cameras[0], ...) must complete without error
+    on multi-camera episodes (mirrors the fix in examples/egocentric/pipeline.py).
+    """
+    from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+    from hflow.transform import write_canonical_episode
+
+    multi_cam_spec = SyntheticEpisodeSpec(duration_s=2.0, cameras=("wrist_cam", "top_cam"))
+    raw = synthesize_episode(tmp_path / "raw.mcap", multi_cam_spec)
+    canonical = tmp_path / "canonical.mcap"
+    write_canonical_episode(raw, canonical)
+
+    app = hflow.App("multi-cam-enrich", data_root=tmp_path / "data")
+    frames_seen: list[int] = []
+
+    @app.enrich(version="1")
+    def count_frames(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        frames_seen.append(sum(1 for _ in ep.frames(camera=ep.cameras[0], fps=1.0)))
+        return hflow.EnrichmentResult(labels={"frame_count": frames_seen[-1]})
+
+    report = app.test(canonical, verbose=False)
+    assert report.enrichments[0].status == hflow.CheckStatus.MEASURED
+    assert frames_seen == [2]

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -10,6 +10,7 @@ import hflow
 from hflow.app import MEDIA_CONTACT_SHEET_STEP_NAME
 from hflow.curation import open_catalog_connection
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+from hflow.transform import write_canonical_episode
 
 FAST_SPEC = SyntheticEpisodeSpec(duration_s=2.0, cameras=())
 
@@ -240,30 +241,37 @@ def test_labels_near_the_artifact_namespace_still_land_with_real_artifacts(
         connection.close()
 
 
-def test_enrichment_resolving_camera_explicitly_succeeds_on_multi_camera_episode(
-    tmp_path: Path,
-) -> None:
-    """Regression: episode.frames() without a camera raises ValueError when the
-    episode has more than one camera track.  An enrichment that calls
-    episode.frames(camera=episode.cameras[0], ...) must complete without error
-    on multi-camera episodes (mirrors the fix in examples/egocentric/pipeline.py).
-    """
-    from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
-    from hflow.transform import write_canonical_episode
+_EGOCENTRIC_PIPELINE = Path(__file__).resolve().parents[1] / "examples/egocentric/pipeline.py"
 
-    multi_cam_spec = SyntheticEpisodeSpec(duration_s=2.0, cameras=("wrist_cam", "top_cam"))
-    raw = synthesize_episode(tmp_path / "raw.mcap", multi_cam_spec)
+
+def test_the_egocentric_example_renders_a_sheet_on_a_multi_camera_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The example itself, not a copy of its shape.
+
+    A test that defines its own enrichment calling
+    ``frames(camera=..., fps=1.0)`` passes whether or not the example does the
+    same, so it cannot catch a regression in the file it ships alongside. This
+    loads the real pipeline: reverting the fix in
+    ``examples/egocentric/pipeline.py`` turns ``contact_sheet`` into an ERROR
+    here.
+
+    The example resolves DATA_ROOT relative to the working directory, so the
+    chdir keeps its artifacts inside tmp_path.
+    """
+    monkeypatch.chdir(tmp_path)
+    raw = synthesize_episode(
+        tmp_path / "raw.mcap",
+        SyntheticEpisodeSpec(duration_s=2.0, cameras=("wrist_cam", "top_cam")),
+    )
     canonical = tmp_path / "canonical.mcap"
     write_canonical_episode(raw, canonical)
 
-    app = hflow.App("multi-cam-enrich", data_root=tmp_path / "data")
-    frames_seen: list[int] = []
+    application = hflow.import_pipeline_application(str(_EGOCENTRIC_PIPELINE))
+    report = application.test(canonical, verbose=False)
 
-    @app.enrich(version="1")
-    def count_frames(ep: hflow.Episode) -> hflow.EnrichmentResult:
-        frames_seen.append(sum(1 for _ in ep.frames(camera=ep.cameras[0], fps=1.0)))
-        return hflow.EnrichmentResult(labels={"frame_count": frames_seen[-1]})
-
-    report = app.test(canonical, verbose=False)
-    assert report.enrichments[0].status == hflow.CheckStatus.MEASURED
-    assert frames_seen == [2]
+    sheet_run = next(run for run in report.enrichments if run.enrichment.name == "contact_sheet")
+    assert sheet_run.status is hflow.CheckStatus.MEASURED, sheet_run.error
+    assert sheet_run.result is not None
+    # The episode has two cameras and the sheet names the one it rendered.
+    assert sheet_run.result.labels["contact_sheet_camera"] == "/top_cam/compressed"


### PR DESCRIPTION
Fixes #234

just clearling it out until i come across some other issues which will be fun to work on.

## What
`contact_sheet` in `examples/egocentric/pipeline.py` called
`episode.frames(fps=1.0)` without specifying a camera. On episodes with
more than one camera track, `Episode._resolve_camera()` raises
`ValueError: episode has multiple cameras; pass one explicitly`.

`timestamp_regularity` (line 30) and `camera_health` (line 35) in the
same file already resolved `episode.cameras[0]`. This change makes
`contact_sheet` consistent with them.

## Validation
```bash
uv run ruff check --fix && uv run ruff format && uv run ty check
uv run pytest -q
