### PR TITLE
fix(lerobot): reject boolean vector dimensions

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -484,7 +484,12 @@ def _derive_numeric_schema(feature_name: str, feature_specification: dict) -> _N
             f"dtype={declared_dtype}, shape={declared_shape} "
             "(only float32 fixed-width numeric vectors are supported)"
         )
-    if len(declared_shape) != 1 or not isinstance(declared_shape[0], int) or declared_shape[0] < 1:
+    if (
+        len(declared_shape) != 1
+        or isinstance(declared_shape[0], bool)
+        or not isinstance(declared_shape[0], int)
+        or declared_shape[0] < 1
+    ):
         raise ValueError(
             f"unsupported feature {feature_name}: "
             f"dtype={declared_dtype}, shape={declared_shape} "

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -155,6 +155,46 @@ def test_derive_numeric_schema_rejects_unsupported() -> None:
         _DERIVE("observation.state", {"dtype": "float32", "shape": [2, 3]})
     with pytest.raises(ValueError, match="unsupported feature"):
         _DERIVE("observation.state", {"dtype": "float32", "shape": []})
+    for shape in ([True], [False]):
+        with pytest.raises(
+            ValueError,
+            match=rf"unsupported feature action: dtype=float32, shape=\[{shape[0]}\]",
+        ):
+            _DERIVE("action", {"dtype": "float32", "shape": shape})
+
+
+def test_import_rejects_required_boolean_dimension_without_dataset_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = tmp_path / "out"
+    dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
+    monkeypatch.setattr(
+        prep,
+        "_hf_repo_info",
+        lambda repo, revision: {"sha": "abc", "license": "apache-2.0"},
+    )
+    monkeypatch.setattr(
+        prep,
+        "_ensure_source_archive",
+        lambda source, cache_dir: {
+            "numeric_features": {
+                "action": {"dtype": "float32", "shape": [True]},
+                "observation.state": {"dtype": "float32", "shape": [6]},
+            },
+            "video_keys": [prep.DEFAULT_CAMERA_KEY],
+            "episodes": [],
+            "dataset": dataset_source,
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"unsupported feature action: dtype=float32, shape=\[True\]",
+    ):
+        prep.import_lerobot_dataset(dataset_repo="fake/repo", output_dir=output_dir)
+
+    assert not (output_dir / "landing").exists()
+    assert not (output_dir / "prepared-manifest.json").exists()
 
 
 def test_cdr_float32_array_n_byte_compatible() -> None:


### PR DESCRIPTION
Fixes #300.

Python treats `bool` as a subclass of `int`, so LeRobot metadata such as `shape: [true]` passed the integer-dimension check and became a one-dimensional numeric feature. This change rejects booleans explicitly while leaving valid integer dimensions alone.

The tests cover both `true` and `false` dimensions and check that importer validation stops before writing a landing dataset or prepared manifest.

Tested with:

- `uv run pytest -q tests/test_lerobot_converter.py`
- `uv run pytest -q` (1251 passed, 6 skipped)
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`