### PR TITLE
feat(examples): add natural EgoSuite sampling

### DIFF
--- a/docs/how-to/run-egosuite-hand-evaluation.md
+++ b/docs/how-to/run-egosuite-hand-evaluation.md
@@ -132,11 +132,37 @@ file records the projected joint count for each hand, the resulting hand count,
 the exact source frame index, and any pose-quality reasons. Run `labels` first
 on a new corpus to inspect class balance before interpreting model accuracy.
 
-For a class-balanced comparison, add `--samples-per-hand-count N`. The command
-deterministically selects up to `N` frames from each projected class across all
-input episodes. `--sample-seed` defaults to 42, and both values are recorded in
-the label report or run contract. `--frame-stride` is applied first, so use
-`--frame-stride 1` when every source frame should be eligible for sampling.
+For a naturally distributed random sample, select episodes and then select
+temporally separated frames within each episode:
+
+```bash
+uv run --project examples/egosuite_evaluation \
+    python examples/egosuite_evaluation/evaluate.py labels \
+    data/egosuite-evaluation/datasets/EgoDemo \
+    --episode-count 100 \
+    --frame-stride 30 \
+    --samples-per-episode 10 \
+    --sample-seed 42 \
+    --output data/egosuite-evaluation/labels/natural-1000.json
+```
+
+`--episode-count` samples from the MCAPs available under the supplied inputs;
+it does not download missing episodes. Sampling the same number of frames from
+each selected episode prevents long recordings from dominating. The frame
+stride is applied before random selection, so the command above samples at
+most ten one-per-second candidates from each of 100 episodes.
+
+The natural sample is the appropriate primary result when measuring expected
+performance on the source distribution. The summary also reports per-class
+agreement and macro agreement so a frequent class cannot hide failures on a
+rare class.
+
+For a class-balanced diagnostic, add `--samples-per-hand-count N`. The command
+deterministically selects up to `N` frames from each projected class after the
+episode and frame selection. `--sample-seed` defaults to 42, and every
+selection value is recorded in the label report or run contract. Use
+`--frame-stride 1` when every source frame should be eligible for the
+diagnostic slice.
 
 Pass a directory to recursively include every MCAP under it:
 
@@ -173,23 +199,26 @@ uv run --project examples/egosuite_evaluation \
     --output data/egosuite-evaluation/runs/gemma-thimble-removal
 ```
 
-After inspecting the full label distribution, run a declared stratified sample
+After inspecting the full label distribution, run a declared natural sample
 over a directory or several MCAP paths:
 
 ```bash
 uv run --project examples/egosuite_evaluation \
     python examples/egosuite_evaluation/evaluate.py run \
     data/egosuite-evaluation/datasets/EgoDemo/EgoStand/mcap \
-    --frame-stride 1 \
-    --samples-per-hand-count 100 \
+    --episode-count 100 \
+    --frame-stride 30 \
+    --samples-per-episode 10 \
     --sample-seed 42 \
     --api-key-env OPENROUTER_API_KEY \
-    --output data/egosuite-evaluation/runs/gemma-stratified-300
+    --output data/egosuite-evaluation/runs/gemma-natural-1000
 ```
 
-This requests at most 300 images. If a class has fewer than 100 eligible
+This requests at most 1,000 images. If an episode has fewer than ten eligible
 frames, all of its frames are retained and the printed target counts expose the
-shortfall.
+shortfall. Add `--samples-per-hand-count` to create a separate rare-case
+diagnostic run; do not describe its constructed class proportions as the
+dataset's natural distribution.
 
 For an unauthenticated self-hosted endpoint, add
 `--allow-missing-api-key`. The model, endpoint, prompt, response format,
@@ -225,8 +254,9 @@ uv run --project examples/egosuite_evaluation \
     data/egosuite-evaluation/runs/qwen-thimble-removal/summary.json
 ```
 
