### PR TITLE
Enforce per-group chunk time order in doctor (#239)

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -157,7 +157,7 @@ A file claiming this convention must satisfy, in increasing strictness:
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
 stamps, chunk purity (against the file's own group map, or a video-versus-state
-approximation when it has none), per-topic time order, and the H.264
+approximation when it has none), per-topic time order, per-group chunk time order, and the H.264
 access-unit properties listed below. It does not currently classify H.264 picture coding types to detect
 B-frames, so a clean report is not proof of the unchecked no-B-frame
 constraint. The doctor also does not reject non-VCL NAL units before the first
@@ -179,6 +179,7 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
 | `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
 | `chunk-mixes-groups` | warning | One chunk contains channels assigned to different groups; custom grouping can make this intentional. |
+| group-chunks-out-of-order | warning | A group's chunks are not strictly ascending by message_start_time. |
 | `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels, reported only when the file has no group map; custom grouping can make this intentional. |
 | `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
 | `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -157,8 +157,9 @@ A file claiming this convention must satisfy, in increasing strictness:
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
 stamps, chunk purity (against the file's own group map, or a video-versus-state
-approximation when it has none), per-topic time order, per-group chunk time order, and the H.264
-access-unit properties listed below. It does not currently classify H.264 picture coding types to detect
+approximation when it has none), per-topic time order, per-group chunk time
+order, and the H.264 access-unit properties listed below. It does not
+currently classify H.264 picture coding types to detect
 B-frames, so a clean report is not proof of the unchecked no-B-frame
 constraint. The doctor also does not reject non-VCL NAL units before the first
 AUD, so a clean report does not prove the canonical AUD-first constraint. An
@@ -179,7 +180,7 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `no-chunk-indexes` | error | The summary has no `ChunkIndex` records. |
 | `chunk-missing-message-indexes` | error | A chunk index has no per-channel `MessageIndex` offsets. |
 | `chunk-mixes-groups` | warning | One chunk contains channels assigned to different groups; custom grouping can make this intentional. |
-| group-chunks-out-of-order | warning | A group's chunks are not strictly ascending by message_start_time. |
+| `group-chunks-out-of-order` | warning | A group's chunks are not ascending by `message_start_time`. |
 | `chunk-mixes-video-and-state` | warning | One chunk contains both video and state channels, reported only when the file has no group map; custom grouping can make this intentional. |
 | `missing-provenance` | error | The `provenance/v1` metadata record is absent. |
 | `provenance-missing-key` | error | `provenance/v1` lacks `schema_version` or `pipeline_version`. |

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -231,6 +231,9 @@ def diagnose(path: Path | str) -> DoctorReport:
                 "no-chunk-indexes",
                 "no ChunkIndex records: the file is unchunked or unindexed",
             )
+        last_chunk_start_by_group = {}
+        out_of_order_groups = set()
+
         for chunk_number, chunk_index in enumerate(summary.chunk_indexes):
             chunk_channel_ids = set(chunk_index.message_index_offsets.keys())
             if not chunk_channel_ids:
@@ -247,6 +250,14 @@ def diagnose(path: Path | str) -> DoctorReport:
                     topic = topics_by_channel_id[channel_id]
                     if topic in group_by_topic:
                         chunk_groups.add(group_by_topic[topic])
+
+                for group in chunk_groups:
+                    if (
+                        group in last_chunk_start_by_group
+                        and chunk_index.message_start_time < last_chunk_start_by_group[group]
+                    ):
+                        out_of_order_groups.add(group)
+                    last_chunk_start_by_group[group] = chunk_index.message_start_time
 
                 if len(chunk_groups) > 1:
                     mixed_topics = sorted(
@@ -275,6 +286,13 @@ def diagnose(path: Path | str) -> DoctorReport:
                         f"chunk {chunk_number} mixes video and state channels {mixed_topics}; "
                         "the default convention separates them",
                     )
+
+        for group in sorted(out_of_order_groups):
+            collector.add(
+                DiagnosticLevel.WARNING,
+                "group-chunks-out-of-order",
+                f"chunks for group {group!r} are not time-ordered",
+            )
 
         if provenance is None:
             collector.add(

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -231,8 +231,10 @@ def diagnose(path: Path | str) -> DoctorReport:
                 "no-chunk-indexes",
                 "no ChunkIndex records: the file is unchunked or unindexed",
             )
