### PR TITLE
Pin tests for the snapshot export refusal guards (issue #276)

### DIFF
--- a/tests/test_dataset_snapshot.py
+++ b/tests/test_dataset_snapshot.py
@@ -557,3 +557,51 @@ def test_snapshot_samples_report_unverified_for_a_crashed_critical_check(
         [str(output_directory / "samples.parquet")],
     ).fetchone()
     assert sample_row == (append_result.episode_id, "unverified")
+
+
+def test_parse_dataset_snapshot_destination_refuses_symlink_before_overwrite_check(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "real-target"
+    target.mkdir()
+    link = tmp_path / "link-to-target"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match=r"must not be a symlink"):
+        snapshot_module._parse_dataset_snapshot_destination(link, overwrite=False)
+
+    with pytest.raises(ValueError, match=r"must not be a symlink"):
+        snapshot_module._parse_dataset_snapshot_destination(link, overwrite=True)
+
+
+def test_dataset_snapshot_rejects_manifest_with_null_episode_id(tmp_path: Path) -> None:
+    catalog = Catalog(tmp_path / "catalog")
+    manifest = tmp_path / "manifest.parquet"
+    duckdb.execute("DROP TABLE IF EXISTS selected")
+    duckdb.execute("CREATE TABLE selected (episode_id VARCHAR)")
+    duckdb.execute("INSERT INTO selected VALUES (NULL)")
+    duckdb.execute(f"COPY selected TO '{manifest}' (FORMAT PARQUET)")
+
+    with pytest.raises(ValueError, match=r"null episode_id"):
+        hflow.export_dataset_snapshot(
+            catalog.location,
+            tmp_path / "dataset-snapshot",
+            manifest=manifest,
+        )
+
+
+def test_parse_dataset_snapshot_destination_refuses_symlinked_format_marker(
+    tmp_path: Path,
+) -> None:
+    output_directory = tmp_path / "existing-snapshot"
+    output_directory.mkdir()
+    format_marker_target = tmp_path / "format.json"
+    format_marker_target.write_text("{}")
+    format_marker_path = output_directory / snapshot_module._FORMAT_MARKER_FILE_NAME
+    format_marker_path.symlink_to(format_marker_target)
+
+    with pytest.raises(
+        ValueError,
+        match=r"does not contain a regular format\.json",
+    ):
+        snapshot_module._parse_dataset_snapshot_destination(output_directory, overwrite=True)


### PR DESCRIPTION
## Pin tests for the snapshot export refusal guards (issue #276)

`src/hflow/snapshot.py` has three refusal guards in the export path that were not pinned by any test. On current `main`, replacing each `raise` with `pass` keeps the whole suite green. This change pins all three.

### What's covered

1. **`_parse_dataset_snapshot_destination` refuses a symlink as the export destination.** Called directly with both `overwrite=False` and `overwrite=True`. The issue calls this out specifically: the guard runs *before* `overwrite` is consulted, and a test that only exercised one branch would still pass if the check were moved below the overwrite branch.
2. **`export_dataset_snapshot` refuses a manifest whose `episode_id` column contains NULL.** Mirrors the structure of the existing `test_dataset_snapshot_rejects_manifest_episode_ids_absent_from_catalog`. Builds a parquet manifest with `INSERT INTO selected VALUES (NULL)`.
3. **`_parse_dataset_snapshot_destination` refuses a symlink at `format.json` inside an existing destination.** The issue asks me to consider whether this second symlink check ten lines below the first wants the same treatment. It does — the pattern is identical (symlink whose `is_file()` follows it to a real file would otherwise be indistinguishable from a regular marker file), so I added it. Both the destination-level and the format-marker-level symlink checks were written together and should be pinned together.

### User-visible outcome

Each guard now has a regression test that goes red the moment the `raise` is replaced with `pass`. A future refactor that drops or reorders any of them breaks the suite instead of silently shipping.

### Validation

```bash
uv run pytest tests/test_dataset_snapshot.py -q
# 12 passed
```

```bash
uv run ruff check tests/test_dataset_snapshot.py
# All checks passed!

uv run ruff format --check tests/test_dataset_snapshot.py
# 1 file already formatted
```

Full suite from the repo root (excluding the opt-in ffmpeg and storage suites that need `HFLOW_NETWORK_TESTS=1` / a writable object-store prefix):

```bash
uv run pytest --ignore=tests/test_ffmpeg.py -q
# 1146 passed, 6 skipped
```

### Sabotage proof (Definition of Done from #276)

Replacing each guard's `raise` with `pass` (then restoring the file):

| Guard disabled | Test that goes red |
| --- | --- |
| Destination symlink check (`is_symlink()` at line 486) | `test_parse_dataset_snapshot_destination_refuses_symlink_before_overwrite_check` |
| Null `episode_id` in manifest (line 145) | `test_dataset_snapshot_rejects_manifest_with_null_episode_id` |
| Format-marker symlink check (`is_symlink()` at line 500) | `test_parse_dataset_snapshot_destination_refuses_symlinked_format_marker` |

In each case the named test fails, and restoring the guard returns the file to green.