-Agreement must be interpreted with the reference distribution and confusion
-matrix. If nearly every selected frame contains two projected hands, a model
-that always answers `2` can have high accuracy without solving the minority
-cases. Expand the episode set or use `--samples-per-hand-count` before making a
-comparative capability claim.
+Agreement must be interpreted with the reference distribution, per-class
+agreement, macro agreement, and confusion matrix. If nearly every selected
+frame contains two projected hands, a model that always answers `2` can have
+high natural-sample accuracy without solving the minority cases. Report that
+distributional result as-is, then use a separately identified
+`--samples-per-hand-count` slice to compare rare-case behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -120,8 +120,8 @@ First calculate labels without calling a model:
 ```bash
 uv run --project examples/egosuite_evaluation \
     python examples/egosuite_evaluation/evaluate.py labels \
-    data/egosuite-evaluation/datasets/EgoDemo/EgoStand/mcap \
-    --frame-stride 30
+    data/egosuite-evaluation/datasets/EgoDemo \
+    --episode-count 100 --frame-stride 30 --samples-per-episode 10
 ```
 
 Then run the same selected frames through a VLM:
@@ -129,8 +129,8 @@ Then run the same selected frames through a VLM:
 ```bash
 uv run --project examples/egosuite_evaluation \
     python examples/egosuite_evaluation/evaluate.py run \
-    data/egosuite-evaluation/datasets/EgoDemo/EgoStand/mcap \
-    --frame-stride 30 --limit-per-episode 10 \
+    data/egosuite-evaluation/datasets/EgoDemo \
+    --episode-count 100 --frame-stride 30 --samples-per-episode 10 \
     --api-key-env OPENROUTER_API_KEY
 ```
 
@@ -138,7 +138,10 @@ For every selected frame, the example inverts the labeled camera pose,
 projects both sets of 21 world-space hand joints through the camera intrinsic
 matrix, and counts a hand when at least one joint lands inside the image. The
 VLM receives only the extracted JPEG. Inspect AI writes its structured logs
-and an agreement/confusion summary under `data/egosuite-evaluation/runs/`.
+and dataset-weighted, per-class, macro-agreement, and confusion summaries under
+`data/egosuite-evaluation/runs/`. A separately declared
+`--samples-per-hand-count` slice can diagnose rare classes without presenting
+constructed class proportions as the dataset's natural distribution.
 
 Guide, download command, label contract, and interpretation:
 [Evaluate VLM hand counts against EgoSuite joint labels](../docs/how-to/run-egosuite-hand-evaluation.md)

--- a/examples/egosuite_evaluation/evaluate.py
+++ b/examples/egosuite_evaluation/evaluate.py
@@ -131,6 +131,8 @@ class EvaluationConfiguration:
     camera_view: CameraView
     frame_stride: int
     limit_per_episode: int | None
+    episode_count: int | None
+    samples_per_episode: int | None
     samples_per_hand_count: int | None
     sample_seed: int
     output_directory: Path
@@ -193,15 +195,57 @@ def _source_episode_name(source_path: Path) -> str:
     return source_path.stem
 
 
-def _selected_frame_index(
-    source_frame_index: int,
+def select_episode_paths(
+    source_paths: Sequence[Path],
+    *,
+    episode_count: int | None,
+    sample_seed: int,
+) -> tuple[Path, ...]:
+    """Select a reproducible uniform sample of episodes."""
+
+    if episode_count is None:
+        return tuple(source_paths)
+    if episode_count <= 0:
+        raise ValueError("episode count must be positive")
+    if sample_seed < 0:
+        raise ValueError("sample seed must be nonnegative")
+    ranked_source_paths = sorted(
+        source_paths,
+        key=lambda source_path: _sha256_text(f"{sample_seed}\0{_source_episode_name(source_path)}"),
+    )
+    selected_source_paths = set(ranked_source_paths[:episode_count])
+    return tuple(
+        source_path for source_path in source_paths if source_path in selected_source_paths
+    )
+
+
+def _selected_frame_indices(
+    source_path: Path,
+    source_frame_count: int,
+    *,
     frame_stride: int,
     limit_per_episode: int | None,
-) -> bool:
-    if source_frame_index % frame_stride != 0:
-        return False
-    selected_ordinal = source_frame_index // frame_stride
-    return limit_per_episode is None or selected_ordinal < limit_per_episode
+    samples_per_episode: int | None,
+    sample_seed: int,
+) -> list[int]:
+    if limit_per_episode is not None and samples_per_episode is not None:
+        raise ValueError("limit per episode and samples per episode are mutually exclusive")
+    eligible_frame_indices = list(range(0, source_frame_count, frame_stride))
+    if limit_per_episode is not None:
+        return eligible_frame_indices[:limit_per_episode]
+    if samples_per_episode is None:
+        return eligible_frame_indices
+    if samples_per_episode <= 0:
+        raise ValueError("samples per episode must be positive")
+    if sample_seed < 0:
+        raise ValueError("sample seed must be nonnegative")
+    ranked_frame_indices = sorted(
+        eligible_frame_indices,
+        key=lambda frame_index: _sha256_text(
+            f"{sample_seed}\0{_source_episode_name(source_path)}\0{frame_index}"
+        ),
+    )
+    return sorted(ranked_frame_indices[:samples_per_episode])
 
 
 def _message_header_count(decoded_message: Any) -> int | None:
