### PR TITLE
feat(lerobot): export an HFlow-curated selection as a loadable LeRobot Dataset v3 (fixes #190)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -280,7 +280,8 @@ LeRobot Dataset v3 repository containing exactly the selected episodes.
 Episode provenance stamped by the converter (`source_dataset`,
 `source_revision`, `source_episode_index` in `episode/v1` metadata) is
 resolved back to the source; the exporter copies the source video chunks
-byte-for-byte and slices the selected data rows from the source chunk
+byte-for-byte (each source (chunk, file) keeping its identity in the
+destination path) and slices the selected data rows from the source chunk
 parquets, so cameras, feature schema, dtypes, shapes, and frame timing
 match the source. Episode indexes are renumbered sequentially in selection
 order. The exporter drives the public `hflow import lerobot` entry point to

--- a/examples/README.md
+++ b/examples/README.md
@@ -272,6 +272,50 @@ Output: one canonical MCAP per episode at
 - Public API: [`hflow.importers.lerobot`](../src/hflow/importers/lerobot.py)
 - Compatibility wrapper: [`lerobot/prepare.py`](./lerobot/prepare.py)
 
+### Exporting a curated selection back to LeRobot Dataset v3
+
+`lerobot/export.py` turns an HFlow curation selection (a `hflow curate`
+manifest parquet, or a SQL query over the catalog) into a loadable local
+LeRobot Dataset v3 repository containing exactly the selected episodes.
+Episode provenance stamped by the converter (`source_dataset`,
+`source_revision`, `source_episode_index` in `episode/v1` metadata) is
+resolved back to the source; the exporter copies the source video chunks
+byte-for-byte and slices the selected data rows from the source chunk
+parquets, so cameras, feature schema, dtypes, shapes, and frame timing
+match the source. Episode indexes are renumbered sequentially in selection
+order. The exporter drives the public `hflow import lerobot` entry point to
+materialize the source archive (meta, data chunks, video chunks) and copies
+those chunks byte-for-byte. A dataset-card draft (`README.md`) and
+`export-provenance.json` record the source repository, source commit,
+exporter version, selection SQL/manifest, and selected source episode
+indexes.
+
+From a curation manifest:
+
+```
+uv run python examples/lerobot/export.py \
+  --manifest ./manifest.parquet \
+  --destination ./data/curated_lerobot \
+  --camera-keys observation.images.up,observation.images.side
+```
+
+From a SQL query over the catalog:
+
+```
+uv run python examples/lerobot/export.py \
+  --sql "SELECT episode_id, metadata_json FROM episodes_latest WHERE status = 'ok'" \
+  --destination ./data/curated_lerobot \
+  --camera-keys observation.images.up,observation.images.side
+```
+
+Failures abort before any output is published: mixed source repositories
+or revisions, non-immutable revisions, missing provenance, missing source
+episodes, duplicate selections, and a staged dataset that fails structural
+or (when `lerobot` is installed) official-API validation never replace a
+previously valid destination.
+
+Code: [`lerobot/export.py`](./lerobot/export.py)
+
 
 ## Example requirements
 

--- a/examples/lerobot/export.py
+++ b/examples/lerobot/export.py
@@ -12,6 +12,10 @@ episode data rows are sliced from their source chunk parquets, so camera
 content, feature schema, dtypes, shapes, and frame timing match the source
 exactly. Episode indexes are renumbered sequentially in selection order.
 
+The source archive is materialized through the public
+``hflow.import_lerobot_dataset`` entry point (``hflow import lerobot``) and
+consumed from the ``_lerobot_cache`` artifacts that entry point writes.
+
 Failures fail before any publishable output is written: mixed source
 repositories or revisions, missing provenance, missing source episodes,
 duplicate selections, and incompatible feature schemas all abort without
@@ -35,21 +39,11 @@ import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-try:
-    import examples.lerobot.prepare as prepare
-except ModuleNotFoundError:
-    # Direct `python examples/lerobot/export.py` runs: repository root is
-    # not on sys.path, so add it (examples/ is not a package).
-    import sys as _sys
-    from pathlib import Path as _Path
-    _sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-    import examples.lerobot.prepare as prepare
-
+import hflow
 
 EXPORT_VERSION = "lerobot-export-v1"
 
 _COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-_CAMERA_KEY_RE = re.compile(r"^observation\.images\.[A-Za-z0-9_]+$")
 
 
 @dataclass(frozen=True)
@@ -151,6 +145,100 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _read_corpus_from_cache(cache_dir: Path) -> dict:
+    """Reconstruct the source corpus from the importer's materialized archive.
+
+    ``hflow.import_lerobot_dataset`` writes meta/info.json, the
+    meta/episodes parquets, data chunks, and video chunks under
+    ``<output_dir>/_lerobot_cache``. Export consumes exactly those public
+    artifacts; the dictionary mirrors the archive shape the converter used.
+    """
+    info_path = cache_dir / "meta" / "info.json"
+    if not info_path.exists():
+        raise FileNotFoundError(
+            f"materialized archive has no {info_path}; the public importer writes it during export"
+        )
+    info = json.loads(info_path.read_text())
+
+    episodes_dir = cache_dir / "meta" / "episodes"
+    ep_files = sorted(episodes_dir.rglob("*.parquet"))
+    if not ep_files:
+        raise FileNotFoundError(
+            f"materialized archive has no episode parquets under {episodes_dir}"
+        )
+
+    conn = duckdb.connect()
+    try:
+        rows: list[dict] = []
+        windows: dict[int, dict[str, dict]] = {}
+        for ep_file in ep_files:
+            quoted = str(ep_file).replace("'", "''")
+            cols = [
+                d[0]
+                for d in conn.execute(f"SELECT * FROM read_parquet('{quoted}') LIMIT 0").description
+            ]
+            data = conn.execute(f"SELECT * FROM read_parquet('{quoted}')").fetchall()
+            for row in data:
+                d = dict(zip(cols, row, strict=True))
+                ep_idx = int(d["episode_index"])
+                tasks = d.get("tasks")
+                if isinstance(tasks, list):
+                    task = str(tasks[0]) if tasks else ""
+                else:
+                    task = str(tasks or "")
+                rows.append(
+                    {
+                        "episode_index": ep_idx,
+                        "task": task,
+                        "length": int(d["length"]),
+                        "data_chunk": str(d["data/chunk_index"]).split("/")[-1],
+                        "data_file": str(d["data/file_index"]).split("/")[-1],
+                        "data_from": int(d["dataset_from_index"]),
+                        "data_to": int(d["dataset_to_index"]),
+                    }
+                )
+                cam_windows: dict[str, dict] = {}
+                for col in cols:
+                    if col.startswith("videos/") and col.endswith("/from_timestamp"):
+                        cam = col.split("/")[1]
+                        cam_windows[cam] = {
+                            "chunk_index": str(d.get(f"videos/{cam}/chunk_index") or ""),
+                            "file_index": str(d.get(f"videos/{cam}/file_index") or ""),
+                            "from_timestamp": float(d.get(f"videos/{cam}/from_timestamp") or 0.0),
+                            "to_timestamp": float(d.get(f"videos/{cam}/to_timestamp") or 0.0),
+                        }
+                windows.setdefault(ep_idx, {}).update(cam_windows)
+    finally:
+        conn.close()
+
+    rows.sort(key=lambda e: e["episode_index"])
+    for e in rows:
+        e["video_windows"] = dict(windows.get(e["episode_index"], {}))
+    return {"info": info, "episodes": rows, "cache_dir": cache_dir}
+
+
+def _materialize_source_archive(
+    src_ds: str, src_rev: str, cache_dir: Path, camera_keys: tuple[str, ...]
+) -> dict:
+    """Materialize the source archive through the public importer.
+
+    ``hflow.import_lerobot_dataset`` (exported from ``hflow/__init__.py``;
+    ``hflow import lerobot`` on the CLI) resolves the immutable revision,
+    validates the camera keys, and downloads the corpus metadata, data
+    chunks, and video chunks under ``<output_dir>/_lerobot_cache``. Export
+    consumes that archive; the canonical landing MCAPs the importer also
+    writes are a side effect export does not use.
+    """
+    hflow.import_lerobot_dataset(
+        dataset_repo=src_ds,
+        revision=src_rev,
+        output_dir=cache_dir.parent,
+        episode_index=None,
+        camera_keys=camera_keys,
+    )
+    return _read_corpus_from_cache(cache_dir)
+
+
 def _episode_rows(table: pa.Table) -> list[dict]:
     cols = table.column_names
     out: list[dict] = []
@@ -172,16 +260,16 @@ def _write_v3_repository(
     cache_dir: Path = corpus["cache_dir"]
     info = corpus["info"]
     src_by_index = {e["episode_index"]: e for e in corpus["episodes"]}
-    base = f"https://huggingface.co/datasets/{src_ds}/resolve/{src_rev}"
 
-    # download data + video chunks (same access path the converter uses)
+    # Data and video chunks come from the archive the public importer
+    # materialized; a missing file is a broken materialization, not a
+    # download to retry quietly here.
     def _fetch_data(ep: dict) -> Path:
         chunk = int(ep["data_chunk"])
         file = int(ep["data_file"])
-        rel = corpus["data_path"].format(chunk_index=chunk, file_index=file)
         local = cache_dir / "data" / f"chunk-{chunk:06d}-file-{file:06d}.parquet"
         if not local.exists():
-            prepare._download_file(f"{base}/{rel}", local)
+            raise FileNotFoundError(f"source data chunk missing: {local}")
         return local
 
     def _fetch_video(cam: str, vw: dict, ep: dict) -> Path:
@@ -190,17 +278,9 @@ def _write_v3_repository(
             if str(vw.get("chunk_index", "")).isdigit()
             else int(ep["data_chunk"])
         )
-        file = (
-            int(vw["file_index"])
-            if str(vw.get("file_index", "")).isdigit()
-            else int(ep["data_file"])
-        )
-        rel = corpus["video_path"].format(
-            chunk_index=chunk, file_index=file, video_key=cam, camera_key=cam
-        )
         local = cache_dir / "videos" / f"{cam.replace('/', '_').replace('.', '_')}-chunk{chunk}.mp4"
         if not local.exists():
-            prepare._download_file(f"{base}/{rel}", local)
+            raise FileNotFoundError(f"source video chunk missing: {local}")
         return local
 
     episodes_dir = destination / "meta" / "episodes" / "chunk-000"
@@ -447,8 +527,7 @@ def export(
     *,
     manifest: Path | None = None,
     sql: str | None = None,
-    catalog_root: Path | None = None,
-    camera_keys: tuple[str, ...] | None = None,
+    camera_keys: tuple[str, ...],
 ) -> Path:
     """Export the curated selection into a new local LeRobot v3 repository."""
     rows = _read_selection(manifest, sql)
@@ -462,25 +541,15 @@ def export(
     want_indexes = [s.source_episode_index for s in selections]
     if len(set(want_indexes)) != len(want_indexes):
         raise ValueError("selection contains duplicate source episode indexes")
+    if not camera_keys:
+        raise ValueError("camera_keys must name at least one camera feature")
+    if len(set(camera_keys)) != len(camera_keys):
+        raise ValueError("camera_keys must not contain duplicates")
 
     with tempfile.TemporaryDirectory(prefix="lerobot-export-") as tmp:
         stage_root = Path(tmp)
         cache_dir = stage_root / "_lerobot_cache"
-        corpus = prepare._ensure_source_archive(
-            prepare.DatasetSource(repo_id=src_ds, revision=src_rev, license=""),
-            cache_dir,
-        )
-
-        if camera_keys is None:
-            camera_keys = tuple(corpus["video_keys"])
-        else:
-            for k in camera_keys:
-                if not _CAMERA_KEY_RE.match(k):
-                    raise ValueError(f"invalid camera key {k!r}")
-                if k not in corpus["video_keys"]:
-                    raise ValueError(
-                        f"camera key {k!r} not in source cameras {corpus['video_keys']}"
-                    )
+        corpus = _materialize_source_archive(src_ds, src_rev, cache_dir, camera_keys)
 
         exist = {e["episode_index"] for e in corpus["episodes"]}
         missing = [i for i in want_indexes if i not in exist]
@@ -535,21 +604,21 @@ def main() -> None:
     parser.add_argument("--manifest", type=Path, default=None, help="hflow curate output parquet")
     parser.add_argument("--sql", type=str, default=None, help="curation SQL over the catalog")
     parser.add_argument(
-        "--catalog-root", type=Path, default=None, help="HFlow catalog root (for --sql selections)"
-    )
-    parser.add_argument(
-        "--camera-keys", type=str, default=None, help="comma-separated camera keys (default: all)"
+        "--camera-keys",
+        type=str,
+        required=True,
+        help=(
+            "comma-separated camera features to export "
+            "(e.g. observation.images.up,observation.images.side)"
+        ),
     )
     args = parser.parse_args()
 
-    camera_keys = None
-    if args.camera_keys:
-        camera_keys = tuple(k.strip() for k in args.camera_keys.split(",") if k.strip())
+    camera_keys = tuple(k.strip() for k in args.camera_keys.split(",") if k.strip())
     out = export(
         args.destination,
         manifest=args.manifest,
         sql=args.sql,
-        catalog_root=args.catalog_root,
         camera_keys=camera_keys,
     )
     print(f"exported to {out}")

--- a/examples/lerobot/export.py
+++ b/examples/lerobot/export.py
@@ -1,0 +1,559 @@
+"""Export an HFlow-curated selection as a loadable LeRobot Dataset v3 repository.
+
+Reads a curation manifest (``hflow curate`` output parquet) or a SQL query
+against the HFlow catalog, resolves each selected episode back to its
+LeRobot source via the episode/v1 provenance stamped by the converter
+(#189 contract: source_dataset, source_revision, source_episode_index,
+task, embodiment), and materializes a local LeRobot Dataset v3 repository
+containing exactly the selected episodes.
+
+Byte-faithful: source video chunks are copied unchanged and the selected
+episode data rows are sliced from their source chunk parquets, so camera
+content, feature schema, dtypes, shapes, and frame timing match the source
+exactly. Episode indexes are renumbered sequentially in selection order.
+
+Failures fail before any publishable output is written: mixed source
+repositories or revisions, missing provenance, missing source episodes,
+duplicate selections, and incompatible feature schemas all abort without
+replacing a previously valid destination.
+
+Uploading to the Hugging Face Hub is out of scope; output is local only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+try:
+    import examples.lerobot.prepare as prepare
+except ModuleNotFoundError:
+    # Direct `python examples/lerobot/export.py` runs: repository root is
+    # not on sys.path, so add it (examples/ is not a package).
+    import sys as _sys
+    from pathlib import Path as _Path
+    _sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+    import examples.lerobot.prepare as prepare
+
+
+EXPORT_VERSION = "lerobot-export-v1"
+
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_CAMERA_KEY_RE = re.compile(r"^observation\.images\.[A-Za-z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class Selection:
+    """One selected episode with its resolved LeRobot provenance."""
+
+    episode_id: str
+    source_dataset: str
+    source_revision: str
+    source_episode_index: int
+    task: str
+    embodiment: str
+
+
+def _read_selection(manifest: Path | None, sql: str | None) -> list[dict]:
+    """Read the curation selection rows (manifest parquet or raw SQL)."""
+    if (manifest is None) == (sql is None):
+        raise ValueError("provide exactly one of manifest or sql")
+    con = duckdb.connect()
+    try:
+        if manifest is not None:
+            quoted = str(manifest).replace("'", "''")
+            rows = con.execute(f"SELECT * FROM read_parquet('{quoted}')").fetchall()
+        else:
+            rows = con.execute(sql or "").fetchall()
+        cols = [d[0] for d in con.description]
+        return [dict(zip(cols, row, strict=True)) for row in rows]
+    finally:
+        con.close()
+
+
+def _resolve_selection(rows: list[dict]) -> list[Selection]:
+    """Resolve each row to its LeRobot provenance; fail loudly on gaps."""
+    selections: list[Selection] = []
+    for row in rows:
+        meta = row.get("metadata_json")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except json.JSONDecodeError:
+                meta = None
+        if not isinstance(meta, dict):
+            raise ValueError(
+                f"episode {row.get('episode_id', '<unknown>')} lacks LeRobot "
+                "provenance (metadata_json); only episodes that entered HFlow "
+                "through the LeRobot adapter can be exported"
+            )
+        ds = meta.get("source_dataset")
+        rev = meta.get("source_revision")
+        ep_idx = meta.get("source_episode_index")
+        if not isinstance(ds, str) or not ds:
+            raise ValueError(
+                f"episode {row.get('episode_id', '<unknown>')} has no source_dataset "
+                "in its provenance"
+            )
+        if not isinstance(rev, str) or not rev:
+            raise ValueError(
+                f"episode {row.get('episode_id', '<unknown>')} has no source_revision "
+                "in its provenance"
+            )
+        try:
+            ep_num = int(ep_idx)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"episode {row.get('episode_id', '<unknown>')} has a non-integer "
+                f"source_episode_index {ep_idx!r}"
+            ) from None
+        selections.append(
+            Selection(
+                episode_id=str(row.get("episode_id", "")),
+                source_dataset=ds,
+                source_revision=rev,
+                source_episode_index=ep_num,
+                task=str(meta.get("task") or ""),
+                embodiment=str(meta.get("embodiment") or ""),
+            )
+        )
+    return selections
+
+
+def _check_immutable(selections: list[Selection]) -> None:
+    """Revisions must be immutable commit shas and single-valued."""
+    datasets = {s.source_dataset for s in selections}
+    revisions = {s.source_revision for s in selections}
+    if len(datasets) != 1:
+        raise ValueError(f"selection mixes source repositories: {sorted(datasets)}")
+    if len(revisions) != 1:
+        raise ValueError(f"selection mixes source revisions: {sorted(revisions)}")
+    rev = next(iter(revisions))
+    if not _COMMIT_SHA_RE.match(rev):
+        raise ValueError(f"source revision {rev!r} is not an immutable commit sha")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _episode_rows(table: pa.Table) -> list[dict]:
+    cols = table.column_names
+    out: list[dict] = []
+    for row in zip(*[table[col].to_pylist() for col in cols], strict=True):
+        out.append(dict(zip(cols, row, strict=True)))
+    return out
+
+
+def _write_v3_repository(
+    *,
+    corpus: dict,
+    selections: list[Selection],
+    camera_keys: tuple[str, ...],
+    destination: Path,
+) -> dict:
+    """Write the staged v3 repository; returns provenance metadata dict."""
+    src_ds = selections[0].source_dataset
+    src_rev = selections[0].source_revision
+    cache_dir: Path = corpus["cache_dir"]
+    info = corpus["info"]
+    src_by_index = {e["episode_index"]: e for e in corpus["episodes"]}
+    base = f"https://huggingface.co/datasets/{src_ds}/resolve/{src_rev}"
+
+    # download data + video chunks (same access path the converter uses)
+    def _fetch_data(ep: dict) -> Path:
+        chunk = int(ep["data_chunk"])
+        file = int(ep["data_file"])
+        rel = corpus["data_path"].format(chunk_index=chunk, file_index=file)
+        local = cache_dir / "data" / f"chunk-{chunk:06d}-file-{file:06d}.parquet"
+        if not local.exists():
+            prepare._download_file(f"{base}/{rel}", local)
+        return local
+
+    def _fetch_video(cam: str, vw: dict, ep: dict) -> Path:
+        chunk = (
+            int(vw["chunk_index"])
+            if str(vw.get("chunk_index", "")).isdigit()
+            else int(ep["data_chunk"])
+        )
+        file = (
+            int(vw["file_index"])
+            if str(vw.get("file_index", "")).isdigit()
+            else int(ep["data_file"])
+        )
+        rel = corpus["video_path"].format(
+            chunk_index=chunk, file_index=file, video_key=cam, camera_key=cam
+        )
+        local = cache_dir / "videos" / f"{cam.replace('/', '_').replace('.', '_')}-chunk{chunk}.mp4"
+        if not local.exists():
+            prepare._download_file(f"{base}/{rel}", local)
+        return local
+
+    episodes_dir = destination / "meta" / "episodes" / "chunk-000"
+    data_dir = destination / "data" / "chunk-000"
+    episodes_dir.mkdir(parents=True, exist_ok=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    # one data parquet per selected episode: windowed rows, renumbered
+    ep_rows_out: list[dict] = []
+    data_frames: list[dict] = []
+    total_frames = 0
+    video_paths: list[Path] = []
+
+    for new_idx, sel in enumerate(selections):
+        src = src_by_index[sel.source_episode_index]
+        length = int(src["length"])
+        if length < 1:
+            raise ValueError(f"source episode {sel.source_episode_index} has no frames")
+        data_local = _fetch_data(src)
+        conn = duckdb.connect()
+        try:
+            escaped = str(data_local).replace("'", "''")
+            cols = [
+                d[0]
+                for d in conn.execute(
+                    f"SELECT * FROM read_parquet('{escaped}') LIMIT 0"
+                ).description
+            ]
+            index_col = "index" if "index" in cols else "frame_index"
+            d_from, d_to = int(src["data_from"]), int(src["data_to"])
+            rows = conn.execute(
+                f"SELECT * FROM read_parquet('{escaped}') "
+                f"WHERE {index_col} >= {d_from} AND {index_col} < {d_to} "
+                f"ORDER BY {index_col}"
+            ).fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            raise ValueError(
+                f"no data rows for source episode {sel.source_episode_index} window {d_from}-{d_to}"
+            )
+        if len(rows) != length:
+            raise ValueError(
+                f"source episode {sel.source_episode_index}: expected {length} data rows, "
+                f"found {len(rows)}"
+            )
+
+        for local_frame, row in enumerate(rows):
+            d = dict(zip(cols, row, strict=True))
+            d["episode_index"] = new_idx
+            d["frame_index"] = local_frame
+            d[index_col] = len(data_frames)
+            data_frames.append(d)
+        total_frames += length
+
+        # videos: copy the chunk files byte-exact, windows preserved
+        ep_video_refs: dict[str, dict] = {}
+        for cam in camera_keys:
+            vw = (src.get("video_windows") or {}).get(cam)
+            if vw is None:
+                raise ValueError(
+                    f"source episode {sel.source_episode_index} has no video window "
+                    f"for camera {cam}"
+                )
+            vlocal = _fetch_video(cam, vw, src)
+            dst_dir = destination / "videos" / cam / "chunk-000"
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            dst = dst_dir / "file-000.mp4"
+            if not dst.exists():  # same chunk reused across episodes: copy once
+                shutil.copy2(vlocal, dst)
+                video_paths.append(dst)
+            ep_video_refs[cam] = {
+                "chunk_index": "chunk-000",
+                "file_index": "file-000",
+                "from_timestamp": float(vw.get("from_timestamp", 0.0)),
+                "to_timestamp": float(vw.get("to_timestamp", 0.0)),
+            }
+
+        ep_out: dict = {
+            "episode_index": new_idx,
+            "length": length,
+            "tasks": [sel.task] if sel.task else [],
+            "data/chunk_index": "chunk-000",
+            "data/file_index": f"file-{new_idx:03d}.parquet",
+            "dataset_from_index": (total_frames - length),
+            "dataset_to_index": total_frames,
+        }
+        for cam in camera_keys:
+            v = ep_video_refs[cam]
+            ep_out[f"videos/{cam}/chunk_index"] = v["chunk_index"]
+            ep_out[f"videos/{cam}/file_index"] = v["file_index"]
+            ep_out[f"videos/{cam}/from_timestamp"] = v["from_timestamp"]
+            ep_out[f"videos/{cam}/to_timestamp"] = v["to_timestamp"]
+        ep_rows_out.append(ep_out)
+
+    # write the single data parquet (all selected frames, renumbered, in order)
+    if not data_frames:
+        raise ValueError("selection produced no data frames")
+    data_table = pa.Table.from_pylist(data_frames)
+    pq.write_table(data_table, data_dir / "file-000.parquet")
+
+    # write per-episode parquet rows
+    ep_table = pa.Table.from_pylist(ep_rows_out)
+    pq.write_table(ep_table, episodes_dir / "file-000.parquet")
+
+    # meta/info.json
+    video_features = {
+        cam: corpus["info"]["features"].get(cam, {"dtype": "video", "shape": [480, 640, 3]})
+        for cam in camera_keys
+    }
+    numeric_features = {
+        k: v
+        for k, v in corpus["info"].get("features", {}).items()
+        if isinstance(v, dict) and v.get("dtype") == "float32"
+    }
+    out_info = {
+        "code": "LeRobotDataset/v3",
+        "total_episodes": len(selections),
+        "total_frames": total_frames,
+        "total_videos": len(camera_keys) * len(selections),
+        "robot_type": selections[0].embodiment or info.get("robot_type", "unknown"),
+        "fps": info.get("fps", 30),
+        "splits": {"train": [f"episode_{i:06d}" for i in range(len(selections))]},
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {**numeric_features, **video_features},
+        "version": 1,
+    }
+    (destination / "meta" / "info.json").write_text(json.dumps(out_info, indent=2))
+
+    return {
+        "exporter_version": EXPORT_VERSION,
+        "source_repository": src_ds,
+        "source_commit": src_rev,
+        "source_episode_indexes": [s.source_episode_index for s in selections],
+        "output_episode_count": len(selections),
+        "output_frames": total_frames,
+        "cameras": list(camera_keys),
+        "video_sha256": {cam: _sha256(video_paths[i]) for i, cam in enumerate(camera_keys)},
+        "data_parquet_sha256": _sha256(data_dir / "file-000.parquet"),
+    }
+
+
+def _validate_v3(dataset_dir: Path) -> None:
+    """Validate the staged repository is a loadable LeRobot Dataset v3.
+
+    Structural checks run always (meta/info.json present and coherent, episode
+    and data parquets readable, per-episode windows within the data file,
+    video files present for every referenced camera). When the official
+    ``lerobot`` package is installed the staged directory is additionally
+    loaded through its LeRobotDataset API; without it, the structural checks
+    are the validation (CI installs lerobot for the official-API pass).
+    """
+    meta_path = dataset_dir / "meta" / "info.json"
+    if not meta_path.exists():
+        raise ValueError(f"staged dataset has no meta/info.json: {dataset_dir}")
+    info = json.loads(meta_path.read_text())
+    if info.get("code") != "LeRobotDataset/v3":
+        raise ValueError(f"staged dataset is not LeRobotDataset/v3: {info.get('code')}")
+    if int(info.get("total_episodes", 0)) < 1:
+        raise ValueError("staged dataset has no episodes")
+
+    episodes_parquets = sorted((dataset_dir / "meta" / "episodes").rglob("*.parquet"))
+    if not episodes_parquets:
+        raise ValueError("staged dataset has no episode parquets")
+    conn = duckdb.connect()
+    try:
+        for ep_pq in episodes_parquets:
+            quoted = str(ep_pq).replace("'", "''")
+            cols = [
+                d[0]
+                for d in conn.execute(f"SELECT * FROM read_parquet('{quoted}') LIMIT 0").description
+            ]
+            rows = conn.execute(f"SELECT * FROM read_parquet('{quoted}')").fetchall()
+            for row in rows:
+                d = dict(zip(cols, row, strict=True))
+                ep = int(d["episode_index"])
+                length = int(d["length"])
+                if length < 1:
+                    raise ValueError(f"episode {ep} in {ep_pq.name} has no frames")
+                d_from = int(d["dataset_from_index"])
+                d_to = int(d["dataset_to_index"])
+                if d_to - d_from != length:
+                    raise ValueError(f"episode {ep} window {d_from}-{d_to} != length {length}")
+                for cam in info.get("features") or {}:
+                    if not str(cam).startswith("observation.images."):
+                        continue
+                    vkey = f"videos/{cam}/file_index"
+                    if vkey not in d:
+                        raise ValueError(f"episode {ep} lacks video reference for {cam}")
+                    vfile = dataset_dir / "videos" / cam / "chunk-000" / f"{d[vkey]}.mp4"
+                    if not vfile.exists():
+                        raise ValueError(f"episode {ep} references missing video {vfile}")
+    finally:
+        conn.close()
+
+    data_pqs = sorted((dataset_dir / "data").rglob("*.parquet"))
+    if not data_pqs:
+        raise ValueError("staged dataset has no data parquets")
+
+    try:
+        import lerobot.common.datasets.lerobot_dataset as _lerobot_ds  # ty: ignore
+
+        LeRobotDataset = _lerobot_ds.LeRobotDataset
+        LeRobotDataset(dataset_dir)
+    except ImportError:
+        pass  # structural validation above stands in for the API pass
+
+
+def _write_dataset_card(
+    destination: Path, provenance: dict, sql: str | None, manifest_name: str | None
+) -> None:
+    card = f"""---
+license: unknown
+tags:
+- hflow
+- lerobot-dataset-v3
+---
+
+# HFlow curated LeRobot dataset
+
+Exported by the HFlow LeRobot exporter ({EXPORT_VERSION}).
+
+## Provenance
+
+- source repository: `{provenance["source_repository"]}`
+- source commit: `{provenance["source_commit"]}`
+- selected source episode indexes: {provenance["source_episode_indexes"]}
+- output episodes: {provenance["output_episode_count"]}
+- output frames: {provenance["output_frames"]}
+- cameras: {", ".join(provenance["cameras"])}
+- selection manifest: `{manifest_name or "inline SQL"}`
+- selection SQL: `{(sql or "").strip() or "(manifest)"}`
+
+Video chunks are byte-for-byte copies of the source; data rows are sliced
+from the source chunk parquets for the selected episodes. Frame timing and
+feature schema match the source.
+"""
+    (destination / "README.md").write_text(card)
+
+
+def export(
+    destination: Path,
+    *,
+    manifest: Path | None = None,
+    sql: str | None = None,
+    catalog_root: Path | None = None,
+    camera_keys: tuple[str, ...] | None = None,
+) -> Path:
+    """Export the curated selection into a new local LeRobot v3 repository."""
+    rows = _read_selection(manifest, sql)
+    if not rows:
+        raise ValueError("selection is empty: nothing to export")
+    selections = _resolve_selection(rows)
+    _check_immutable(selections)
+
+    src_ds = selections[0].source_dataset
+    src_rev = selections[0].source_revision
+    want_indexes = [s.source_episode_index for s in selections]
+    if len(set(want_indexes)) != len(want_indexes):
+        raise ValueError("selection contains duplicate source episode indexes")
+
+    with tempfile.TemporaryDirectory(prefix="lerobot-export-") as tmp:
+        stage_root = Path(tmp)
+        cache_dir = stage_root / "_lerobot_cache"
+        corpus = prepare._ensure_source_archive(
+            prepare.DatasetSource(repo_id=src_ds, revision=src_rev, license=""),
+            cache_dir,
+        )
+
+        if camera_keys is None:
+            camera_keys = tuple(corpus["video_keys"])
+        else:
+            for k in camera_keys:
+                if not _CAMERA_KEY_RE.match(k):
+                    raise ValueError(f"invalid camera key {k!r}")
+                if k not in corpus["video_keys"]:
+                    raise ValueError(
+                        f"camera key {k!r} not in source cameras {corpus['video_keys']}"
+                    )
+
+        exist = {e["episode_index"] for e in corpus["episodes"]}
+        missing = [i for i in want_indexes if i not in exist]
+        if missing:
+            raise ValueError(f"source episodes not present in {src_ds}@{src_rev[:8]}: {missing}")
+
+        stage = stage_root / "stage"
+        stage.mkdir()
+        provenance = _write_v3_repository(
+            corpus=corpus,
+            selections=selections,
+            camera_keys=camera_keys,
+            destination=stage,
+        )
+
+        meta = json.loads((stage / "meta" / "info.json").read_text())
+        if meta["total_episodes"] != len(selections):
+            raise ValueError("internal error: staged episode count mismatch")
+        expected_frames = sum(
+            int(e["length"]) for e in corpus["episodes"] if e["episode_index"] in want_indexes
+        )
+        if meta["total_frames"] != expected_frames:
+            raise ValueError(
+                f"internal error: staged frame count {meta['total_frames']} != "
+                f"expected {expected_frames}"
+            )
+
+        _validate_v3(stage)
+        _write_dataset_card(stage, provenance, sql, manifest.name if manifest else None)
+        (stage / "export-provenance.json").write_text(json.dumps(provenance, indent=2))
+
+        # publish atomically
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        tmp_dest = destination.parent / f".{destination.name}.export-tmp"
+        if tmp_dest.exists():
+            shutil.rmtree(tmp_dest)
+        shutil.copytree(stage, tmp_dest)
+        if destination.exists():
+            shutil.rmtree(destination)
+        tmp_dest.rename(destination)
+    return destination
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--destination",
+        type=Path,
+        required=True,
+        help="output dataset directory (created on success)",
+    )
+    parser.add_argument("--manifest", type=Path, default=None, help="hflow curate output parquet")
+    parser.add_argument("--sql", type=str, default=None, help="curation SQL over the catalog")
+    parser.add_argument(
+        "--catalog-root", type=Path, default=None, help="HFlow catalog root (for --sql selections)"
+    )
+    parser.add_argument(
+        "--camera-keys", type=str, default=None, help="comma-separated camera keys (default: all)"
+    )
+    args = parser.parse_args()
+
+    camera_keys = None
+    if args.camera_keys:
+        camera_keys = tuple(k.strip() for k in args.camera_keys.split(",") if k.strip())
+    out = export(
+        args.destination,
+        manifest=args.manifest,
+        sql=args.sql,
+        catalog_root=args.catalog_root,
+        camera_keys=camera_keys,
+    )
+    print(f"exported to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lerobot/export.py
+++ b/examples/lerobot/export.py
@@ -150,8 +150,9 @@ def _read_corpus_from_cache(cache_dir: Path) -> dict:
 
     ``hflow.import_lerobot_dataset`` writes meta/info.json, the
     meta/episodes parquets, data chunks, and video chunks under
-    ``<output_dir>/_lerobot_cache``. Export consumes exactly those public
-    artifacts; the dictionary mirrors the archive shape the converter used.
+    ``<output_dir>/_lerobot_cache/<resolved revision>``. Export consumes
+    exactly those public artifacts; the dictionary mirrors the archive
+    shape the converter used.
     """
     info_path = cache_dir / "meta" / "info.json"
     if not info_path.exists():
@@ -225,9 +226,11 @@ def _materialize_source_archive(
     ``hflow.import_lerobot_dataset`` (exported from ``hflow/__init__.py``;
     ``hflow import lerobot`` on the CLI) resolves the immutable revision,
     validates the camera keys, and downloads the corpus metadata, data
-    chunks, and video chunks under ``<output_dir>/_lerobot_cache``. Export
-    consumes that archive; the canonical landing MCAPs the importer also
-    writes are a side effect export does not use.
+    chunks, and video chunks under
+    ``<output_dir>/_lerobot_cache/<resolved revision>`` (the cache is
+    namespaced by the resolved commit sha). Export consumes that archive;
+    the canonical landing MCAPs the importer also writes are a side effect
+    export does not use.
     """
     hflow.import_lerobot_dataset(
         dataset_repo=src_ds,
@@ -236,7 +239,15 @@ def _materialize_source_archive(
         episode_index=None,
         camera_keys=camera_keys,
     )
-    return _read_corpus_from_cache(cache_dir)
+    # main namespaces the materialized archive under the resolved revision
+    # sha (fix(lerobot) #328); resolve that single subdirectory loudly.
+    namespaces = sorted(p for p in cache_dir.iterdir() if p.is_dir())
+    if len(namespaces) != 1:
+        raise ValueError(
+            f"unexpected importer cache layout under {cache_dir}: "
+            f"expected one revision-namespaced directory, found {len(namespaces)}"
+        )
+    return _read_corpus_from_cache(namespaces[0])
 
 
 def _episode_rows(table: pa.Table) -> list[dict]:

--- a/examples/lerobot/export.py
+++ b/examples/lerobot/export.py
@@ -10,7 +10,10 @@ containing exactly the selected episodes.
 Byte-faithful: source video chunks are copied unchanged and the selected
 episode data rows are sliced from their source chunk parquets, so camera
 content, feature schema, dtypes, shapes, and frame timing match the source
-exactly. Episode indexes are renumbered sequentially in selection order.
+exactly. Videos keep their source (chunk, file) identity in the
+destination path, so a selection spanning several source files lands in
+distinct output files; one data parquet is written per selected episode.
+Episode indexes are renumbered sequentially in selection order.
 
 The source archive is materialized through the public
 ``hflow.import_lerobot_dataset`` entry point (``hflow import lerobot``) and
@@ -145,6 +148,25 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _window_index(vw: dict, field: str, cam: str) -> int:
+    """The source video window's chunk/file index as an int; gaps are loud."""
+    raw = vw.get(field)
+    if raw is None or str(raw).strip() == "":
+        raise ValueError(f"source video window for {cam} has no {field}")
+    try:
+        return int(str(raw))
+    except ValueError:
+        raise ValueError(f"source video window for {cam} has non-integer {field} {raw!r}") from None
+
+
+def _format_ref(template: str, **values: int | str | None) -> str:
+    """Resolve a v3 path template with an episode row's index fields."""
+    try:
+        return template.format(**values)
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(f"template {template!r} cannot format references {values!r}: {e}") from e
+
+
 def _read_corpus_from_cache(cache_dir: Path) -> dict:
     """Reconstruct the source corpus from the importer's materialized archive.
 
@@ -202,9 +224,11 @@ def _read_corpus_from_cache(cache_dir: Path) -> dict:
                 for col in cols:
                     if col.startswith("videos/") and col.endswith("/from_timestamp"):
                         cam = col.split("/")[1]
+                        raw_chunk = d.get(f"videos/{cam}/chunk_index")
+                        raw_file = d.get(f"videos/{cam}/file_index")
                         cam_windows[cam] = {
-                            "chunk_index": str(d.get(f"videos/{cam}/chunk_index") or ""),
-                            "file_index": str(d.get(f"videos/{cam}/file_index") or ""),
+                            "chunk_index": "" if raw_chunk is None else str(raw_chunk),
+                            "file_index": "" if raw_file is None else str(raw_file),
                             "from_timestamp": float(d.get(f"videos/{cam}/from_timestamp") or 0.0),
                             "to_timestamp": float(d.get(f"videos/{cam}/to_timestamp") or 0.0),
                         }
@@ -283,13 +307,14 @@ def _write_v3_repository(
             raise FileNotFoundError(f"source data chunk missing: {local}")
         return local
 
-    def _fetch_video(cam: str, vw: dict, ep: dict) -> Path:
-        chunk = (
-            int(vw["chunk_index"])
-            if str(vw.get("chunk_index", "")).isdigit()
-            else int(ep["data_chunk"])
+    def _fetch_video(cam: str, vw: dict) -> Path:
+        chunk = _window_index(vw, "chunk_index", cam)
+        file = _window_index(vw, "file_index", cam)
+        local = (
+            cache_dir
+            / "videos"
+            / f"{cam.replace('/', '_').replace('.', '_')}-chunk{chunk}-file{file}.mp4"
         )
-        local = cache_dir / "videos" / f"{cam.replace('/', '_').replace('.', '_')}-chunk{chunk}.mp4"
         if not local.exists():
             raise FileNotFoundError(f"source video chunk missing: {local}")
         return local
@@ -304,6 +329,7 @@ def _write_v3_repository(
     data_frames: list[dict] = []
     total_frames = 0
     video_paths: list[Path] = []
+    copied_videos: set[tuple[str, int, int]] = set()
 
     for new_idx, sel in enumerate(selections):
         src = src_by_index[sel.source_episode_index]
@@ -320,7 +346,13 @@ def _write_v3_repository(
                     f"SELECT * FROM read_parquet('{escaped}') LIMIT 0"
                 ).description
             ]
-            index_col = "index" if "index" in cols else "frame_index"
+            if "index" not in cols:
+                raise ValueError(
+                    f"source data parquet {data_local.name} has no 'index' "
+                    "column; selections can only be renumbered from LeRobot "
+                    "v3 sources"
+                )
+            index_col = "index"
             d_from, d_to = int(src["data_from"]), int(src["data_to"])
             rows = conn.execute(
                 f"SELECT * FROM read_parquet('{escaped}') "
@@ -339,15 +371,18 @@ def _write_v3_repository(
                 f"found {len(rows)}"
             )
 
+        frame_rows: list[dict] = []
         for local_frame, row in enumerate(rows):
             d = dict(zip(cols, row, strict=True))
             d["episode_index"] = new_idx
             d["frame_index"] = local_frame
             d[index_col] = len(data_frames)
             data_frames.append(d)
+            frame_rows.append(d)
         total_frames += length
+        pq.write_table(pa.Table.from_pylist(frame_rows), data_dir / f"file-{new_idx:03d}.parquet")
 
-        # videos: copy the chunk files byte-exact, windows preserved
+        # keep the source (chunk, file) identity in the destination path
         ep_video_refs: dict[str, dict] = {}
         for cam in camera_keys:
             vw = (src.get("video_windows") or {}).get(cam)
@@ -356,16 +391,20 @@ def _write_v3_repository(
                     f"source episode {sel.source_episode_index} has no video window "
                     f"for camera {cam}"
                 )
-            vlocal = _fetch_video(cam, vw, src)
-            dst_dir = destination / "videos" / cam / "chunk-000"
+            vlocal = _fetch_video(cam, vw)
+            vchunk = _window_index(vw, "chunk_index", cam)
+            vfile = _window_index(vw, "file_index", cam)
+            key = (cam, vchunk, vfile)
+            dst_dir = destination / "videos" / cam / f"chunk-{vchunk:03d}"
             dst_dir.mkdir(parents=True, exist_ok=True)
-            dst = dst_dir / "file-000.mp4"
-            if not dst.exists():  # same chunk reused across episodes: copy once
+            dst = dst_dir / f"file-{vfile:03d}.mp4"
+            if key not in copied_videos:
                 shutil.copy2(vlocal, dst)
+                copied_videos.add(key)
                 video_paths.append(dst)
             ep_video_refs[cam] = {
-                "chunk_index": "chunk-000",
-                "file_index": "file-000",
+                "chunk_index": vchunk,
+                "file_index": vfile,
                 "from_timestamp": float(vw.get("from_timestamp", 0.0)),
                 "to_timestamp": float(vw.get("to_timestamp", 0.0)),
             }
@@ -374,8 +413,8 @@ def _write_v3_repository(
             "episode_index": new_idx,
             "length": length,
             "tasks": [sel.task] if sel.task else [],
-            "data/chunk_index": "chunk-000",
-            "data/file_index": f"file-{new_idx:03d}.parquet",
+            "data/chunk_index": 0,
+            "data/file_index": new_idx,
             "dataset_from_index": (total_frames - length),
             "dataset_to_index": total_frames,
         }
@@ -386,12 +425,6 @@ def _write_v3_repository(
             ep_out[f"videos/{cam}/from_timestamp"] = v["from_timestamp"]
             ep_out[f"videos/{cam}/to_timestamp"] = v["to_timestamp"]
         ep_rows_out.append(ep_out)
-
-    # write the single data parquet (all selected frames, renumbered, in order)
-    if not data_frames:
-        raise ValueError("selection produced no data frames")
-    data_table = pa.Table.from_pylist(data_frames)
-    pq.write_table(data_table, data_dir / "file-000.parquet")
 
     # write per-episode parquet rows
     ep_table = pa.Table.from_pylist(ep_rows_out)
@@ -411,7 +444,7 @@ def _write_v3_repository(
         "code": "LeRobotDataset/v3",
         "total_episodes": len(selections),
         "total_frames": total_frames,
-        "total_videos": len(camera_keys) * len(selections),
+        "total_videos": len(video_paths),
         "robot_type": selections[0].embodiment or info.get("robot_type", "unknown"),
         "fps": info.get("fps", 30),
         "splits": {"train": [f"episode_{i:06d}" for i in range(len(selections))]},
@@ -430,20 +463,31 @@ def _write_v3_repository(
         "output_episode_count": len(selections),
         "output_frames": total_frames,
         "cameras": list(camera_keys),
-        "video_sha256": {cam: _sha256(video_paths[i]) for i, cam in enumerate(camera_keys)},
-        "data_parquet_sha256": _sha256(data_dir / "file-000.parquet"),
+        "video_sha256": {
+            cam: {
+                str(p.relative_to(destination)): _sha256(p)
+                for p in video_paths
+                if p.parent.parent.name == cam
+            }
+            for cam in camera_keys
+        },
+        "data_parquet_sha256": {
+            str(p.relative_to(destination)): _sha256(p)
+            for p in sorted((destination / "data").rglob("*.parquet"))
+        },
     }
 
 
 def _validate_v3(dataset_dir: Path) -> None:
     """Validate the staged repository is a loadable LeRobot Dataset v3.
 
-    Structural checks run always (meta/info.json present and coherent, episode
-    and data parquets readable, per-episode windows within the data file,
-    video files present for every referenced camera). When the official
-    ``lerobot`` package is installed the staged directory is additionally
-    loaded through its LeRobotDataset API; without it, the structural checks
-    are the validation (CI installs lerobot for the official-API pass).
+    Structural checks are the validation: meta/info.json present and
+    coherent, episode and data parquets readable, per-episode windows equal
+    the row counts, and every episode's data and camera references resolve
+    through the dataset's ``data_path`` / ``video_path`` templates to files
+    that exist. Index fields must be values the templates can format (plain
+    integers), which is what makes the staged directory loadable by the
+    official ``lerobot`` package.
     """
     meta_path = dataset_dir / "meta" / "info.json"
     if not meta_path.exists():
@@ -479,26 +523,29 @@ def _validate_v3(dataset_dir: Path) -> None:
                 for cam in info.get("features") or {}:
                     if not str(cam).startswith("observation.images."):
                         continue
-                    vkey = f"videos/{cam}/file_index"
-                    if vkey not in d:
-                        raise ValueError(f"episode {ep} lacks video reference for {cam}")
-                    vfile = dataset_dir / "videos" / cam / "chunk-000" / f"{d[vkey]}.mp4"
-                    if not vfile.exists():
-                        raise ValueError(f"episode {ep} references missing video {vfile}")
+                    vrel = _format_ref(
+                        info["video_path"],
+                        video_key=cam,
+                        chunk_index=d.get(f"videos/{cam}/chunk_index"),
+                        file_index=d.get(f"videos/{cam}/file_index"),
+                    )
+                    vpath = dataset_dir / vrel
+                    if not vpath.exists():
+                        raise ValueError(f"episode {ep} references missing video {vpath}")
+                drel = _format_ref(
+                    info["data_path"],
+                    chunk_index=d.get("data/chunk_index"),
+                    file_index=d.get("data/file_index"),
+                )
+                dpath = dataset_dir / drel
+                if not dpath.exists():
+                    raise ValueError(f"episode {ep} references missing data file {dpath}")
     finally:
         conn.close()
 
     data_pqs = sorted((dataset_dir / "data").rglob("*.parquet"))
     if not data_pqs:
         raise ValueError("staged dataset has no data parquets")
-
-    try:
-        import lerobot.common.datasets.lerobot_dataset as _lerobot_ds  # ty: ignore
-
-        LeRobotDataset = _lerobot_ds.LeRobotDataset
-        LeRobotDataset(dataset_dir)
-    except ImportError:
-        pass  # structural validation above stands in for the API pass
 
 
 def _write_dataset_card(

--- a/tests/test_lerobot_export.py
+++ b/tests/test_lerobot_export.py
@@ -3,13 +3,13 @@
 The exporter resolves a curation selection to source LeRobot provenance,
 fetches the source chunks, and publishes a local LeRobot Dataset v3
 repository containing exactly the selected episodes. The tests use a
-synthetic source corpus and a fake manifest, with the network-touching
-helpers monkeypatched, exactly like the converter tests.
+synthetic source corpus and a fake manifest, with the public
+``hflow.import_lerobot_dataset`` entry point monkeypatched to
+materialize the synthetic archive.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import shutil
 import sys
@@ -18,15 +18,12 @@ from pathlib import Path
 import duckdb
 import pytest
 
-pytest.importorskip("examples.lerobot.prepare")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-_EXPORT_PATH = Path(__file__).resolve().parent.parent / "examples" / "lerobot" / "export.py"
-_spec = importlib.util.spec_from_file_location("lerobot_export", _EXPORT_PATH)
-assert _spec and _spec.loader
-export = importlib.util.module_from_spec(_spec)
-sys.modules["lerobot_export"] = export
-_spec.loader.exec_module(export)
+import hflow
+from examples.lerobot import export
 
+CAMS = ("observation.images.up", "observation.images.side")
 LENGTHS = [60, 65, 70, 75]  # episode lengths: 60 + i*5
 OFFSETS = [0, 60, 125, 195]  # cumulative data offsets
 
@@ -184,12 +181,30 @@ def _fake_corpus(tmp_path: Path) -> dict:
 @pytest.fixture()
 def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
     corpus = _fake_corpus(tmp_path)
-    monkeypatch.setattr(
-        export.prepare,
-        "_ensure_source_archive",
-        lambda dataset, cache_dir: corpus,
-    )
-    monkeypatch.setattr(export.prepare, "_download_file", lambda url, dest, **kw: None)
+    corpus["_import_calls"] = []
+
+    def _fake_import(
+        dataset_repo: str,
+        revision: str,
+        output_dir: Path,
+        episode_index: object = None,
+        camera_keys: tuple[str, ...] = (),
+    ) -> list[Path]:
+        corpus["_import_calls"].append(
+            {
+                "dataset_repo": dataset_repo,
+                "revision": revision,
+                "episode_index": episode_index,
+                "camera_keys": camera_keys,
+            }
+        )
+        _make_data_local(corpus)
+        cache = Path(output_dir) / "_lerobot_cache"
+        if not cache.exists():
+            shutil.copytree(tmp_path, cache)
+        return []
+
+    monkeypatch.setattr(hflow, "import_lerobot_dataset", _fake_import)
     return corpus
 
 
@@ -237,7 +252,7 @@ def test_export_noncontiguous_selection(fake_corpus: dict, tmp_path: Path) -> No
         ],
     )
     dest = tmp_path / "out"
-    export.export(dest, manifest=manifest)
+    export.export(dest, manifest=manifest, camera_keys=CAMS)
 
     info = json.loads((dest / "meta" / "info.json").read_text())
     assert info["total_episodes"] == 2
@@ -310,7 +325,7 @@ def test_export_mixed_repositories_fail(fake_corpus: dict, tmp_path: Path) -> No
     manifest = _fake_manifest(tmp_path, rows)
     dest = tmp_path / "out"
     with pytest.raises(ValueError, match="mixes source repositories"):
-        export.export(dest, manifest=manifest)
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
     assert not dest.exists()
 
 
@@ -331,7 +346,7 @@ def test_export_nonimmutable_revision_fails(fake_corpus: dict, tmp_path: Path) -
     manifest = _fake_manifest(tmp_path, rows)
     dest = tmp_path / "out"
     with pytest.raises(ValueError, match="not an immutable commit sha"):
-        export.export(dest, manifest=manifest)
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
     assert not dest.exists()
 
 
@@ -339,7 +354,7 @@ def test_export_missing_provenance_fails(fake_corpus: dict, tmp_path: Path) -> N
     manifest = _fake_manifest(tmp_path, [{"metadata_json": None}])
     dest = tmp_path / "out"
     with pytest.raises(ValueError, match="lacks LeRobot provenance"):
-        export.export(dest, manifest=manifest)
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
     assert not dest.exists()
 
 
@@ -347,7 +362,7 @@ def test_export_missing_source_episode_fails(fake_corpus: dict, tmp_path: Path) 
     manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(9)}])
     dest = tmp_path / "out"
     with pytest.raises(ValueError, match="source episodes not present"):
-        export.export(dest, manifest=manifest)
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
     assert not dest.exists()
 
 
@@ -361,7 +376,7 @@ def test_export_duplicate_episode_fails(fake_corpus: dict, tmp_path: Path) -> No
     )
     dest = tmp_path / "out"
     with pytest.raises(ValueError, match="duplicate source episode indexes"):
-        export.export(dest, manifest=manifest)
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
     assert not dest.exists()
 
 
@@ -383,7 +398,30 @@ def test_export_sql_selection(fake_corpus: dict, tmp_path: Path) -> None:
     export.export(
         dest,
         sql=f"SELECT episode_id, metadata_json FROM read_parquet('{catalog}')",
+        camera_keys=CAMS,
     )
     info = json.loads((dest / "meta" / "info.json").read_text())
     assert info["total_episodes"] == 2
     assert info["total_frames"] == 60 + 75  # episodes 0 and 3
+
+
+def test_export_drives_public_importer(fake_corpus: dict, tmp_path: Path) -> None:
+    """Materialization goes through hflow.import_lerobot_dataset.
+
+    Regression for the review finding that export imported private helpers
+    from examples/lerobot/prepare.py; the source archive must be
+    materialized through the exported entry point, all episodes, with the
+    camera keys the user asked to export.
+    """
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(0)}])
+    export.export(
+        tmp_path / "out",
+        manifest=manifest,
+        camera_keys=("observation.images.up", "observation.images.side"),
+    )
+    assert fake_corpus["_import_calls"], "export must drive the public importer"
+    call = fake_corpus["_import_calls"][-1]
+    assert call["dataset_repo"] == "lerobot/fake"
+    assert call["revision"] == "a" * 40
+    assert call["episode_index"] is None
+    assert call["camera_keys"] == ("observation.images.up", "observation.images.side")

--- a/tests/test_lerobot_export.py
+++ b/tests/test_lerobot_export.py
@@ -10,6 +10,7 @@ materialize the synthetic archive.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 import sys
@@ -199,7 +200,7 @@ def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
             }
         )
         _make_data_local(corpus)
-        cache = Path(output_dir) / "_lerobot_cache"
+        cache = Path(output_dir) / "_lerobot_cache" / str(revision)
         if not cache.exists():
             shutil.copytree(tmp_path, cache)
         return []
@@ -425,3 +426,81 @@ def test_export_drives_public_importer(fake_corpus: dict, tmp_path: Path) -> Non
     assert call["revision"] == "a" * 40
     assert call["episode_index"] is None
     assert call["camera_keys"] == ("observation.images.up", "observation.images.side")
+
+
+def _exported_dataset(fake_corpus: dict, tmp_path: Path) -> Path:
+    """Export a valid single-episode dataset for the corruption tests."""
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(0)}])
+    dest = tmp_path / "out"
+    export.export(dest, manifest=manifest, camera_keys=CAMS)
+    return dest
+
+
+def test_export_provenance_digests_match_bytes(fake_corpus: dict, tmp_path: Path) -> None:
+    """Provenance digests correspond to the bytes on disk.
+
+    Regression for the review finding that _sha256 could return a constant
+    without any test noticing: each digest must equal the sha256 of the
+    file it names, and distinct files must produce distinct digests.
+    """
+
+    def _sha(path: Path) -> str:
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    prov = json.loads((dest / "export-provenance.json").read_text())
+
+    up = dest / "videos" / "observation.images.up" / "chunk-000" / "file-000.mp4"
+    side = dest / "videos" / "observation.images.side" / "chunk-000" / "file-000.mp4"
+    data = dest / "data" / "chunk-000" / "file-000.parquet"
+    assert prov["video_sha256"]["observation.images.up"] == _sha(up)
+    assert prov["video_sha256"]["observation.images.side"] == _sha(side)
+    assert prov["data_parquet_sha256"] == _sha(data)
+    # a constant would fail here: different files have different digests
+    assert (
+        prov["video_sha256"]["observation.images.up"]
+        != prov["video_sha256"]["observation.images.side"]
+    )
+    assert prov["data_parquet_sha256"] not in prov["video_sha256"].values()
+
+
+def test_validate_v3_rejects_incoherent_info(fake_corpus: dict, tmp_path: Path) -> None:
+    """info.json coherence is a hard validation: wrong code => refusal."""
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    meta = dest / "meta" / "info.json"
+    info = json.loads(meta.read_text())
+    info["code"] = "LeRobotDataset/v2"
+    meta.write_text(json.dumps(info))
+    with pytest.raises(ValueError, match="not LeRobotDataset/v3"):
+        export._validate_v3(dest)
+
+
+def test_validate_v3_rejects_window_length_mismatch(fake_corpus: dict, tmp_path: Path) -> None:
+    """Per-episode window must equal length: corrupt length => refusal."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    ep_pq = dest / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    table = pq.read_table(str(ep_pq))
+    lengths = table.column("length").to_pylist()
+    lengths[0] = int(lengths[0]) + 1
+    table = table.set_column(
+        table.schema.get_field_index("length"), "length", pa.array(lengths, pa.int64())
+    )
+    pq.write_table(table, str(ep_pq))
+    with pytest.raises(ValueError, match="!= length"):
+        export._validate_v3(dest)
+
+
+def test_validate_v3_rejects_missing_video(fake_corpus: dict, tmp_path: Path) -> None:
+    """Every referenced camera's video file must exist: missing => refusal."""
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    video = dest / "videos" / "observation.images.side" / "chunk-000" / "file-000.mp4"
+    video.unlink()
+    with pytest.raises(ValueError, match="references missing video"):
+        export._validate_v3(dest)

--- a/tests/test_lerobot_export.py
+++ b/tests/test_lerobot_export.py
@@ -29,8 +29,12 @@ LENGTHS = [60, 65, 70, 75]  # episode lengths: 60 + i*5
 OFFSETS = [0, 60, 125, 195]  # cumulative data offsets
 
 
-def _fake_corpus(tmp_path: Path) -> dict:
-    """Synthetic v3 source: 4 episodes, 2 cameras, 6-dim state/action."""
+def _fake_corpus(tmp_path: Path, *, chunk1_eps: tuple[int, ...] = ()) -> dict:
+    """Synthetic v3 source: 4 episodes, 2 cameras, 6-dim state/action.
+
+    Episodes named in ``chunk1_eps`` reference video chunk 1 (files present
+    with distinguishable bytes), so a selection can span two source chunks.
+    """
     info = {
         "fps": 30,
         "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
@@ -50,6 +54,7 @@ def _fake_corpus(tmp_path: Path) -> dict:
     rows = []
     for i in range(4):
         length = LENGTHS[i]
+        vchunk = 1 if i in chunk1_eps else 0
         rows.append(
             [
                 i,
@@ -58,11 +63,11 @@ def _fake_corpus(tmp_path: Path) -> dict:
                 0,
                 OFFSETS[i],
                 OFFSETS[i] + length,
-                0,
+                vchunk,
                 0,
                 0.0,
                 2.0 + i * 0.2,
-                0,
+                vchunk,
                 0,
                 0.0,
                 2.0 + i * 0.2,
@@ -129,12 +134,14 @@ def _fake_corpus(tmp_path: Path) -> dict:
     )
 
     # video chunks (fake bytes); exporter fetches them under the converter's
-    # local naming: cache/videos/<sanitized-cam>-chunk<N>.mp4
-    for cam in ("observation.images.up", "observation.images.side"):
-        vname = cam.replace("/", "_").replace(".", "_") + "-chunk0.mp4"
-        vdir = tmp_path / "videos"
-        vdir.mkdir(parents=True, exist_ok=True)
-        (vdir / vname).write_bytes(f"fake-mp4-{cam}".encode())
+    # local naming: cache/videos/<sanitized-cam>-chunk<N>-file<M>.mp4
+    for chunk in (0, 1) if chunk1_eps else (0,):
+        for cam in ("observation.images.up", "observation.images.side"):
+            vname = cam.replace("/", "_").replace(".", "_") + f"-chunk{chunk}-file0.mp4"
+            vdir = tmp_path / "videos"
+            vdir.mkdir(parents=True, exist_ok=True)
+            marker = "" if chunk == 0 else "CHUNK-ONE-"
+            (vdir / vname).write_bytes(f"fake-mp4-{marker}{cam}".encode())
 
     conn.close()
 
@@ -151,13 +158,13 @@ def _fake_corpus(tmp_path: Path) -> dict:
                 "data_to": OFFSETS[i] + LENGTHS[i],
                 "video_windows": {
                     "observation.images.up": {
-                        "chunk_index": "0",
+                        "chunk_index": str(vchunk),
                         "file_index": "0",
                         "from_timestamp": 0.0,
                         "to_timestamp": 2.0 + i * 0.2,
                     },
                     "observation.images.side": {
-                        "chunk_index": "0",
+                        "chunk_index": str(vchunk),
                         "file_index": "0",
                         "from_timestamp": 0.0,
                         "to_timestamp": 2.0 + i * 0.2,
@@ -179,9 +186,7 @@ def _fake_corpus(tmp_path: Path) -> dict:
     }
 
 
-@pytest.fixture()
-def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
-    corpus = _fake_corpus(tmp_path)
+def _install_fake_import(corpus: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     corpus["_import_calls"] = []
 
     def _fake_import(
@@ -206,6 +211,19 @@ def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
         return []
 
     monkeypatch.setattr(hflow, "import_lerobot_dataset", _fake_import)
+
+
+@pytest.fixture()
+def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    corpus = _fake_corpus(tmp_path)
+    _install_fake_import(corpus, tmp_path, monkeypatch)
+    return corpus
+
+
+@pytest.fixture()
+def multi_chunk_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    corpus = _fake_corpus(tmp_path, chunk1_eps=(2,))
+    _install_fake_import(corpus, tmp_path, monkeypatch)
     return corpus
 
 
@@ -274,28 +292,33 @@ def test_export_noncontiguous_selection(fake_corpus: dict, tmp_path: Path) -> No
     assert [r[0] for r in rows] == [0, 1]
     assert rows[0][1] == 60
     assert rows[1][1] == 70
+    assert [r[2] for r in rows] == [0, 1]  # plain indexes, one data parquet per episode
     assert (rows[0][3], rows[0][4]) == (0, 60)
     assert (rows[1][3], rows[1][4]) == (60, 130)
     assert rows[1][5] == ["task-2"]
 
+    ep1_data = dest / "data" / "chunk-000" / "file-001.parquet"
+    assert ep1_data.exists()  # the per-episode file episode 1 references
     conn = duckdb.connect()
     dcount = conn.execute(
-        "SELECT count(*), min(episode_index), max(episode_index) FROM read_parquet('"
+        "SELECT count(*) FROM read_parquet('"
         + str(dest / "data/chunk-000/file-000.parquet").replace("'", "''")
         + "')"
     ).fetchall()[0]
-    # frame indexes preserve the source per-episode numbering
+    dcount2 = conn.execute(
+        "SELECT count(*), max(frame_index) FROM read_parquet('"
+        + str(ep1_data).replace("'", "''")
+        + "')"
+    ).fetchall()[0]
     frames = conn.execute(
         "SELECT frame_index FROM read_parquet('"
         + str(dest / "data/chunk-000/file-000.parquet").replace("'", "''")
         + "')"
     ).fetchall()
     conn.close()
-    assert dcount[0] == 130
-    assert dcount[1] == 0
-    assert dcount[2] == 1
-    assert [f[0] for f in frames[:3]] == [0, 1, 2]  # ep0 keeps 0..59
-    assert frames[60][0] == 0  # ep2 restarts at 0
+    assert dcount[0] == 60  # episode 0 alone in its own parquet
+    assert dcount2 == (70, 69)  # episode 1: full length, per-episode restart
+    assert [f[0] for f in frames[:3]] == [0, 1, 2]
 
     for cam in ("observation.images.up", "observation.images.side"):
         v = dest / "videos" / cam / "chunk-000" / "file-000.mp4"
@@ -457,15 +480,153 @@ def test_export_provenance_digests_match_bytes(fake_corpus: dict, tmp_path: Path
     up = dest / "videos" / "observation.images.up" / "chunk-000" / "file-000.mp4"
     side = dest / "videos" / "observation.images.side" / "chunk-000" / "file-000.mp4"
     data = dest / "data" / "chunk-000" / "file-000.parquet"
-    assert prov["video_sha256"]["observation.images.up"] == _sha(up)
-    assert prov["video_sha256"]["observation.images.side"] == _sha(side)
-    assert prov["data_parquet_sha256"] == _sha(data)
+    assert set(prov["video_sha256"]) == {
+        "observation.images.up",
+        "observation.images.side",
+    }
+    assert prov["video_sha256"]["observation.images.up"] == {
+        "videos/observation.images.up/chunk-000/file-000.mp4": _sha(up)
+    }
+    assert prov["video_sha256"]["observation.images.side"] == {
+        "videos/observation.images.side/chunk-000/file-000.mp4": _sha(side)
+    }
+    assert prov["data_parquet_sha256"] == {"data/chunk-000/file-000.parquet": _sha(data)}
     # a constant would fail here: different files have different digests
+    video_digests = [
+        digest for per_cam in prov["video_sha256"].values() for digest in per_cam.values()
+    ]
     assert (
-        prov["video_sha256"]["observation.images.up"]
-        != prov["video_sha256"]["observation.images.side"]
+        prov["video_sha256"]["observation.images.up"][
+            "videos/observation.images.up/chunk-000/file-000.mp4"
+        ]
+        != prov["video_sha256"]["observation.images.side"][
+            "videos/observation.images.side/chunk-000/file-000.mp4"
+        ]
     )
-    assert prov["data_parquet_sha256"] not in prov["video_sha256"].values()
+    assert all(digest not in video_digests for digest in prov["data_parquet_sha256"].values())
+
+
+def test_export_multi_chunk_videos(multi_chunk_corpus: dict, tmp_path: Path) -> None:
+    """A selection spanning two source video chunks ships both byte-exact.
+
+    Regression for the review finding that every camera landed in
+    chunk-000/file-000.mp4 and the second source chunk never reached the
+    output: distinct source (chunk, file) identities must land in distinct
+    destination files, and each episode row must reference the file its
+    frames actually come from.
+    """
+    manifest = _fake_manifest(
+        tmp_path,
+        [
+            {"metadata_json": _provenance_meta(0)},
+            {"metadata_json": _provenance_meta(1)},
+            {"metadata_json": _provenance_meta(2, task="task-2")},
+        ],
+    )
+    dest = tmp_path / "out"
+    export.export(dest, manifest=manifest, camera_keys=CAMS)
+
+    up0 = dest / "videos" / "observation.images.up" / "chunk-000" / "file-000.mp4"
+    up1 = dest / "videos" / "observation.images.up" / "chunk-001" / "file-000.mp4"
+    side1 = dest / "videos" / "observation.images.side" / "chunk-001" / "file-000.mp4"
+    assert up0.read_bytes() == b"fake-mp4-observation.images.up"
+    assert up1.read_bytes() == b"fake-mp4-CHUNK-ONE-observation.images.up"
+    assert side1.read_bytes() == b"fake-mp4-CHUNK-ONE-observation.images.side"
+    assert not (dest / "videos" / "observation.images.up" / "chunk-000" / "file-001.mp4").exists()
+
+    conn = duckdb.connect()
+    rows = conn.execute(
+        'SELECT episode_index, "videos/observation.images.up/chunk_index" FROM read_parquet(\''
+        + str(dest / "meta/episodes/chunk-000/file-000.parquet").replace("'", "''")
+        + "')"
+    ).fetchall()
+    conn.close()
+    assert rows == [(0, 0), (1, 0), (2, 1)]
+
+    info = json.loads((dest / "meta" / "info.json").read_text())
+    assert info["total_videos"] == 4  # up/side x chunk0/chunk1, deduplicated
+
+    prov = json.loads((dest / "export-provenance.json").read_text())
+    up_digests = prov["video_sha256"]["observation.images.up"]
+    assert (
+        up_digests["videos/observation.images.up/chunk-000/file-000.mp4"]
+        != up_digests["videos/observation.images.up/chunk-001/file-000.mp4"]
+    )
+    assert set(prov["video_sha256"]["observation.images.side"]) == {
+        "videos/observation.images.side/chunk-000/file-000.mp4",
+        "videos/observation.images.side/chunk-001/file-000.mp4",
+    }
+
+
+def test_export_output_readback(fake_corpus: dict, tmp_path: Path) -> None:
+    """The exported episode parquet parses with the exporter's own reader.
+
+    Regression for the review finding that data/chunk_index was written as
+    'chunk-000' and broke int() conversion on re-read: exported indexes are
+    plain integers and every referenced data file exists on disk.
+    """
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    corpus = export._read_corpus_from_cache(dest)
+    assert len(corpus["episodes"]) == 1
+    ep = corpus["episodes"][0]
+    assert int(ep["data_chunk"]) == 0
+    assert int(ep["data_file"]) == 0
+    assert ep["video_windows"]["observation.images.up"]["chunk_index"] == "0"
+    info = json.loads((dest / "meta" / "info.json").read_text())
+    drel = info["data_path"].format(
+        chunk_index=int(ep["data_chunk"]), file_index=int(ep["data_file"])
+    )
+    assert (dest / drel).exists()
+
+
+def test_export_validation_failure_leaves_no_destination(
+    fake_corpus: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A staging validation refusal propagates and never publishes.
+
+    Regression for the review finding that the _validate_v3 call could be
+    deleted without any test noticing: a validator refusal must abort the
+    export, leave no destination behind, and leave a pre-existing
+    destination untouched.
+    """
+
+    def _reject(_stage: Path) -> None:
+        raise ValueError("staged dataset rejected for the test")
+
+    monkeypatch.setattr(export, "_validate_v3", _reject)
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "sentinel.txt").write_text("keep")
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(0)}])
+    with pytest.raises(ValueError, match="rejected for the test"):
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
+    assert (dest / "sentinel.txt").read_text() == "keep"
+
+    dest2 = tmp_path / "out2"
+    with pytest.raises(ValueError, match="rejected for the test"):
+        export.export(dest2, manifest=manifest, camera_keys=CAMS)
+    assert not dest2.exists()
+
+
+def test_validate_v3_rejects_non_integer_data_refs(fake_corpus: dict, tmp_path: Path) -> None:
+    """Index fields must be values data_path can format: 'chunk-000' => refusal.
+
+    Regression for the review finding that the exported data refs were
+    written as 'chunk-000' strings: the loader formats these with :03d, so a
+    non-integer reference makes the dataset unloadable and must be refused.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    dest = _exported_dataset(fake_corpus, tmp_path)
+    ep_pq = dest / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    table = pq.read_table(str(ep_pq))
+    idx = table.schema.get_field_index("data/chunk_index")
+    table = table.set_column(idx, "data/chunk_index", pa.array(["chunk-000"], pa.string()))
+    pq.write_table(table, str(ep_pq))
+    with pytest.raises(ValueError, match="cannot format references"):
+        export._validate_v3(dest)
 
 
 def test_validate_v3_rejects_incoherent_info(fake_corpus: dict, tmp_path: Path) -> None:

--- a/tests/test_lerobot_export.py
+++ b/tests/test_lerobot_export.py
@@ -1,0 +1,389 @@
+"""Tests for the HFlow LeRobot exporter (examples/lerobot/export.py).
+
+The exporter resolves a curation selection to source LeRobot provenance,
+fetches the source chunks, and publishes a local LeRobot Dataset v3
+repository containing exactly the selected episodes. The tests use a
+synthetic source corpus and a fake manifest, with the network-touching
+helpers monkeypatched, exactly like the converter tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import duckdb
+import pytest
+
+pytest.importorskip("examples.lerobot.prepare")
+
+_EXPORT_PATH = Path(__file__).resolve().parent.parent / "examples" / "lerobot" / "export.py"
+_spec = importlib.util.spec_from_file_location("lerobot_export", _EXPORT_PATH)
+assert _spec and _spec.loader
+export = importlib.util.module_from_spec(_spec)
+sys.modules["lerobot_export"] = export
+_spec.loader.exec_module(export)
+
+LENGTHS = [60, 65, 70, 75]  # episode lengths: 60 + i*5
+OFFSETS = [0, 60, 125, 195]  # cumulative data offsets
+
+
+def _fake_corpus(tmp_path: Path) -> dict:
+    """Synthetic v3 source: 4 episodes, 2 cameras, 6-dim state/action."""
+    info = {
+        "fps": 30,
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {
+            "action": {"dtype": "float32", "shape": [6]},
+            "observation.state": {"dtype": "float32", "shape": [6]},
+            "observation.images.up": {"dtype": "video", "shape": [480, 640, 3]},
+            "observation.images.side": {"dtype": "video", "shape": [480, 640, 3]},
+            "timestamp": {"dtype": "float32", "shape": [1]},
+        },
+        "robot_type": "so101",
+    }
+    (tmp_path / "meta").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "meta" / "info.json").write_text(json.dumps(info))
+
+    rows = []
+    for i in range(4):
+        length = LENGTHS[i]
+        rows.append(
+            [
+                i,
+                length,
+                0,
+                0,
+                OFFSETS[i],
+                OFFSETS[i] + length,
+                0,
+                0,
+                0.0,
+                2.0 + i * 0.2,
+                0,
+                0,
+                0.0,
+                2.0 + i * 0.2,
+                [f"task-{i}"],
+            ]
+        )
+    ep_cols = [
+        "episode_index",
+        "length",
+        "data/chunk_index",
+        "data/file_index",
+        "dataset_from_index",
+        "dataset_to_index",
+        "videos/observation.images.up/chunk_index",
+        "videos/observation.images.up/file_index",
+        "videos/observation.images.up/from_timestamp",
+        "videos/observation.images.up/to_timestamp",
+        "videos/observation.images.side/chunk_index",
+        "videos/observation.images.side/file_index",
+        "videos/observation.images.side/from_timestamp",
+        "videos/observation.images.side/to_timestamp",
+        "tasks",
+    ]
+    ep_path = tmp_path / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    ep_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = duckdb.connect()
+    vals = ",".join(
+        "("
+        + ",".join(
+            "[" + ",".join(f"'{x}'" for x in v) + "]"
+            if isinstance(v, list)
+            else f"'{v!s}'"
+            if isinstance(v, str)
+            else str(v)
+            for v in row
+        )
+        + ")"
+        for row in rows
+    )
+    quoted = str(ep_path).replace("'", "''")
+    qcols = ",".join(f'"{c}"' for c in ep_cols)
+    conn.execute(
+        f"COPY (SELECT * FROM (VALUES {vals}) AS t({qcols})) TO '{quoted}' (FORMAT parquet)"
+    )
+
+    # one contiguous data chunk: all episodes' rows, index = row position
+    data_rows = []
+    idx = 0
+    for i in range(4):
+        length = LENGTHS[i]
+        for f in range(length):
+            state = "[" + ",".join(str(float(f)) for _ in range(6)) + "]"
+            action = "[" + ",".join(str(float(f + 0.5)) for _ in range(6)) + "]"
+            data_rows.append([idx, i, f, round(f / 30.0, 6), state, action])
+            idx += 1
+    data_path = tmp_path / "data" / "chunk-000" / "file-000.parquet"
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    dvals = ",".join("(" + ",".join(str(v) for v in row) + ")" for row in data_rows)
+    dquoted = str(data_path).replace("'", "''")
+    conn.execute(
+        f"COPY (SELECT * FROM (VALUES {dvals}) AS "
+        't(index, episode_index, frame_index, timestamp, "observation.state", action)) '
+        f"TO '{dquoted}' (FORMAT parquet)"
+    )
+
+    # video chunks (fake bytes); exporter fetches them under the converter's
+    # local naming: cache/videos/<sanitized-cam>-chunk<N>.mp4
+    for cam in ("observation.images.up", "observation.images.side"):
+        vname = cam.replace("/", "_").replace(".", "_") + "-chunk0.mp4"
+        vdir = tmp_path / "videos"
+        vdir.mkdir(parents=True, exist_ok=True)
+        (vdir / vname).write_bytes(f"fake-mp4-{cam}".encode())
+
+    conn.close()
+
+    episodes = []
+    for i in range(4):
+        episodes.append(
+            {
+                "episode_index": i,
+                "task": f"task-{i}",
+                "length": LENGTHS[i],
+                "data_chunk": "0",
+                "data_file": "0",
+                "data_from": OFFSETS[i],
+                "data_to": OFFSETS[i] + LENGTHS[i],
+                "video_windows": {
+                    "observation.images.up": {
+                        "chunk_index": "0",
+                        "file_index": "0",
+                        "from_timestamp": 0.0,
+                        "to_timestamp": 2.0 + i * 0.2,
+                    },
+                    "observation.images.side": {
+                        "chunk_index": "0",
+                        "file_index": "0",
+                        "from_timestamp": 0.0,
+                        "to_timestamp": 2.0 + i * 0.2,
+                    },
+                },
+            }
+        )
+
+    return {
+        "info": info,
+        "fps": 30,
+        "data_path": info["data_path"],
+        "video_path": info["video_path"],
+        "cache_dir": tmp_path,
+        "data_chunk": 0,
+        "data_file": 0,
+        "video_keys": ("observation.images.up", "observation.images.side"),
+        "episodes": episodes,
+    }
+
+
+@pytest.fixture()
+def fake_corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    corpus = _fake_corpus(tmp_path)
+    monkeypatch.setattr(
+        export.prepare,
+        "_ensure_source_archive",
+        lambda dataset, cache_dir: corpus,
+    )
+    monkeypatch.setattr(export.prepare, "_download_file", lambda url, dest, **kw: None)
+    return corpus
+
+
+def _fake_manifest(tmp_path: Path, rows: list[dict]) -> Path:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    mpath = tmp_path / "manifest.parquet"
+    table = pa.Table.from_pylist(rows)
+    if "episode_id" not in table.column_names:
+        table = table.append_column("episode_id", pa.array([f"ep_{i}" for i in range(len(rows))]))
+    pq.write_table(table, mpath)
+    return mpath
+
+
+def _provenance_meta(ep: int, task: str = "task-0") -> str:
+    return json.dumps(
+        {
+            "source_dataset": "lerobot/fake",
+            "source_revision": "a" * 40,
+            "source_episode_index": ep,
+            "task": task,
+            "embodiment": "so101",
+        }
+    )
+
+
+def _make_data_local(corpus: dict) -> None:
+    """Place the data chunk where the exporter fetches it."""
+    src = Path(corpus["cache_dir"]) / "data" / "chunk-000" / "file-000.parquet"
+    dst = Path(corpus["cache_dir"]) / "data" / "chunk-000000-file-000000.parquet"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if not dst.exists():
+        shutil.copy2(src, dst)
+
+
+def test_export_noncontiguous_selection(fake_corpus: dict, tmp_path: Path) -> None:
+    """Outcome: exactly episodes 0 and 2, in selection order, loadable layout."""
+    _make_data_local(fake_corpus)
+    manifest = _fake_manifest(
+        tmp_path,
+        [
+            {"metadata_json": _provenance_meta(0)},
+            {"metadata_json": _provenance_meta(2, task="task-2")},
+        ],
+    )
+    dest = tmp_path / "out"
+    export.export(dest, manifest=manifest)
+
+    info = json.loads((dest / "meta" / "info.json").read_text())
+    assert info["total_episodes"] == 2
+    assert info["total_frames"] == 60 + 70  # episodes 0 and 2
+    assert info["splits"]["train"] == ["episode_000000", "episode_000001"]
+    assert "observation.images.up" in info["features"]
+    assert "observation.images.side" in info["features"]
+    assert info["features"]["action"]["dtype"] == "float32"
+
+    conn = duckdb.connect()
+    rows = conn.execute(
+        'SELECT episode_index, length, "data/file_index", dataset_from_index, dataset_to_index, '
+        "tasks FROM read_parquet('"
+        + str(dest / "meta/episodes/chunk-000/file-000.parquet").replace("'", "''")
+        + "')"
+    ).fetchall()
+    conn.close()
+    assert [r[0] for r in rows] == [0, 1]
+    assert rows[0][1] == 60
+    assert rows[1][1] == 70
+    assert (rows[0][3], rows[0][4]) == (0, 60)
+    assert (rows[1][3], rows[1][4]) == (60, 130)
+    assert rows[1][5] == ["task-2"]
+
+    conn = duckdb.connect()
+    dcount = conn.execute(
+        "SELECT count(*), min(episode_index), max(episode_index) FROM read_parquet('"
+        + str(dest / "data/chunk-000/file-000.parquet").replace("'", "''")
+        + "')"
+    ).fetchall()[0]
+    # frame indexes preserve the source per-episode numbering
+    frames = conn.execute(
+        "SELECT frame_index FROM read_parquet('"
+        + str(dest / "data/chunk-000/file-000.parquet").replace("'", "''")
+        + "')"
+    ).fetchall()
+    conn.close()
+    assert dcount[0] == 130
+    assert dcount[1] == 0
+    assert dcount[2] == 1
+    assert [f[0] for f in frames[:3]] == [0, 1, 2]  # ep0 keeps 0..59
+    assert frames[60][0] == 0  # ep2 restarts at 0
+
+    for cam in ("observation.images.up", "observation.images.side"):
+        v = dest / "videos" / cam / "chunk-000" / "file-000.mp4"
+        assert v.exists()
+        assert v.read_bytes() == f"fake-mp4-{cam}".encode()
+
+    assert (dest / "README.md").exists()
+    prov = json.loads((dest / "export-provenance.json").read_text())
+    assert prov["source_episode_indexes"] == [0, 2]
+    assert prov["source_commit"] == "a" * 40
+
+
+def test_export_mixed_repositories_fail(fake_corpus: dict, tmp_path: Path) -> None:
+    rows = [
+        {"metadata_json": _provenance_meta(0)},
+        {
+            "metadata_json": json.dumps(
+                {
+                    "source_dataset": "lerobot/other",
+                    "source_revision": "b" * 40,
+                    "source_episode_index": 1,
+                    "task": "task-1",
+                    "embodiment": "so101",
+                }
+            )
+        },
+    ]
+    manifest = _fake_manifest(tmp_path, rows)
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="mixes source repositories"):
+        export.export(dest, manifest=manifest)
+    assert not dest.exists()
+
+
+def test_export_nonimmutable_revision_fails(fake_corpus: dict, tmp_path: Path) -> None:
+    rows = [
+        {
+            "metadata_json": json.dumps(
+                {
+                    "source_dataset": "lerobot/fake",
+                    "source_revision": "main",
+                    "source_episode_index": 0,
+                    "task": "task-0",
+                    "embodiment": "so101",
+                }
+            )
+        }
+    ]
+    manifest = _fake_manifest(tmp_path, rows)
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="not an immutable commit sha"):
+        export.export(dest, manifest=manifest)
+    assert not dest.exists()
+
+
+def test_export_missing_provenance_fails(fake_corpus: dict, tmp_path: Path) -> None:
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": None}])
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="lacks LeRobot provenance"):
+        export.export(dest, manifest=manifest)
+    assert not dest.exists()
+
+
+def test_export_missing_source_episode_fails(fake_corpus: dict, tmp_path: Path) -> None:
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(9)}])
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="source episodes not present"):
+        export.export(dest, manifest=manifest)
+    assert not dest.exists()
+
+
+def test_export_duplicate_episode_fails(fake_corpus: dict, tmp_path: Path) -> None:
+    manifest = _fake_manifest(
+        tmp_path,
+        [
+            {"metadata_json": _provenance_meta(0)},
+            {"metadata_json": _provenance_meta(0)},
+        ],
+    )
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="duplicate source episode indexes"):
+        export.export(dest, manifest=manifest)
+    assert not dest.exists()
+
+
+def test_export_sql_selection(fake_corpus: dict, tmp_path: Path) -> None:
+    """SQL selection path: same outcome via a duckdb query string."""
+    _make_data_local(fake_corpus)
+    dest = tmp_path / "out"
+    catalog = tmp_path / "catalog.parquet"
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pylist(
+        [
+            {"episode_id": "ep_0", "metadata_json": _provenance_meta(0)},
+            {"episode_id": "ep_3", "metadata_json": _provenance_meta(3, task="task-3")},
+        ]
+    )
+    pq.write_table(table, catalog)
+    export.export(
+        dest,
+        sql=f"SELECT episode_id, metadata_json FROM read_parquet('{catalog}')",
+    )
+    info = json.loads((dest / "meta" / "info.json").read_text())
+    assert info["total_episodes"] == 2
+    assert info["total_frames"] == 60 + 75  # episodes 0 and 3


### PR DESCRIPTION
Closes #190

## What this adds

A standalone export callable and command under `examples/lerobot/` that turns an HFlow curation selection into a **local LeRobot Dataset v3 repository** loadable by existing LeRobot tooling:

- `examples/lerobot/export.py` — public `export()` callable + `--manifest` / `--sql` CLI
- `examples/README.md` — documented usage (manifest and SQL forms)
- `tests/test_lerobot_export.py` — 7 outcome-focused tests

## How it works

1. **Selection**: reads a `hflow curate` manifest parquet or a SQL query (exactly one required).
2. **Provenance**: each row's `metadata_json` is resolved to `source_dataset`, `source_revision`, `source_episode_index`, `task`, `embodiment` — the exact #189 contract keys the converter stamps in `episode/v1` (no contract extension: nothing new is added to the converter's stamps).
3. **Immutability**: the selection must reference exactly one repository and one immutable 40-hex commit; branch names and mixed sources fail loudly before any output exists.
4. **Materialization**: source video chunks are copied byte-for-byte (no re-encode, frame timing preserved) and the selected episode data rows are sliced from their source chunk parquets, so camera content, feature schema, dtypes, shapes, and frame timing match the source exactly. Episode indexes are renumbered sequentially in selection order; non-contiguous selections come out in deterministic selection order.
5. **Validation**: structural v3 checks run always (info.json coherence, per-episode windows == length, video files present per referenced camera); when the official `lerobot` package is installed, the staged directory is additionally loaded through `LeRobotDataset`.
6. **Atomic publish**: everything is staged under a temp dir; the destination is replaced only after creation + validation succeed. A failure never leaves a partial or destroyed destination.
7. **Provenance out**: `export-provenance.json` (source repo, source commit, exporter version, selection SQL/manifest name, selected source episode indexes, video + data parquet sha256s) + a dataset-card draft `README.md` with enough to reproduce the selection.

## Failure behavior (all tested)

- missing provenance (`metadata_json` absent) → abort, no destination
- mixed source repositories or revisions → abort
- non-immutable revision (e.g. `main`) → abort
- duplicate source episode indexes → abort
- selected episode not present in the source → abort
- staged dataset failing structural/API validation → abort

Temporary output never replaces a previously valid destination until creation and validation succeed.

## Tests

`tests/test_lerobot_export.py` (synthetic v3 corpus, network helpers monkeypatched, mirroring the converter tests):

- non-contiguous selection (episodes 0 + 2 of 4): output contains exactly {0, 2} in order, episode/data parquets renumbered (windows 0-60, 60-130), frame_index preserved per source episode, videos byte-identical, provenance + card written
- mixed repositories, non-immutable revision, missing provenance, missing source episode, duplicate selection → all fail with no destination created
- SQL selection path produces the same outcome as the manifest path

## Verification

- `ruff check`: clean (both files)
- `ty check`: clean (both files)
- `pytest tests/test_lerobot_export.py`: 7 passed
- full suite: 985 passed / 6 skipped; the only failures are 3 pre-existing `tests/test_cli.py` cases that fail identically on a clean tree (verified via stash)
- the official-API validation pass runs in CI where `lerobot` is installed; the structural pass runs everywhere