### PR TITLE
fix(checks): report camera decode deficit

### DIFF
--- a/.changeset/report-camera-decode-deficit.md
+++ b/.changeset/report-camera-decode-deficit.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Report camera frames that arrive but fail to decode.

--- a/.changeset/report-camera-decode-deficit.md
+++ b/.changeset/report-camera-decode-deficit.md
@@ -1,5 +1,0 @@
----
-"hunkdiff": patch
----
-
-Report camera frames that arrive but fail to decode.

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -183,9 +183,15 @@ as media, so a user key there would ship as media the pipeline never produced.
 Keys containing `/` need double quotes in SQL:
 
 ```sql
-SELECT episode_id, "/wrist_cam/compressed/black_frame_pct" AS black_pct
-FROM episodes WHERE black_pct < 5.0
+SELECT episode_id,
+       "/wrist_cam/compressed/black_frame_pct" AS black_pct,
+       "/wrist_cam/compressed/decode_deficit_pct" AS decode_deficit_pct
+FROM episodes WHERE black_pct < 5.0 AND decode_deficit_pct = 0.0
 ```
+
+The built-in `camera_frame_stats` check keeps two deficits separate:
+`frame_deficit_pct` measures missing messages against the expected rate, while
+`decode_deficit_pct` measures messages present whose frames did not decode.
 
 **Omit the key rather than measuring NaN or infinity.** A non-finite float is
 refused at append time, naming the check and the key. NaN compares false against

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -410,7 +410,7 @@ def _camera_frame_stats_keys(episode: Episode, *, cameras: Sequence[str] | None 
 
     Per topic: ``message_count`` always; ``expected_frame_count`` and
     ``frame_deficit_pct`` only when the topic carries at least two messages;
-    the seven decoded-evidence keys always. ``camera_instrument`` and
+    the eight decoded-evidence keys always. ``camera_instrument`` and
     ``camera_measurement_definition`` are the two non-topic keys; they ride
     inside the per-topic selection, so an episode with no cameras emits
     nothing at all.
@@ -426,6 +426,7 @@ def _camera_frame_stats_keys(episode: Episode, *, cameras: Sequence[str] | None 
             f"{topic}/{name}"
             for name in (
                 "decoded_frame_count",
+                "decode_deficit_pct",
                 "black_frame_pct",
                 "overexposed_frame_pct",
                 "freeze_total_s",
@@ -529,6 +530,11 @@ def _camera_value(
                 )
             case "decoded_frame_count":
                 return inter.stats.decoded_frame_count
+            case "decode_deficit_pct":
+                message_count = inter.stamps_ns.size
+                return float(
+                    100.0 * (message_count - inter.stats.decoded_frame_count) / message_count
+                )
             case "black_frame_pct":
                 return inter.stats.black_frame_percent
             case "overexposed_frame_pct":
@@ -571,8 +577,8 @@ def camera_frame_stats(
     (blackframe + freezedetect + signalstats in one filter graph, one shared
     frame denominator) over each camera's lossless MP4 remux, and compares
     the stored frame count against the rate the stream claims (declared
-    ``expected_hz`` when given, else the stream's median delta) -- the
-    LeRobot-style frame-count-vs-rate question. Freeze spans become labeled
+    ``expected_hz`` when given, else the stream's median delta), and compares
+    messages present with frames decoded. Freeze spans become labeled
     ``freeze:<topic>`` intervals in log time. Requires a canonical episode
     (``Episode.video`` remuxes in-band H.264 only).
 
@@ -1916,7 +1922,7 @@ def keyframe_interval(episode: Episode, *, cameras: Sequence[str] | None = None)
 _DEFAULT_CHECK_VERSION_BY_FUNCTION: dict[CheckFunction, str] = {
     episode_duration: "1",
     timestamp_regularity: "1",
-    camera_frame_stats: "1",
+    camera_frame_stats: "2",
     keyframe_interval: "1",
     content_digest: "1",
     media_digest: "1",

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -532,6 +532,11 @@ def _camera_value(
                 return inter.stats.decoded_frame_count
             case "decode_deficit_pct":
                 message_count = inter.stamps_ns.size
+                if message_count == 0:
+                    raise ValueError(
+                        f"{key!r} has no message denominator: decode deficit is undefined "
+                        "for an empty camera topic"
+                    )
                 return float(
                     100.0 * (message_count - inter.stats.decoded_frame_count) / message_count
                 )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -384,6 +384,7 @@ def test_camera_frame_stats_sees_the_injected_black_segment(tmp_path: Path) -> N
     message_count = result.measurements[f"{camera_topic}/message_count"]
     decoded_frame_count = result.measurements[f"{camera_topic}/decoded_frame_count"]
     assert message_count == decoded_frame_count
+    assert result.measurements[f"{camera_topic}/decode_deficit_pct"] == pytest.approx(0.0)
     # No dropped frames were injected: the stored count matches the rate.
     assert result.measurements[f"{camera_topic}/frame_deficit_pct"] == pytest.approx(0.0)
     assert result.measurements[f"{camera_topic}/expected_frame_count"] == message_count

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1,5 +1,6 @@
 """The baseline every episode gets without anyone registering it."""
 
+import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from pathlib import Path
@@ -7,6 +8,9 @@ from typing import Any
 
 import numpy as np
 import pytest
+from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
+from mcap.writer import Writer as StockWriter
+from mcap_protobuf.schema import build_file_descriptor_set
 
 import hflow
 from hflow._video_measurements import (
@@ -34,7 +38,9 @@ from hflow.checks import (
     camera_frame_stats,
     episode_duration,
 )
+from hflow.ffmpeg import ffmpeg_path
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+from hflow.video import split_annex_b_stream
 
 
 @pytest.fixture(scope="module")
@@ -65,7 +71,14 @@ def test_a_pipeline_that_registers_nothing_still_records_evidence(
         "media_digest",
     }
     assert len(DEFAULT_CHECKS) == len(measured)
-    assert {run.check.version for run in report.checks} == {"1"}
+    assert {run.check.name: run.check.version for run in report.checks} == {
+        "episode_duration": "1",
+        "timestamp_regularity": "1",
+        "camera_frame_stats": "2",
+        "keyframe_interval": "1",
+        "content_digest": "1",
+        "media_digest": "1",
+    }
     duration = next(run for run in report.checks if run.check.name == "episode_duration")
     assert duration.result is not None
     assert duration.result.measurements["duration_s"] == pytest.approx(1.0, abs=0.2)
@@ -552,6 +565,7 @@ def _pinned_camera_measurements(
     pinned: dict[str, object] = {
         f"{topic}/message_count": frames,
         f"{topic}/decoded_frame_count": frames,
+        f"{topic}/decode_deficit_pct": 0.0,
         f"{topic}/freeze_total_s": 0.0,
         f"{topic}/black_frame_pct": black_frame_pct,
         f"{topic}/overexposed_frame_pct": overexposed_frame_pct,
@@ -701,6 +715,7 @@ def test_a_single_stamp_camera_topic_errors_before_any_measurement(
     assert _camera_frame_stats_keys(Episode(report.canonical_path), cameras=[topic]) == {
         f"{topic}/message_count",
         f"{topic}/decoded_frame_count",
+        f"{topic}/decode_deficit_pct",
         f"{topic}/black_frame_pct",
         f"{topic}/overexposed_frame_pct",
         f"{topic}/freeze_total_s",
@@ -739,6 +754,7 @@ def test_the_body_emits_what_the_fact_names_even_when_the_fact_withdraws_one(
         f"{topic}/expected_frame_count",
         f"{topic}/frame_deficit_pct",
         f"{topic}/decoded_frame_count",
+        f"{topic}/decode_deficit_pct",
         f"{topic}/overexposed_frame_pct",
         f"{topic}/freeze_total_s",
         f"{topic}/luma_avg_mean",
@@ -886,6 +902,84 @@ def test_dispatcher_message_count_and_decoded_frame_count_read_distinct_sources(
     assert _camera_value("/cam0/decoded_frame_count", by_topic) == 15
     # A swap that returns 15 for message_count -- or 13 for decoded_frame_count
     # -- would have to break both asserts, not just one.
+
+
+def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Path) -> None:
+    """B-frame reorder loss is visible separately from missing messages."""
+    encoded = subprocess.run(
+        [
+            str(ffmpeg_path()),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x120:rate=30:duration=3,format=yuv420p",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-g",
+            "30",
+            "-keyint_min",
+            "30",
+            "-sc_threshold",
+            "0",
+            "-x264-params",
+            "aud=1:repeat-headers=1",
+            "-f",
+            "h264",
+            "pipe:1",
+        ],
+        capture_output=True,
+        check=True,
+    )
+    access_units = split_annex_b_stream(encoded.stdout)
+    assert len(access_units) == 90
+
+    source = tmp_path / "b-frames.mcap"
+    with source.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        topic = "/camera/compressed"
+        channel_id = writer.register_channel(
+            topic=topic, message_encoding="protobuf", schema_id=schema_id
+        )
+        start_time_ns = 1_000_000_000
+        for frame_index, access_unit in enumerate(access_units):
+            log_time_ns = start_time_ns + round(frame_index * 1_000_000_000 / 30)
+            message = CompressedVideo()
+            message.timestamp.FromNanoseconds(log_time_ns)
+            message.frame_id = "camera"
+            message.data = access_unit.data
+            message.format = "h264"
+            writer.add_message(
+                channel_id,
+                log_time=log_time_ns,
+                data=message.SerializeToString(),
+                publish_time=log_time_ns,
+                sequence=frame_index,
+            )
+        writer.finish()
+
+    with hflow.Episode(source) as episode:
+        result = camera_frame_stats(episode)
+
+    message_count = result.measurements[f"{topic}/message_count"]
+    decoded_frame_count = result.measurements[f"{topic}/decoded_frame_count"]
+    assert isinstance(message_count, int)
+    assert isinstance(decoded_frame_count, int)
+    assert message_count == 90
+    assert decoded_frame_count < message_count
+    assert result.measurements[f"{topic}/decode_deficit_pct"] == pytest.approx(
+        100.0 * (message_count - decoded_frame_count) / message_count
+    )
 
 
 # episode_duration: three fixed keys, independent of which topics the episode

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -900,12 +900,19 @@ def test_dispatcher_message_count_and_decoded_frame_count_read_distinct_sources(
 
     assert _camera_value("/cam0/message_count", by_topic) == 13
     assert _camera_value("/cam0/decoded_frame_count", by_topic) == 15
+    assert _camera_value("/cam0/decode_deficit_pct", by_topic) == pytest.approx(
+        100.0 * (13 - 15) / 13
+    )
     # A swap that returns 15 for message_count -- or 13 for decoded_frame_count
     # -- would have to break both asserts, not just one.
 
+    empty_topic = {"/cam0": replace(inter, stamps_ns=np.asarray([], dtype=np.int64))}
+    with pytest.raises(ValueError, match="decode deficit is undefined"):
+        _camera_value("/cam0/decode_deficit_pct", empty_topic)
+
 
 def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Path) -> None:
-    """B-frame reorder loss is visible separately from missing messages."""
+    """A recorder message without a coded picture creates a decode deficit."""
     encoded = subprocess.run(
         [
             str(ffmpeg_path()),
@@ -927,7 +934,7 @@ def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Pat
             "-sc_threshold",
             "0",
             "-x264-params",
-            "aud=1:repeat-headers=1",
+            "aud=1:bframes=0:repeat-headers=1",
             "-f",
             "h264",
             "pipe:1",
@@ -938,7 +945,8 @@ def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Pat
     access_units = split_annex_b_stream(encoded.stdout)
     assert len(access_units) == 90
 
-    source = tmp_path / "b-frames.mcap"
+    source = tmp_path / "missing-picture.mcap"
+    access_unit_delimiter_only = b"\x00\x00\x00\x01\x09\xf0"
     with source.open("wb") as stream:
         writer = StockWriter(stream)
         writer.start(profile="", library="test")
@@ -957,7 +965,11 @@ def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Pat
             message = CompressedVideo()
             message.timestamp.FromNanoseconds(log_time_ns)
             message.frame_id = "camera"
-            message.data = access_unit.data
+            message.data = (
+                access_unit_delimiter_only
+                if frame_index == len(access_units) - 1
+                else access_unit.data
+            )
             message.format = "h264"
             writer.add_message(
                 channel_id,
@@ -976,7 +988,7 @@ def test_camera_frame_stats_reports_frames_present_but_not_decoded(tmp_path: Pat
     assert isinstance(message_count, int)
     assert isinstance(decoded_frame_count, int)
     assert message_count == 90
-    assert decoded_frame_count < message_count
+    assert decoded_frame_count == message_count - 1
     assert result.measurements[f"{topic}/decode_deficit_pct"] == pytest.approx(
         100.0 * (message_count - decoded_frame_count) / message_count
     )


### PR DESCRIPTION
## Summary

Adds `<topic>/decode_deficit_pct` to the built-in `camera_frame_stats` check so recordings expose messages whose video frames did not decode. The catalog documentation distinguishes it from the existing rate-based deficit.

## Why

`frame_deficit_pct` compares received messages with the expected message rate. A stream can receive every message and still decode fewer frames, as #254 demonstrates. The new key preserves both questions instead of changing the existing measurement.

Closes #254.

The automatic `camera_frame_stats` version changes from `1` to `2` because its result rows gain a key.

## Regression coverage

The shortfall fixture uses an H.264 stream encoded with `bframes=0`, then models a faulty recorder by replacing its final frame payload with an access-unit delimiter that contains no coded picture. This gives 90 messages and exactly 89 decoded frames without depending on the open B-frame remux bug in #255. A healthy canonical episode separately asserts `decode_deficit_pct == 0.0`.

An empty camera topic has no valid percentage denominator, so the dispatcher now raises a named `ValueError` instead of dividing by zero. The normal `camera_frame_stats` path already rejects fewer than two timestamps while constructing the video.

## Validation

- `uv sync --locked --all-extras`: passed
- `uv run ruff check --fix`: passed
- `uv run ruff format`: passed
- `uv run ty check`: passed
- `uv run pytest -q`: 1,191 passed, 11 skipped
- `lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .`: 354 links checked, 0 errors

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
