### PR TITLE
Fix VideoEpisodeSpec numeric validation

### DIFF
--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -349,7 +349,31 @@ def _validate_video_fault_segment(
         )
 
 
+def _validate_numeric_spec_fields(
+    *,
+    float_fields: tuple[tuple[str, int | float], ...],
+    int_fields: tuple[tuple[str, int], ...],
+) -> None:
+    """Require the declared numeric field types and finite real-valued fields."""
+    for field_name, value in float_fields:
+        _require_float(value, field_name)
+    for field_name, value in int_fields:
+        _require_int(value, field_name)
+    for field_name, value in float_fields:
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{field_name} must be finite, got {value!r}")
+
+
 def _validate_video_episode_spec(spec: VideoEpisodeSpec) -> None:
+    _validate_numeric_spec_fields(
+        float_fields=(
+            ("source_start_s", spec.source_start_s),
+            ("duration_s", spec.duration_s),
+            ("image_hz", spec.image_hz),
+        ),
+        int_fields=(("image_width", spec.image_width), ("image_height", spec.image_height)),
+    )
+
     if spec.source_start_s < 0.0:
         raise ValueError(f"source_start_s must be >= 0, got {spec.source_start_s}")
     if spec.duration_s <= 0.0:
@@ -380,17 +404,18 @@ def _validate_video_episode_spec(spec: VideoEpisodeSpec) -> None:
 
 
 def _validate_synthetic_episode_spec(spec: "SyntheticEpisodeSpec") -> None:
-    _require_float(spec.duration_s, "duration_s")
-    _require_float(spec.image_hz, "image_hz")
-    _require_float(spec.joint_hz, "joint_hz")
-    _require_int(spec.image_width, "image_width")
-    _require_int(spec.image_height, "image_height")
-    _require_int(spec.joint_count, "joint_count")
-
-    for field_name in ("duration_s", "image_hz", "joint_hz"):
-        value = getattr(spec, field_name)
-        if not math.isfinite(float(value)):
-            raise ValueError(f"{field_name} must be finite, got {value!r}")
+    _validate_numeric_spec_fields(
+        float_fields=(
+            ("duration_s", spec.duration_s),
+            ("image_hz", spec.image_hz),
+            ("joint_hz", spec.joint_hz),
+        ),
+        int_fields=(
+            ("image_width", spec.image_width),
+            ("image_height", spec.image_height),
+            ("joint_count", spec.joint_count),
+        ),
+    )
 
     if spec.duration_s <= 0.0:
         raise ValueError(f"duration_s must be > 0, got {spec.duration_s}")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -285,6 +285,95 @@ def test_video_episode_missing_source_names_the_path_with_errno(tmp_path: Path) 
 @pytest.mark.parametrize(
     ("spec_kwargs", "match"),
     [
+        pytest.param(
+            {"source_start_s": True},
+            r"source_start_s must be an int or float, got bool",
+            id="source_start_s-bool",
+        ),
+        pytest.param(
+            {"source_start_s": float("nan")},
+            r"source_start_s must be finite",
+            id="source_start_s-nan",
+        ),
+        pytest.param(
+            {"source_start_s": -1.0},
+            r"source_start_s must be >= 0",
+            id="source_start_s-negative",
+        ),
+        pytest.param(
+            {"duration_s": True},
+            r"duration_s must be an int or float, got bool",
+            id="duration_s-bool",
+        ),
+        pytest.param(
+            {"duration_s": float("nan")},
+            r"duration_s must be finite",
+            id="duration_s-nan",
+        ),
+        pytest.param({"duration_s": 0.0}, r"duration_s must be > 0", id="duration_s-zero"),
+        pytest.param(
+            {"image_hz": True},
+            r"image_hz must be an int or float, got bool",
+            id="image_hz-bool",
+        ),
+        pytest.param({"image_hz": float("inf")}, r"image_hz must be finite", id="image_hz-inf"),
+        pytest.param({"image_hz": 0.0}, r"image_hz must be > 0", id="image_hz-zero"),
+        pytest.param(
+            {"image_width": True},
+            r"image_width must be an int, got bool",
+            id="image_width-bool",
+        ),
+        pytest.param(
+            {"image_width": float("inf")},
+            r"image_width must be an int, got float",
+            id="image_width-inf",
+        ),
+        pytest.param(
+            {"image_width": 640.0},
+            r"image_width must be an int, got float",
+            id="image_width-float",
+        ),
+        pytest.param(
+            {"image_width": 0}, r"image dimensions must be positive", id="image_width-zero"
+        ),
+        pytest.param({"image_width": 639}, r"image dimensions must be even", id="image_width-odd"),
+        pytest.param(
+            {"image_height": True},
+            r"image_height must be an int, got bool",
+            id="image_height-bool",
+        ),
+        pytest.param(
+            {"image_height": float("nan")},
+            r"image_height must be an int, got float",
+            id="image_height-nan",
+        ),
+        pytest.param(
+            {"image_height": 360.0},
+            r"image_height must be an int, got float",
+            id="image_height-float",
+        ),
+        pytest.param(
+            {"image_height": 0}, r"image dimensions must be positive", id="image_height-zero"
+        ),
+        pytest.param(
+            {"image_height": 359}, r"image dimensions must be even", id="image_height-odd"
+        ),
+    ],
+)
+def test_write_video_episode_refuses_invalid_spec(
+    tmp_path: Path, spec_kwargs: dict[str, object], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        write_video_episode(
+            tmp_path / "source-is-not-read.mp4",
+            tmp_path / "refused.mcap",
+            VideoEpisodeSpec(**spec_kwargs),  # ty: ignore
+        )
+
+
+@pytest.mark.parametrize(
+    ("spec_kwargs", "match"),
+    [
         pytest.param({"duration_s": 0.0}, r"duration_s must be > 0", id="duration_s-zero"),
         pytest.param({"duration_s": -1.0}, r"duration_s must be > 0", id="duration_s-negative"),
         pytest.param({"joint_hz": 0.0}, r"joint_hz must be > 0", id="joint_hz-zero"),


### PR DESCRIPTION
## What was wrong

`VideoEpisodeSpec` validated numeric fields only with range comparisons, unlike the adjacent `SyntheticEpisodeSpec` validator. As a result, booleans were treated as integers and non-finite floats could bypass range checks. For example, `duration_s=True`, `duration_s=nan`, and `image_hz=inf` were accepted. `image_width=True` was rejected only by the later even-dimension rule, producing a misleading H.264 error instead of a field-specific type error.

## What changed

- Added one shared numeric-spec validation helper and used it from both episode-spec validators so their type and finiteness checks cannot drift independently again.
- Made `source_start_s`, `duration_s`, and `image_hz` accept finite `int` or `float` values while explicitly rejecting `bool`.
- Made `image_width` and `image_height` require integers, explicitly rejecting booleans, floats, and non-finite float values.
- Kept the existing positive-dimension and even-dimension H.264 rules unchanged.
- Added a parametrized `VideoEpisodeSpec` rejection table covering type, finiteness, range, and dimension constraints. The `image_width=True` case specifically asserts the field-level type error.

`SyntheticEpisodeSpec` keeps its existing behavior; its validator now delegates the same checks to the shared helper, and its existing rejection table remains unchanged.

## Validation

Ran the repository's requested checks from the root:

- `uv sync --locked --all-extras`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check` — passed
- `uv run pytest -q` — **1209 passed, 11 skipped**

Focused validation of both rejection tables also passed:

- `uv run pytest -q tests/test_testing.py::test_write_video_episode_refuses_invalid_spec tests/test_testing.py::test_synthesize_episode_refuses_invalid_spec` — **35 passed**

As a mutation check, I temporarily removed the new video numeric-validation call and reran the video rejection table. The 12 type/finiteness rows failed as intended, including the `image_width=True` row failing because it fell through to the wrong evenness error. After restoring the guard, all focused tests passed.

closes #274 