-        last_chunk_start_by_group = {}
-        out_of_order_groups = set()
+        # Item 3's second half: within one group the chunks must ascend by
+        # start time. Groups interleave freely, so this tracks each separately.
+        last_chunk_start_by_group: dict[str, int] = {}
+        out_of_order_groups: set[str] = set()
 
         for chunk_number, chunk_index in enumerate(summary.chunk_indexes):
             chunk_channel_ids = set(chunk_index.message_index_offsets.keys())

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -334,8 +334,8 @@ def test_group_chunks_out_of_order(tmp_path: Path) -> None:
         schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
         ch1 = writer.register_channel(topic="/alpha", message_encoding="json", schema_id=schema_id)
 
-        # force a chunk boundary by writing and flushing?
-        # we can just write 2000 bytes since chunk_size=1024
+        # chunk_size=1 puts every message in its own chunk, so the descending
+        # log times below are descending chunk start times.
         writer.add_message(ch1, log_time=1000, data=b"{" + b"a" * 2000 + b"}", publish_time=1000)
         writer.add_message(ch1, log_time=500, data=b"{}", publish_time=500)
         writer.finish()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -316,3 +316,109 @@ def test_chunk_mix_without_map(tmp_path: Path) -> None:
     codes = {finding.code for finding in report.findings}
     assert "chunk-mixes-video-and-state" in codes
     assert "chunk-mixes-groups" not in codes
+
+
+def test_group_chunks_out_of_order(tmp_path: Path) -> None:
+    path = tmp_path / "descending.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=1)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            data={
+                "group//alpha": "state",
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(topic="/alpha", message_encoding="json", schema_id=schema_id)
+
+        # force a chunk boundary by writing and flushing?
+        # we can just write 2000 bytes since chunk_size=1024
+        writer.add_message(ch1, log_time=1000, data=b"{" + b"a" * 2000 + b"}", publish_time=1000)
+        writer.add_message(ch1, log_time=500, data=b"{}", publish_time=500)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "group-chunks-out-of-order" in codes
+
+
+def test_group_chunks_ascending_is_clean(tmp_path: Path) -> None:
+    path = tmp_path / "ascending.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=1)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            data={
+                "group//alpha": "state",
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(topic="/alpha", message_encoding="json", schema_id=schema_id)
+        writer.add_message(ch1, log_time=500, data=b"x" * 2000, publish_time=500)
+        writer.add_message(ch1, log_time=1000, data=b"x" * 2000, publish_time=1000)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "group-chunks-out-of-order" not in codes
+
+
+def test_group_chunks_interleaved_different_groups_is_clean(tmp_path: Path) -> None:
+    path = tmp_path / "interleaved.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=1)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            data={
+                "group//alpha": "state1",
+                "group//beta": "state2",
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(topic="/alpha", message_encoding="json", schema_id=schema_id)
+        ch2 = writer.register_channel(topic="/beta", message_encoding="json", schema_id=schema_id)
+
+        # alpha chunk 1: t=1000
+        writer.add_message(ch1, log_time=1000, data=b"x" * 2000, publish_time=1000)
+        # beta chunk 1: t=500
+        writer.add_message(ch2, log_time=500, data=b"x" * 2000, publish_time=500)
+        # alpha chunk 2: t=2000 (ascending for alpha)
+        writer.add_message(ch1, log_time=2000, data=b"x" * 2000, publish_time=2000)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "group-chunks-out-of-order" not in codes
+
+
+def test_descending_without_map_is_clean(tmp_path: Path) -> None:
+    path = tmp_path / "descending_nomap.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=1)
+        writer.start(profile="", library="test")
+        writer.add_metadata(
+            name="provenance/v1",
+            data={
+                "schema_version": "1",
+                "pipeline_version": "1",
+            },
+        )
+        schema_id = writer.register_schema(name="dummy", encoding="json", data=b"{}")
+        ch1 = writer.register_channel(topic="/alpha", message_encoding="json", schema_id=schema_id)
+
+        writer.add_message(ch1, log_time=1000, data=b"x" * 2000, publish_time=1000)
+        writer.add_message(ch1, log_time=500, data=b"x" * 2000, publish_time=500)
+        writer.finish()
+
+    report = diagnose(path)
+    codes = {finding.code for finding in report.findings}
+    assert "group-chunks-out-of-order" not in codes


### PR DESCRIPTION
Resolves #239. This PR implements the second half of \FORMAT.md\ item 3, checking that chunks within a single group ascend strictly by \message_start_time\. It adds the \group-chunks-out-of-order\ warning finding, updates the documentation table, and includes 4 new test cases covering all edge cases defined in the issue.