@@ -381,6 +425,8 @@ def load_projected_hand_labels(
     camera_view: CameraView,
     frame_stride: int,
     limit_per_episode: int | None,
+    samples_per_episode: int | None = None,
+    sample_seed: int = 42,
 ) -> list[ProjectedHandFrameLabel]:
     """Read synchronized EgoSuite labels without decoding the video payloads."""
 
@@ -402,11 +448,14 @@ def load_projected_hand_labels(
         camera_view,
         _topic_message_counts(source_path),
     )
-    selected_frame_indices = [
-        frame_index
-        for frame_index in range(source_frame_count)
-        if _selected_frame_index(frame_index, frame_stride, limit_per_episode)
-    ]
+    selected_frame_indices = _selected_frame_indices(
+        source_path,
+        source_frame_count,
+        frame_stride=frame_stride,
+        limit_per_episode=limit_per_episode,
+        samples_per_episode=samples_per_episode,
+        sample_seed=sample_seed,
+    )
     partial_geometry_by_frame = {
         frame_index: _PartialFrameGeometry() for frame_index in selected_frame_indices
     }
@@ -838,6 +887,8 @@ def write_label_report(
     camera_view: CameraView,
     frame_stride: int,
     limit_per_episode: int | None,
+    episode_count: int | None,
+    samples_per_episode: int | None,
     samples_per_hand_count: int | None,
     sample_seed: int,
     output_path: Path,
@@ -849,6 +900,8 @@ def write_label_report(
         "camera_view": camera_view.value,
         "frame_stride": frame_stride,
         "limit_per_episode": limit_per_episode,
+        "episode_count": episode_count,
+        "samples_per_episode": samples_per_episode,
         "samples_per_hand_count": samples_per_hand_count,
         "sample_seed": sample_seed,
         "projection_rule": "hand is in frame when at least one labeled joint has positive depth and projects inside the image bounds",
@@ -871,6 +924,8 @@ def _run_metadata(configuration: EvaluationConfiguration) -> dict[str, object]:
         "camera_view": configuration.camera_view.value,
         "frame_stride": configuration.frame_stride,
         "limit_per_episode": configuration.limit_per_episode,
+        "episode_count": configuration.episode_count,
+        "samples_per_episode": configuration.samples_per_episode,
         "samples_per_hand_count": configuration.samples_per_hand_count,
         "sample_seed": configuration.sample_seed,
         "projection_contract": {
@@ -1003,6 +1058,29 @@ def _evaluation_result_summary(results: Sequence[dict[str, object]]) -> dict[str
     agreement_count = sum(
         result["expected_value"] == result["predicted_value"] for result in valid_results
     )
+    per_class_agreement: dict[str, dict[str, int | float | None]] = {}
+    valid_class_agreement_fractions: list[float] = []
+    attempted_class_agreement_fractions: list[float] = []
+    for expected_value, attempted_count in sorted(expected_counts.items()):
+        valid_count = sum(
+            confusion_counts.get((expected_value, predicted_value), 0)
+            for predicted_value in (0, 1, 2)
+        )
+        class_agreement_count = confusion_counts.get((expected_value, expected_value), 0)
+        valid_class_agreement_fraction = (
+            class_agreement_count / valid_count if valid_count else None
+        )
+        attempted_class_agreement_fraction = class_agreement_count / attempted_count
+        per_class_agreement[str(expected_value)] = {
+            "attempted_count": attempted_count,
+            "valid_count": valid_count,
+            "agreement_count": class_agreement_count,
+            "agreement_fraction": valid_class_agreement_fraction,
+            "attempted_agreement_fraction": attempted_class_agreement_fraction,
+        }
+        if valid_class_agreement_fraction is not None:
+            valid_class_agreement_fractions.append(valid_class_agreement_fraction)
+        attempted_class_agreement_fractions.append(attempted_class_agreement_fraction)
     latency_values = [
         float(latency)
         for result in results
@@ -1029,6 +1107,17 @@ def _evaluation_result_summary(results: Sequence[dict[str, object]]) -> dict[str
         "agreement_count": agreement_count,
         "agreement_fraction": agreement_count / len(valid_results) if valid_results else None,
         "attempted_agreement_fraction": agreement_count / len(results) if results else None,
+        "macro_agreement_fraction": (
+            sum(valid_class_agreement_fractions) / len(valid_class_agreement_fractions)
+            if valid_class_agreement_fractions
+            else None
+        ),
+        "macro_attempted_agreement_fraction": (
+            sum(attempted_class_agreement_fractions) / len(attempted_class_agreement_fractions)
+            if attempted_class_agreement_fractions
+            else None
+        ),
+        "per_class_agreement": per_class_agreement,
         "confusion_matrix": {
             str(expected): {
                 str(predicted): confusion_counts.get((expected, predicted), 0)
@@ -1056,6 +1145,8 @@ def summarize_evaluation_results(
         "model": run_metadata["model"],
         "camera_view": run_metadata["camera_view"],
         "frame_stride": run_metadata["frame_stride"],
+        "episode_count": run_metadata.get("episode_count"),
+        "samples_per_episode": run_metadata.get("samples_per_episode"),
         "samples_per_hand_count": run_metadata["samples_per_hand_count"],
         "sample_seed": run_metadata["sample_seed"],
         "overall": _evaluation_result_summary(deduplicated_results),
@@ -1083,16 +1174,17 @@ def _print_evaluation_summary(summary: Mapping[str, object]) -> None:
     print(f"\nEgoSuite projected-hand evaluation: {summary['label']}")
     print(
         "| valid / attempted | target 0 | target 1 | target 2 | predicted 0 | predicted 1 | "
-        "predicted 2 | valid accuracy | end-to-end accuracy |"
+        "predicted 2 | valid accuracy | end-to-end accuracy | macro end-to-end accuracy |"
     )
-    print("|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    print("|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     print(
         f"| {overall['valid_count']} / {overall['attempted_count']} "
         f"| {expected_counts.get(0, 0)} | {expected_counts.get(1, 0)} "
         f"| {expected_counts.get(2, 0)} | {predicted_counts.get(0, 0)} "
         f"| {predicted_counts.get(1, 0)} | {predicted_counts.get(2, 0)} "
         f"| {_format_percentage(overall['agreement_fraction'])} "
-        f"| {_format_percentage(overall['attempted_agreement_fraction'])} |"
+        f"| {_format_percentage(overall['attempted_agreement_fraction'])} "
+        f"| {_format_percentage(overall['macro_attempted_agreement_fraction'])} |"
     )
 
 
@@ -1110,6 +1202,8 @@ def run_evaluation(configuration: EvaluationConfiguration) -> dict[str, object]:
             camera_view=configuration.camera_view,
             frame_stride=configuration.frame_stride,
             limit_per_episode=configuration.limit_per_episode,
+            samples_per_episode=configuration.samples_per_episode,
+            sample_seed=configuration.sample_seed,
         )
         for source_path in configuration.source_paths
     }
@@ -1141,6 +1235,8 @@ def run_evaluation(configuration: EvaluationConfiguration) -> dict[str, object]:
             "requested_model": configuration.model,
             "camera_view": configuration.camera_view.value,
             "frame_stride": configuration.frame_stride,
+            "episode_count": configuration.episode_count,
+            "samples_per_episode": configuration.samples_per_episode,
             "samples_per_hand_count": configuration.samples_per_hand_count,
             "sample_seed": configuration.sample_seed,
             "prompt_sha256": _sha256_text(configuration.prompt),
@@ -1194,9 +1290,9 @@ def run_evaluation(configuration: EvaluationConfiguration) -> dict[str, object]:
 def compare_summaries(summary_paths: Sequence[Path]) -> None:
     print(
         "| run | model | camera | valid / attempted | valid accuracy | end-to-end accuracy "
-        "| predicted 0 | predicted 1 | predicted 2 |"
+        "| macro end-to-end accuracy | predicted 0 | predicted 1 | predicted 2 |"
     )
-    print("|---|---|---|---:|---:|---:|---:|---:|---:|")
+    print("|---|---|---|---:|---:|---:|---:|---:|---:|---:|")
     for summary_path in summary_paths:
         summary = json.loads(summary_path.read_text())
         overall = summary["overall"]
@@ -1209,6 +1305,7 @@ def compare_summaries(summary_paths: Sequence[Path]) -> None:
             f"| {overall['valid_count']} / {overall['attempted_count']} "
             f"| {_format_percentage(overall['agreement_fraction'])} "
             f"| {_format_percentage(attempted_agreement_fraction)} "
+            f"| {_format_percentage(overall.get('macro_attempted_agreement_fraction'))} "
             f"| {predicted_counts.get('0', 0)} | {predicted_counts.get('1', 0)} "
             f"| {predicted_counts.get('2', 0)} |"
         )
@@ -1236,7 +1333,11 @@ def _default_output_directory(model: str, camera_view: CameraView) -> Path:
 def _labels_by_source_from_arguments(
     arguments: argparse.Namespace,
 ) -> dict[Path, list[ProjectedHandFrameLabel]]:
-    source_paths = _resolved_mcap_paths(arguments.inputs)
+    source_paths = select_episode_paths(
+        _resolved_mcap_paths(arguments.inputs),
+        episode_count=arguments.episode_count,
+        sample_seed=arguments.sample_seed,
+    )
     camera_view = CameraView(arguments.camera)
     candidate_labels_by_source = {
         source_path: load_projected_hand_labels(
@@ -1244,6 +1345,8 @@ def _labels_by_source_from_arguments(
             camera_view=camera_view,
             frame_stride=arguments.frame_stride,
             limit_per_episode=arguments.limit_per_episode,
+            samples_per_episode=arguments.samples_per_episode,
+            sample_seed=arguments.sample_seed,
         )
         for source_path in source_paths
     }
@@ -1261,11 +1364,18 @@ def _run_configuration_from_arguments(arguments: argparse.Namespace) -> Evaluati
         raise ValueError("--base-url or OPENAI_BASE_URL is required")
     camera_view = CameraView(arguments.camera)
     output_directory = arguments.output or _default_output_directory(arguments.model, camera_view)
+    source_paths = select_episode_paths(
+        _resolved_mcap_paths(arguments.inputs),
+        episode_count=arguments.episode_count,
+        sample_seed=arguments.sample_seed,
+    )
     return EvaluationConfiguration(
-        source_paths=_resolved_mcap_paths(arguments.inputs),
+        source_paths=source_paths,
         camera_view=camera_view,
         frame_stride=arguments.frame_stride,
         limit_per_episode=arguments.limit_per_episode,
+        episode_count=arguments.episode_count,
+        samples_per_episode=arguments.samples_per_episode,
         samples_per_hand_count=arguments.samples_per_hand_count,
         sample_seed=arguments.sample_seed,
         output_directory=output_directory,
@@ -1298,11 +1408,24 @@ def _add_input_and_projection_arguments(parser: argparse.ArgumentParser) -> None
         default=30,
         help="evaluate every Nth source frame; default 30 (about 1 fps)",
     )
-    parser.add_argument(
+    per_episode_selection = parser.add_mutually_exclusive_group()
+    per_episode_selection.add_argument(
         "--limit-per-episode",
         type=_positive_integer,
         default=None,
         help="stop after this many selected frames in each episode",
+    )
+    parser.add_argument(
+        "--episode-count",
+        type=_positive_integer,
+        default=None,
+        help="select up to N input episodes deterministically",
+    )
+    per_episode_selection.add_argument(
+        "--samples-per-episode",
+        type=_positive_integer,
+        default=None,
+        help="randomly select up to N eligible frames in each episode deterministically",
     )
     parser.add_argument(
         "--samples-per-hand-count",
@@ -1314,7 +1437,7 @@ def _add_input_and_projection_arguments(parser: argparse.ArgumentParser) -> None
         "--sample-seed",
         type=_nonnegative_integer,
         default=42,
-        help="seed for deterministic class-stratified selection; default 42",
+        help="seed for deterministic episode, frame, and class selection; default 42",
     )
 
 
@@ -1369,6 +1492,8 @@ def main() -> None:
                     camera_view=CameraView(arguments.camera),
                     frame_stride=arguments.frame_stride,
                     limit_per_episode=arguments.limit_per_episode,
+                    episode_count=arguments.episode_count,
+                    samples_per_episode=arguments.samples_per_episode,
                     samples_per_hand_count=arguments.samples_per_hand_count,
                     sample_seed=arguments.sample_seed,
                     output_path=arguments.output,

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -12,7 +12,9 @@ from examples.egosuite_evaluation.evaluate import (
     CameraView,
     ProjectedHandFrameLabel,
     _evaluation_result_summary,
+    _selected_frame_indices,
     parse_hand_count_response,
+    select_episode_paths,
     select_stratified_labels,
 )
 from examples.egosuite_evaluation.geometry import (
@@ -103,6 +105,31 @@ def test_evaluation_summary_reports_accuracy_and_confusion_without_counting_fail
     assert summary["invalid_count"] == 1
     assert summary["agreement_fraction"] == 0.5
     assert summary["attempted_agreement_fraction"] == pytest.approx(1 / 3)
+    assert summary["macro_agreement_fraction"] == 0.5
+    assert summary["macro_attempted_agreement_fraction"] == pytest.approx(1 / 3)
+    assert summary["per_class_agreement"] == {
+        "0": {
+            "attempted_count": 1,
+            "valid_count": 0,
+            "agreement_count": 0,
+            "agreement_fraction": None,
+            "attempted_agreement_fraction": 0.0,
+        },
+        "1": {
+            "attempted_count": 1,
+            "valid_count": 1,
+            "agreement_count": 0,
+            "agreement_fraction": 0.0,
+            "attempted_agreement_fraction": 0.0,
+        },
+        "2": {
+            "attempted_count": 1,
+            "valid_count": 1,
+            "agreement_count": 1,
+            "agreement_fraction": 1.0,
+            "attempted_agreement_fraction": 1.0,
+        },
+    }
     assert summary["confusion_matrix"] == {
         "0": {"0": 0, "1": 0, "2": 0},
         "1": {"0": 0, "1": 0, "2": 1},
@@ -142,3 +169,33 @@ def test_stratified_selection_caps_each_class_and_is_reproducible() -> None:
     assert [label.expected_hand_count for label in selected_labels].count(1) == 2
     assert [label.expected_hand_count for label in selected_labels].count(2) == 2
     assert first_selection == repeated_selection
+
+
+def test_natural_sampling_selects_reproducible_episodes_and_frames() -> None:
+    source_paths = tuple(Path(f"episode-{episode_index}.mcap") for episode_index in range(5))
+
+    first_episode_selection = select_episode_paths(
+        source_paths,
+        episode_count=3,
+        sample_seed=7,
+    )
+    repeated_episode_selection = select_episode_paths(
+        source_paths,
+        episode_count=3,
+        sample_seed=7,
+    )
+    selected_frame_indices = _selected_frame_indices(
+        first_episode_selection[0],
+        300,
+        frame_stride=30,
+        limit_per_episode=None,
+        samples_per_episode=4,
+        sample_seed=7,
+    )
+
+    assert first_episode_selection == repeated_episode_selection
+    assert len(first_episode_selection) == 3
+    assert set(first_episode_selection).issubset(source_paths)
+    assert selected_frame_indices == sorted(selected_frame_indices)
+    assert len(selected_frame_indices) == 4
+    assert all(frame_index % 30 == 0 for frame_index in selected_frame_indices)


### PR DESCRIPTION
## Outcome

Adds deterministic episode and within-episode frame sampling for naturally distributed EgoSuite evaluations. Reports per-class and macro agreement alongside overall agreement, while retaining class-balanced sampling as a separate diagnostic.

Updates the runnable example and guide to distinguish natural-distribution results from constructed class-balanced slices.

## Validation

- `uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests`
- `uv run --locked --project examples/egosuite_evaluation ruff check examples/egosuite_evaluation`
- `uv run --locked --project examples/egosuite_evaluation ruff format --check examples/egosuite_evaluation`
- `uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . examples/egosuite_evaluation`
- `git diff --check`