### PR TITLE
test: cover malformed video input guards

### DIFF
--- a/docs/contrib-note.md
+++ b/docs/contrib-note.md
@@ -1,0 +1,1 @@
+Temporary note

--- a/docs/contrib-note.md
+++ b/docs/contrib-note.md
@@ -1,1 +1,0 @@
-Temporary note

--- a/tests/test_video_malformed_guards.py
+++ b/tests/test_video_malformed_guards.py
@@ -1,0 +1,48 @@
+"""Regression tests for malformed H.264 inputs rejected by hflow.video."""
+
+import pytest
+
+from hflow.video import (
+    _nal_header_offset,
+    ensure_access_unit_delimiter,
+    source_log_times_for_sampled_frames,
+)
+
+_ANNEX_B_4_BYTE_START_CODE = b"\x00\x00\x00\x01"
+_IDR_NAL_HEADER = b"\x65"  # NAL type 5: IDR coded slice.
+
+
+def _single_slice_idr(rbsp: bytes) -> bytes:
+    """Build one Annex B IDR NAL with an explicitly supplied slice-header RBSP."""
+    return _ANNEX_B_4_BYTE_START_CODE + _IDR_NAL_HEADER + rbsp
+
+
+def test_sampled_frame_mapping_rejects_empty_source_stream() -> None:
+    with pytest.raises(ValueError, match="cannot map sampled frames onto an empty source stream"):
+        source_log_times_for_sampled_frames(
+            [], source_fps=30.0, sample_fps=10.0, start_s=0.0, frame_count=1
+        )
+
+
+def test_nal_header_rejects_invalid_annex_b_start_code() -> None:
+    with pytest.raises(ValueError, match="invalid Annex B start code at byte 3"):
+        _nal_header_offset(b"\x00\x00\x00\xff", 3)
+
+
+def test_ensure_aud_rejects_slice_header_without_complete_first_mb_value() -> None:
+    # first_mb_in_slice is unsigned Exp-Golomb. An all-zero RBSP has no
+    # terminating one bit, so the decoder must reject it as incomplete.
+    malformed_slice = _single_slice_idr(b"\x00")
+
+    with pytest.raises(ValueError, match="slice header has no complete first_mb_in_slice value"):
+        ensure_access_unit_delimiter(malformed_slice)
+
+
+def test_ensure_aud_rejects_truncated_first_mb_value() -> None:
+    # 00000100 starts an Exp-Golomb value with five leading zero bits and a
+    # one bit, but only two suffix bits remain in the byte. This deliberately
+    # reaches the truncation guard rather than the no-complete-value guard.
+    malformed_slice = _single_slice_idr(b"\x04")
+
+    with pytest.raises(ValueError, match="slice header truncates its first_mb_in_slice value"):
+        ensure_access_unit_delimiter(malformed_slice)

--- a/tests/test_video_malformed_guards.py
+++ b/tests/test_video_malformed_guards.py
@@ -18,7 +18,8 @@ def _single_slice_idr(rbsp: bytes) -> bytes:
 
 
 def test_sampled_frame_mapping_rejects_empty_source_stream() -> None:
-    with pytest.raises(ValueError, match="cannot map sampled frames onto an empty source stream"):
+    message = "cannot map sampled frames onto an empty source stream"
+    with pytest.raises(ValueError, match=message):
         source_log_times_for_sampled_frames(
             [], source_fps=30.0, sample_fps=10.0, start_s=0.0, frame_count=1
         )
@@ -33,8 +34,9 @@ def test_ensure_aud_rejects_slice_header_without_complete_first_mb_value() -> No
     # first_mb_in_slice is unsigned Exp-Golomb. An all-zero RBSP has no
     # terminating one bit, so the decoder must reject it as incomplete.
     malformed_slice = _single_slice_idr(b"\x00")
+    message = "slice header has no complete first_mb_in_slice value"
 
-    with pytest.raises(ValueError, match="slice header has no complete first_mb_in_slice value"):
+    with pytest.raises(ValueError, match=message):
         ensure_access_unit_delimiter(malformed_slice)
 
 
@@ -43,6 +45,7 @@ def test_ensure_aud_rejects_truncated_first_mb_value() -> None:
     # one bit, but only two suffix bits remain in the byte. This deliberately
     # reaches the truncation guard rather than the no-complete-value guard.
     malformed_slice = _single_slice_idr(b"\x04")
+    message = "slice header truncates its first_mb_in_slice value"
 
-    with pytest.raises(ValueError, match="slice header truncates its first_mb_in_slice value"):
+    with pytest.raises(ValueError, match=message):
         ensure_access_unit_delimiter(malformed_slice)


### PR DESCRIPTION
## Summary

- add focused regression tests for the four malformed-input guards in `hflow.video`
- cover the empty source-stream mapping failure and invalid Annex B start code
- distinguish the two `first_mb_in_slice` failure paths with deliberately different RBSP inputs
- assert the specific error messages
- leave `src/hflow/video.py` unchanged

Fixes #275

The two `first_mb_in_slice` inputs are intentional:
- `0x00` contains no terminating `1` bit, reaching the "no complete" guard.
- `0x04` has five leading zero bits followed by `1`, but not enough suffix bits, reaching the truncation guard.