### PR TITLE
fix(server): warn on non-loopback binds

### DIFF
--- a/packages/hflow-server/src/hflow_server/server.py
+++ b/packages/hflow-server/src/hflow_server/server.py
@@ -12,8 +12,10 @@ identity.
 """
 
 import importlib.resources
+import ipaddress
 import os
 import socket
+import sys
 import threading
 import webbrowser
 from pathlib import Path
@@ -439,6 +441,16 @@ class ServerStartupError(RuntimeError):
     """
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return whether a host is a loopback IP literal or the localhost name."""
+    if host.casefold() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def serve(settings: ServerSettings) -> None:
     """Run the workspace server: free port, printed URL, browser, uvicorn."""
     application = create_app(settings)
@@ -453,6 +465,14 @@ def serve(settings: ServerSettings) -> None:
     url_host = "127.0.0.1" if settings.host == "0.0.0.0" else settings.host
     workspace_url = f"http://{url_host}:{chosen_port}/"
     print(f"hflow serve: serving {settings.data_root} at {workspace_url}", flush=True)
+    if not _is_loopback_host(settings.host):
+        print(
+            f"hflow serve: warning: binding to {settings.host} exposes this unauthenticated "
+            "workspace to reachable networks; use a loopback host and SSH port forwarding "
+            "for remote access",
+            file=sys.stderr,
+            flush=True,
+        )
     if settings.open_browser:
         # uvicorn.run blocks this thread; a short timer opens the browser
         # once the server has had time to bind.

--- a/packages/hflow-server/tests/test_server_launch.py
+++ b/packages/hflow-server/tests/test_server_launch.py
@@ -1,0 +1,89 @@
+"""Observable startup output from ``hflow serve``."""
+
+from pathlib import Path
+
+import pytest
+from hflow_server import ServerSettings
+from hflow_server import server as server_module
+
+
+def _launch_without_starting_server(
+    host: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    def fake_create_app(_settings: ServerSettings) -> object:
+        return object()
+
+    def choose_requested_port(_host: str, requested_port: int) -> int:
+        return requested_port
+
+    def do_not_start_uvicorn(*_args: object, **_kwargs: object) -> None:
+        pass
+
+    monkeypatch.setattr(server_module, "create_app", fake_create_app)
+    monkeypatch.setattr(server_module, "_first_free_port", choose_requested_port)
+    monkeypatch.setattr(server_module.uvicorn, "run", do_not_start_uvicorn)
+
+    data_root = tmp_path / "workspace"
+    server_module.serve(
+        ServerSettings(
+            data_root=str(data_root),
+            host=host,
+            port=4356,
+            open_browser=False,
+        )
+    )
+    return data_root
+
+
+def test_loopback_launch_output_is_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_root = _launch_without_starting_server("127.0.0.1", tmp_path, monkeypatch)
+
+    captured = capsys.readouterr()
+    assert captured.out == f"hflow serve: serving {data_root} at http://127.0.0.1:4356/\n"
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("host", "warning_expected"),
+    [
+        ("127.0.0.42", False),
+        ("::1", False),
+        ("localhost", False),
+        ("LOCALHOST", False),
+        ("::", True),
+        ("192.168.1.42", True),
+        ("workspace.example.com", True),
+    ],
+)
+def test_warning_is_only_printed_for_non_loopback_hosts(
+    host: str,
+    warning_expected: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _launch_without_starting_server(host, tmp_path, monkeypatch)
+
+    captured = capsys.readouterr()
+    assert bool(captured.err) is warning_expected
+
+
+def test_wildcard_launch_warns_without_changing_the_dialable_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_root = _launch_without_starting_server("0.0.0.0", tmp_path, monkeypatch)
+
+    captured = capsys.readouterr()
+    assert captured.out == f"hflow serve: serving {data_root} at http://127.0.0.1:4356/\n"
+    assert captured.err == (
+        "hflow serve: warning: binding to 0.0.0.0 exposes this unauthenticated workspace "
+        "to reachable networks; use a loopback host and SSH port forwarding for remote access\n"
+    )


### PR DESCRIPTION
## Summary

- print one actionable warning on stderr when `hflow serve` binds beyond loopback
- classify IPv4 and IPv6 literals with `ipaddress`, while treating case-insensitive `localhost` as the only safe hostname
- preserve the existing bind behavior and dialable URL on stdout

Closes #259

## Why

The existing launch line rewrites `0.0.0.0` to a usable `127.0.0.1` URL, which is correct, but it leaves an unauthenticated network-wide bind looking identical to a loopback bind. The warning now lives in `serve()` beside that launch output, where both the configured host and the operator-visible URL are available.

Stderr keeps the established stdout line unchanged for scripts and supervisors. For IP literals, `ipaddress.ip_address(...).is_loopback` handles the full `127.0.0.0/8` range and `::1`. Exact `localhost`, matched case-insensitively, is the only hostname treated as loopback; other hostnames warn conservatively rather than relying on environment-dependent DNS resolution.

This does not refuse or alter any bind, change the default, or change the displayed dialable URL. No documentation change is included because `docs/SERVE.md` already states the trust posture and recommends loopback plus SSH port forwarding.

## Validation

- TDD RED: the wildcard launch regression failed against unchanged `main` because stderr was empty
- focused WSL2 suite: `uv run pytest -q packages/hflow-server/tests tests/test_runtime_cli.py` (`281 passed`)
- Python 3.11.16: `uv sync --locked --python 3.11`; `uv run ruff check`; `uv run ruff format --check`; `uv run ty check`; `uv run pytest -q` (`1204 passed, 6 skipped`)
- Python 3.14.7: `UV_MANAGED_PYTHON=1 uv sync --locked --python 3.14`; `uv run ruff check`; `uv run ruff format --check`; `uv run ty check`; `uv run pytest -q` (`1204 passed, 6 skipped`)
- repository write-mode checks: `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` (passed; formatter changed no files)
- real WSL2 launch: loopback printed no warning; `0.0.0.0` printed exactly one warning while stdout still advertised `http://127.0.0.1:<port>/`

## Checklist

- [x] I added outcome-focused tests for changed business logic.
- [x] Documentation remains current for this behavior; `docs/SERVE.md` already documents the trust posture and SSH forwarding alternative.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite and the complete suite on Python 3.11 and 3.14.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged.
