### PR TITLE
test: cover the snapshot export symlink and null episode_id refusals

### DIFF
--- a/tests/test_dataset_snapshot.py
+++ b/tests/test_dataset_snapshot.py
@@ -307,6 +307,23 @@ def test_dataset_snapshot_rejects_manifest_episode_ids_absent_from_catalog(tmp_p
     assert not (tmp_path / "dataset-snapshot").exists()
 
 
+def test_dataset_snapshot_rejects_a_manifest_with_a_null_episode_id(tmp_path: Path) -> None:
+    catalog = Catalog(tmp_path / "catalog")
+    manifest = tmp_path / "manifest.parquet"
+    duckdb.execute("CREATE TABLE selected_with_a_null (episode_id VARCHAR)")
+    duckdb.execute("INSERT INTO selected_with_a_null VALUES (NULL)")
+    duckdb.execute(f"COPY selected_with_a_null TO '{manifest}' (FORMAT PARQUET)")
+
+    with pytest.raises(ValueError, match=r"manifest\.parquet contains a null episode_id"):
+        hflow.export_dataset_snapshot(
+            catalog.location,
+            tmp_path / "dataset-snapshot",
+            manifest=manifest,
+        )
+
+    assert not (tmp_path / "dataset-snapshot").exists()
+
+
 def test_dataset_snapshot_overwrite_refuses_unmarked_directory_without_removing_it(
     tmp_path: Path,
 ) -> None:
@@ -324,6 +341,59 @@ def test_dataset_snapshot_overwrite_refuses_unmarked_directory_without_removing_
         )
 
     assert sentinel_file.read_text() == "unrelated user data"
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_dataset_snapshot_refuses_a_symlinked_destination(tmp_path: Path, overwrite: bool) -> None:
+    """A symlinked destination is refused before overwrite is consulted.
+
+    ``Path.is_dir()`` follows symlinks, so every check after this one sees an
+    ordinary directory. Were the refusal to move below the overwrite branch,
+    an overwriting export would rename the link aside and put a real
+    directory in its place instead of exporting into what it pointed at.
+    """
+    catalog = Catalog(tmp_path / "catalog")
+    linked_directory = tmp_path / "linked-directory"
+    linked_directory.mkdir()
+    sentinel_file = linked_directory / "keep-me.txt"
+    sentinel_file.write_text("unrelated user data")
+    output_directory = tmp_path / "dataset-snapshot-link"
+    output_directory.symlink_to(linked_directory)
+
+    with pytest.raises(ValueError, match="dataset-snapshot-link must not be a symlink"):
+        hflow.export_dataset_snapshot(
+            catalog.location,
+            output_directory,
+            overwrite=overwrite,
+        )
+
+    assert output_directory.is_symlink()
+    assert sentinel_file.read_text() == "unrelated user data"
+
+
+def test_dataset_snapshot_overwrite_refuses_a_symlinked_format_marker(tmp_path: Path) -> None:
+    """The marker has to be a regular file, not a link to a valid one elsewhere.
+
+    ``Path.is_file()`` follows symlinks, so without the symlink half of that
+    check a planted link would vouch for a directory that is not a snapshot,
+    and the export would replace it.
+    """
+    catalog = Catalog(tmp_path / "catalog")
+    output_directory = tmp_path / "dataset-snapshot"
+    hflow.export_dataset_snapshot(catalog.location, output_directory)
+    format_marker = output_directory / "format.json"
+    relocated_marker = tmp_path / "relocated-format.json"
+    format_marker.replace(relocated_marker)
+    format_marker.symlink_to(relocated_marker)
+
+    with pytest.raises(ValueError, match=r"regular format\.json"):
+        hflow.export_dataset_snapshot(
+            catalog.location,
+            output_directory,
+            overwrite=True,
+        )
+
+    assert format_marker.is_symlink()
 
 
 def test_dataset_snapshot_excludes_check_runs_without_a_committed_episode(tmp_path: Path) -> None:

--- a/tests/test_dataset_snapshot.py
+++ b/tests/test_dataset_snapshot.py
@@ -310,9 +310,10 @@ def test_dataset_snapshot_rejects_manifest_episode_ids_absent_from_catalog(tmp_p
 def test_dataset_snapshot_rejects_a_manifest_with_a_null_episode_id(tmp_path: Path) -> None:
     catalog = Catalog(tmp_path / "catalog")
     manifest = tmp_path / "manifest.parquet"
-    duckdb.execute("CREATE TABLE selected_with_a_null (episode_id VARCHAR)")
-    duckdb.execute("INSERT INTO selected_with_a_null VALUES (NULL)")
-    duckdb.execute(f"COPY selected_with_a_null TO '{manifest}' (FORMAT PARQUET)")
+    connection = duckdb.connect()
+    connection.execute("CREATE TABLE selected_with_a_null (episode_id VARCHAR)")
+    connection.execute("INSERT INTO selected_with_a_null VALUES (NULL)")
+    connection.execute(f"COPY selected_with_a_null TO '{manifest}' (FORMAT PARQUET)")
 
     with pytest.raises(ValueError, match=r"manifest\.parquet contains a null episode_id"):
         hflow.export_dataset_snapshot(


### PR DESCRIPTION
Closes #276.

## Summary

Three refusals in the snapshot export now have tests, none of which had one before:

- `_parse_dataset_snapshot_destination` refuses a symlinked destination
- the same function refuses a `format.json` that is itself a symlink
- `_register_selected_episode_ids` refuses a manifest carrying a null `episode_id`

The symlink-destination test is parametrized over `overwrite` because the ordering is the property worth holding, not just the message. `Path.is_dir()` follows symlinks, so every check after the first one sees an ordinary directory: if the refusal moved below the overwrite branch, an overwriting export would rename the link aside and put a real directory in its place instead of exporting into what it pointed at. Each test asserts on the message and then checks that the destination was left alone.

I did cover the format-marker check the issue asks about, because it turned out to be a distinct gap rather than a duplicate. `test_dataset_snapshot_overwrite_refuses_unmarked_directory_without_removing_it` already exercises the `not is_file()` half of that condition; the `is_symlink()` half needs the link to point at a *valid* marker, otherwise `is_file()` refuses anyway and the test would still pass with the guard gone.

Nothing in `src/hflow/snapshot.py` changed.

## Red-before proof

Each guard was disabled on its own, the relevant test run, then reverted.

| Mutation | Result |
| --- | --- |
| destination `raise` → `pass` | `refuses_a_symlinked_destination[False]` and `[True]` both red; `[False]` gets `FileExistsError: ... already exists; pass overwrite=True` |
| symlink check moved below the `overwrite` branch | `[False]` red, `[True]` green — which is why both parameters are there |
| `format_marker_path.is_symlink() or` dropped | `refuses_a_symlinked_format_marker` red with `DID NOT RAISE ValueError` |
| null `episode_id` `raise` → `pass` | `rejects_a_manifest_with_a_null_episode_id` red |

The last one is worth a note. Without that guard the export still fails, but later and on the wrong message: the null falls through to the catalog-membership check and comes back as `first missing values: 'None'`. So the guard is buying a readable diagnosis rather than the refusal itself, and the test pins the message accordingly.

## Validation

- `uv sync --locked`
- `uv run ruff check --fix` — All checks passed!
- `uv run ruff format` — 194 files already formatted
- `uv run ty check` — All checks passed!
- `uv run pytest -q` — **1234 passed, 11 skipped**
- `uv run pytest -q tests/test_dataset_snapshot.py` — **13 passed** (was 9)
- `uv run --python 3.11 --locked pytest -q tests/test_dataset_snapshot.py` and the same on 3.14 — 13 passed on both

Two notes on the run. I used `uv sync --locked` rather than `--all-extras`: syncing the `mediapipe` extra in and back out left `import cv2` broken exactly as CONTRIBUTING warns, and the default sync already mirrors every extra the suite exercises. Separately, `tests/test_catalog_ui.py::test_catalog_ui_starts_empty_then_exposes_the_first_completed_append` failed once on a full-suite run, then passed on two further full runs, five runs of that file alone, and three runs of it directly after `test_dataset_snapshot.py`. It is new in 05fae79 and unrelated to this change, but it looks timing-sensitive so I am flagging it.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements. (n/a, test-only)
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change. (n/a, test-only)
