### PR TITLE
fix: constrain hand-count evaluation schema

### DIFF
--- a/examples/build_ai_evaluation/judgment.py
+++ b/examples/build_ai_evaluation/judgment.py
@@ -53,7 +53,7 @@ class VisionCheckOutcome:
 
 HAND_COUNT_RESPONSE_SCHEMA: dict[str, object] = {
     "type": "object",
-    "properties": {"hand_count": {"type": "integer"}},
+    "properties": {"hand_count": {"type": "integer", "enum": [0, 1, 2]}},
     "required": ["hand_count"],
 }
 ACTIVE_MANIPULATION_RESPONSE_SCHEMA: dict[str, object] = {

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -76,14 +76,28 @@ _TASK_VALUE_CONTRACTS: dict[
 
 
 def test_task_schema_value_sets_match_their_parsers() -> None:
+    """Each task's schema must state the value set its parser enforces.
+
+    Both tasks answer from a closed set, so the schema can say so and a
+    provider doing constrained decoding will not emit anything else. When only
+    the parser knows, an out-of-set answer costs a request and lands as an
+    unparsed episode with no prediction (#257).
+    """
     executable_tasks = set(EvaluationTask) - {EvaluationTask.BOTH}
     assert set(_TASK_VALUE_CONTRACTS) == executable_tasks
 
-    for schema, property_name, parser, rejected_values in _TASK_VALUE_CONTRACTS.values():
+    for task, (schema, property_name, parser, rejected_values) in _TASK_VALUE_CONTRACTS.items():
         properties = cast(dict[str, dict[str, object]], schema["properties"])
-        permitted_values = cast(list[object], properties[property_name]["enum"])
+        property_schema = properties[property_name]
+        assert "enum" in property_schema, (
+            f"{task.value}: {property_name!r} has no 'enum', so its schema does not state the "
+            "value set its parser enforces and the model is free to answer outside it"
+        )
+        permitted_values = cast(list[object], property_schema["enum"])
         for value in permitted_values:
-            assert parser(json.dumps({property_name: value})) == value
+            assert parser(json.dumps({property_name: value})) == value, (
+                f"{task.value}: the schema permits {value!r} but the parser does not accept it"
+            )
         for value in rejected_values:
             with pytest.raises(ValueError):
                 parser(json.dumps({property_name: value}))

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -19,6 +21,8 @@ from examples.build_ai_evaluation.evaluate import (
     summarize_results,
 )
 from examples.build_ai_evaluation.judgment import (
+    ACTIVE_MANIPULATION_RESPONSE_SCHEMA,
+    HAND_COUNT_RESPONSE_SCHEMA,
     EvaluationTask,
     ResponseFormat,
     TaskDefinition,
@@ -50,6 +54,39 @@ class _FixtureCompletions:
 class _FixtureOpenAICompatibleClient:
     def __init__(self, response_text: str) -> None:
         self.chat = SimpleNamespace(completions=_FixtureCompletions(response_text))
+
+
+_TASK_VALUE_CONTRACTS: dict[
+    EvaluationTask,
+    tuple[dict[str, object], str, Callable[[str], int | str], tuple[object, ...]],
+] = {
+    EvaluationTask.HAND_COUNT: (
+        HAND_COUNT_RESPONSE_SCHEMA,
+        "hand_count",
+        parse_hand_count_response,
+        (-1, 3),
+    ),
+    EvaluationTask.ACTIVE_MANIPULATION: (
+        ACTIVE_MANIPULATION_RESPONSE_SCHEMA,
+        "answer",
+        parse_active_manipulation_response,
+        ("maybe", ""),
+    ),
+}
+
+
+def test_task_schema_value_sets_match_their_parsers() -> None:
+    executable_tasks = set(EvaluationTask) - {EvaluationTask.BOTH}
+    assert set(_TASK_VALUE_CONTRACTS) == executable_tasks
+
+    for schema, property_name, parser, rejected_values in _TASK_VALUE_CONTRACTS.values():
+        properties = cast(dict[str, dict[str, object]], schema["properties"])
+        permitted_values = cast(list[object], properties[property_name]["enum"])
+        for value in permitted_values:
+            assert parser(json.dumps({property_name: value})) == value
+        for value in rejected_values:
+            with pytest.raises(ValueError):
+                parser(json.dumps({property_name: value}))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- constrain `hand_count` structured output to the parser-supported values 0, 1, and 2
- add a table-driven contract test for both executable Build AI tasks
- fail the contract test when a future executable task is added without schema/parser coverage

Closes #257

## Validation
- `uv run --locked --project examples/build_ai_evaluation pytest -q examples/build_ai_evaluation/tests` (19 passed)
- `uv run pytest -q` (1190 passed, 11 skipped)
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run ty check`

This changes an evaluation check contract, not transform output, so no transform behavior version bump is required.