### PR TITLE
fix: handle invalid compare inputs

### DIFF
--- a/examples/build_ai_evaluation/evaluate.py
+++ b/examples/build_ai_evaluation/evaluate.py
@@ -800,7 +800,13 @@ def run_evaluation(configuration: EvaluationConfiguration, *, download: bool) ->
 
 
 def compare_summaries(summary_paths: Sequence[Path]) -> None:
-    summaries = [json.loads(path.read_text()) for path in summary_paths]
+    summaries = []
+    for path in summary_paths:
+        content = path.read_text()
+        try:
+            summaries.append(json.loads(content))
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid JSON in {path}: {error}") from error
     print(
         "| run | dataset | source | hand n | 1+ hands | 2 hands | active n | "
         "active yes | hand agreement | active agreement |"
@@ -933,17 +939,17 @@ def _argument_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = _argument_parser()
     arguments = parser.parse_args()
-    match arguments.command:
-        case "run":
-            try:
+    try:
+        match arguments.command:
+            case "run":
                 configuration = _run_configuration_from_arguments(arguments)
                 run_evaluation(configuration, download=arguments.download)
-            except (FileNotFoundError, RuntimeError, ValueError) as error:
-                parser.error(str(error))
-        case "compare":
-            compare_summaries(arguments.summaries)
-        case unknown_command:
-            raise AssertionError(f"unhandled command: {unknown_command}")
+            case "compare":
+                compare_summaries(arguments.summaries)
+            case unknown_command:
+                raise AssertionError(f"unhandled command: {unknown_command}")
+    except (FileNotFoundError, ValueError, RuntimeError) as error:
+        parser.error(str(error))
 
 
 if __name__ == "__main__":

--- a/examples/build_ai_evaluation/evaluate.py
+++ b/examples/build_ai_evaluation/evaluate.py
@@ -932,7 +932,12 @@ def _argument_parser() -> argparse.ArgumentParser:
     )
 
     compare_parser = subparsers.add_parser("compare", help="compare completed run summaries")
-    compare_parser.add_argument("summaries", nargs="+", type=Path)
+    compare_parser.add_argument(
+        "summaries",
+        nargs="+",
+        type=Path,
+        help="paths to evaluation run summary JSON files to compare",
+    )
     return parser
 
 

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -18,6 +18,7 @@ from examples.build_ai_evaluation.evaluate import (
     _run_configuration_from_arguments,
     _sanitize_base_url,
     iter_evaluation_frames,
+    main,
     summarize_results,
 )
 from examples.build_ai_evaluation.judgment import (
@@ -312,3 +313,98 @@ def test_evaluation_reader_supports_both_published_parquet_schemas(
     assert frames[0].expected_hand_count == 2
     assert frames[0].expected_active_manipulation == expected_active_manipulation
     assert frames[0].image_data_url.startswith("data:image/png;base64,")
+
+
+def test_compare_missing_file_exits_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing_file = "/tmp/nope_file_does_not_exist.json"
+    monkeypatch.setattr(sys, "argv", ["evaluate.py", "compare", missing_file])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.err
+    assert missing_file in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_compare_malformed_json_exits_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("not json content")
+    monkeypatch.setattr(sys, "argv", ["evaluate.py", "compare", str(bad_json)])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "invalid JSON in" in captured.err
+    assert str(bad_json) in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_compare_success_exits_normally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    summary_data = {
+        "label": "run1",
+        "dataset_variant": "10k",
+        "sources": {
+            "egocentric": {
+                EvaluationTask.HAND_COUNT.value: {
+                    "valid_count": 10,
+                    "predicted_value_fractions": {"0": 0.1, "2": 0.8},
+                    "reference_value_fractions": {"2": 0.9},
+                    "agreement_fraction": 0.85,
+                },
+                EvaluationTask.ACTIVE_MANIPULATION.value: {
+                    "valid_count": 10,
+                    "predicted_value_fractions": {"yes": 0.9},
+                    "reference_value_fractions": {"yes": 0.95},
+                    "agreement_fraction": 0.9,
+                },
+            }
+        },
+    }
+    summary_file = tmp_path / "summary.json"
+    summary_file.write_text(json.dumps(summary_data))
+
+    monkeypatch.setattr(sys, "argv", ["evaluate.py", "compare", str(summary_file)])
+    main()
+
+    captured = capsys.readouterr()
+    assert "| run | dataset | source |" in captured.out
+    assert "| run1 | 10k | egocentric |" in captured.out
+
+
+def test_run_missing_file_exits_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing_file = "/tmp/nope.txt"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluate.py",
+            "run",
+            "--dataset",
+            "10k",
+            "--model",
+            "x",
+            "--base-url",
+            "http://127.0.0.1:1",
+            "--hand-count-prompt",
+            missing_file,
+            "--allow-missing-api-key",
+            "--limit",
+            "1",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.err
+    assert missing_file in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Summary

Fixes the `compare` command so missing or malformed summary files are reported as CLI errors instead of escaping as unhandled tracebacks.

## Why

The `compare` command previously allowed errors from missing or malformed summary files to escape as unhandled tracebacks.

The exception handling is intentionally placed around the match statement rather than inside the compare arm. This keeps the error handling at the CLI boundary and ensures that the same handling applies consistently to all current subcommands and future subcommands without duplicating the error handling logic.

## Validation

Ran all of the following validations successfully:

```bash
uv sync --locked --all-extras

Resolved 124 packages in 1ms
Uninstalled 61 packages in 142ms

uv run ruff check --fix

All checks passed!

uv run ruff format

195 files left unchanged

uv run ty check

All checks passed!

uv run pytest -q

1244 passed, 6 skipped in 88.32s (0:01:28)

uv run --locked --project examples/build_ai_evaluation pytest -q examples/build_ai_evaluation/tests

23 passed in 4.70s
```

Closes #260

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
