### PR TITLE
test: guard against module-level hflow_server imports under src/hflow

### DIFF
--- a/tests/test_server_import_boundary.py
+++ b/tests/test_server_import_boundary.py
@@ -1,0 +1,57 @@
+"""Architecture test for the hflow_server module-level import boundary."""
+
+import ast
+from pathlib import Path
+
+import hflow
+
+_MUST_NOT_IMPORT_SERVER_AT_MODULE_LEVEL = (
+    "hflow_server ships as a separate package (packages/hflow-server) so pipeline "
+    "workers never carry it. A module-level import anywhere under src/hflow/ would "
+    "make `import hflow.cli` -- and therefore every hflow command, not just "
+    "`serve` -- fail for anyone who installed only the core package. The existing "
+    "function-level import inside `_command_serve`, guarded by an `except "
+    "ImportError`, is the correct pattern and must stay function-scoped."
+)
+
+
+def _module_level_server_imports(source_path: Path) -> list[str]:
+    syntax_tree = ast.parse(source_path.read_text(), filename=str(source_path))
+    forbidden: list[str] = []
+    # Only the module's top-level statements matter here: a function-scoped
+    # import (like the one in cli.py's _command_serve) is deliberately allowed,
+    # so this does not walk into function or class bodies.
+    for syntax_node in syntax_tree.body:
+        if isinstance(syntax_node, ast.Import):
+            for imported_alias in syntax_node.names:
+                if imported_alias.name == "hflow_server" or imported_alias.name.startswith(
+                    "hflow_server."
+                ):
+                    forbidden.append(f"import {imported_alias.name}")
+        elif isinstance(syntax_node, ast.ImportFrom):
+            if syntax_node.level > 0:
+                continue
+            imported_module = syntax_node.module
+            if imported_module is not None and (
+                imported_module == "hflow_server" or imported_module.startswith("hflow_server.")
+            ):
+                forbidden.append(f"from {imported_module} import ...")
+    return forbidden
+
+
+def test_no_module_under_hflow_imports_server_at_module_level() -> None:
+    package_directory = Path(hflow.__file__).parent
+    forbidden_imports_by_source: dict[str, list[str]] = {}
+    for source_path in package_directory.rglob("*.py"):
+        forbidden = _module_level_server_imports(source_path)
+        if forbidden:
+            forbidden_imports_by_source[str(source_path.relative_to(package_directory))] = forbidden
+
+    assert forbidden_imports_by_source == {}, (
+        f"{_MUST_NOT_IMPORT_SERVER_AT_MODULE_LEVEL}\n"
+        "Offending imports: "
+        + ", ".join(
+            f"{source}: {', '.join(imports)}"
+            for source, imports in forbidden_imports_by_source.items()
+        )
+    )


### PR DESCRIPTION
## Scope

This addresses only item 2 of #261 (the server-import guard) — leaving item 1 (the `testing.py` boundary) open, per the issue's own note that "a partial fix is welcome and the remainder can stay open."

## What this adds

`hflow_server` ships as a separate package (`packages/hflow-server`) so pipeline workers never carry it. `cli.py`'s `_command_serve` already imports it correctly at function scope, guarded by `except ImportError`, but nothing enforced that staying true — a module-level import anywhere under `src/hflow/` would make `import hflow.cli` fail for anyone who installed only the core package.

Added `test_no_module_under_hflow_imports_server_at_module_level`, following the same `ast`-based pattern as `test_video_measurement_boundary.py`. I chose static `ast` analysis over a `sys.modules` post-import check because it's consistent with the existing pattern in this codebase and catches the violation from source without needing a real `hflow_server` install in the test environment.

The check only inspects each module's **top-level** statements (not `ast.walk`, which would recurse into function bodies) — this is deliberate, so the existing function-scoped import in `_command_serve` stays valid and isn't pushed toward module scope.

## Testing

I don't have a Linux/macOS environment available (this repo's `hflow.storage` imports `fcntl`, a POSIX-only module, so the package doesn't import at all on Windows — unrelated to this change). I validated the actual detection logic directly instead of via `pytest`, per the issue's "prove it" requirement:

- Ran the check against the real, current `src/hflow/cli.py` and the whole `src/hflow/` tree — zero false positives, confirming the existing function-scoped import is correctly allowed.
- Reproduced the exact bug scenario in an isolated snippet (`from hflow_server import ServerSettings` at module level) — confirmed it's caught.
- Confirmed a function-scoped equivalent of that same import is *not* flagged.

Also ran `uv run ruff check --fix` and `uv run ruff format` on the new file — both clean.

I'd appreciate a maintainer (or CI) running the actual `pytest` suite to confirm, since I could only verify the logic in isolation here.

Contributes to #261