### PR TITLE
Transcode egocentric landing episodes to H.264 directly

### DIFF
--- a/examples/egocentric/README.md
+++ b/examples/egocentric/README.md
@@ -12,7 +12,9 @@ The source is one pinned, hash-verified shard of
 (Apache-2.0): genuine factory footage spanning navigation, machine
 interaction, material handling, component sorting, tray handling, and tool
 setup. From it, [`prepare.py`](./prepare.py) deterministically generates 96
-20-second, 640×360, 10 FPS input episodes:
+20-second, 640×360, 10 FPS input episodes. Each source excerpt is decoded once
+and transcoded directly from HEVC to in-band H.264
+`foxglove.CompressedVideo`; there is no intermediate per-frame JPEG stage:
 
 - 90 unmodified excerpts;
 - three with an injected three-second **camera blackout**
@@ -30,8 +32,8 @@ declared data you can edit (see [inject your own faults](#inject-your-own-faults
 - A Hugging Face account that has accepted the dataset's access terms, and the
   `hf` CLI, authenticated: `uv tool install -U huggingface_hub` then
   `hf auth login`.
-- Network access and disk: a ~1 GB download, about 2.5 GB total once the
-  sources are extracted and the 96 episodes (~640 MB) are written.
+- Network access and disk: a ~1 GB download plus space for the extracted
+  sources and 96 H.264 landing episodes.
 - Docker with Compose v2 (only for the [Airflow path](#run-it-under-airflow)).
 
 All media stays under the gitignored `data/` directory; the repository tracks
@@ -45,7 +47,12 @@ uv run python examples/egocentric/prepare.py
 ```
 
 The script downloads the pinned shard once, verifies every hash, extracts the
-11 source videos, and writes the episodes:
+11 source videos, and writes the episodes. Its one ffmpeg invocation per episode
+applies `fps`, `scale`, and `pad`, injects blackouts with `drawbox` or freezes
+with `freezeframes`, and encodes Annex B H.264 with one AUD-delimited access
+unit per message plus SPS/PPS on each keyframe. Because that already meets the
+canonical video contract, HFlow's transform passes the encoded media bytes
+through instead of re-encoding them:
 
 ```text
 data/egocentric/

--- a/examples/egocentric/prepare.py
+++ b/examples/egocentric/prepare.py
@@ -10,6 +10,7 @@ any pipeline result.
 import argparse
 import hashlib
 import json
+import math
 import shutil
 import subprocess
 import tarfile
@@ -18,7 +19,13 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import hflow
+from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
+from mcap.writer import Writer
+from mcap_protobuf.schema import build_file_descriptor_set
+
+from hflow.ffmpeg import ffmpeg_path, ffmpeg_version
+from hflow.format import EPISODE_KEY_ROBOT_SOFTWARE_VERSION, METADATA_RECORD_EPISODE
+from hflow.video import AccessUnit, split_annex_b_stream
 
 DEFAULT_MANIFEST_PATH = Path(__file__).with_name("manifest.json")
 DEFAULT_SOURCE_ROOT = Path("data/egocentric")
@@ -369,35 +376,185 @@ def _extract_source_videos(
     return source_paths
 
 
-def _video_episode_spec(
+def _fault_frame_range(episode: PlannedEpisode) -> tuple[int, int] | None:
+    if episode.fault_segment_s is None:
+        return None
+    fault_start_s, fault_end_s = episode.fault_segment_s
+    first_frame = math.ceil(fault_start_s * EPISODE_IMAGE_HZ)
+    last_frame = math.ceil(fault_end_s * EPISODE_IMAGE_HZ) - 1
+    return first_frame, last_frame
+
+
+def _video_filter_arguments(episode: PlannedEpisode) -> list[str]:
+    base_filter = (
+        f"fps={EPISODE_IMAGE_HZ:g},"
+        f"scale={EPISODE_IMAGE_WIDTH}:{EPISODE_IMAGE_HEIGHT}:"
+        "force_original_aspect_ratio=decrease:flags=lanczos,"
+        f"pad={EPISODE_IMAGE_WIDTH}:{EPISODE_IMAGE_HEIGHT}:(ow-iw)/2:(oh-ih)/2:black"
+    )
+    fault_frame_range = _fault_frame_range(episode)
+    if episode.fault is FaultKind.NONE:
+        return ["-vf", base_filter]
+    if fault_frame_range is None:
+        raise ValueError(
+            f"episode {episode.episode_id} declares {episode.fault.value} without a segment"
+        )
+
+    first_fault_frame, last_fault_frame = fault_frame_range
+    if episode.fault is FaultKind.BLACKOUT:
+        # drawbox runs before H.264 encoding, so the source is decoded and encoded
+        # exactly once while every selected pixel in the segment becomes black.
+        blackout_filter = (
+            "drawbox=x=0:y=0:w=iw:h=ih:color=black:t=fill:"
+            f"enable=between(n\\,{first_fault_frame}\\,{last_fault_frame})"
+        )
+        return ["-vf", f"{base_filter},{blackout_filter}"]
+    if episode.fault is FaultKind.FREEZE:
+        # freezeframes takes a main and replacement input. Splitting the filtered
+        # source lets it replace the interval with its first frame in the same
+        # decode/filter/encode invocation.
+        filter_graph = (
+            f"[0:v]{base_filter},split=2[main][replacement];"
+            "[main][replacement]freezeframes="
+            f"first={first_fault_frame}:last={last_fault_frame}:replace={first_fault_frame}[video]"
+        )
+        return ["-filter_complex", filter_graph, "-map", "[video]"]
+    raise AssertionError(f"unhandled fault kind {episode.fault!r}")
+
+
+def _transcode_episode_to_h264(
+    source_video_path: Path, episode: PlannedEpisode
+) -> list[AccessUnit]:
+    frame_count = round(episode.duration_s * EPISODE_IMAGE_HZ)
+    keyframe_interval = max(1, round(EPISODE_IMAGE_HZ))
+    x264_parameters = (
+        f"keyint={keyframe_interval}:min-keyint={keyframe_interval}:"
+        "scenecut=0:bframes=0:repeat-headers=1:aud=1"
+    )
+    command = [
+        str(ffmpeg_path()),
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{episode.source_start_s:g}",
+        "-i",
+        str(source_video_path),
+        *_video_filter_arguments(episode),
+        "-an",
+        "-frames:v",
+        str(frame_count),
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "23",
+        "-pix_fmt",
+        "yuv420p",
+        "-x264-params",
+        x264_parameters,
+        "-fps_mode",
+        "passthrough",
+        "-f",
+        "h264",
+        "pipe:1",
+    ]
+    completed = subprocess.run(command, capture_output=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed ({' '.join(command)}): {completed.stderr.decode(errors='replace')}"
+        )
+    try:
+        access_units = split_annex_b_stream(completed.stdout)
+    except ValueError as error:
+        raise RuntimeError(
+            f"ffmpeg produced invalid H.264 for {episode.episode_id}: {error}"
+        ) from error
+    if len(access_units) != frame_count:
+        raise RuntimeError(
+            f"expected {frame_count} frames from {source_video_path}, got {len(access_units)}; "
+            "the requested excerpt may extend past the source video"
+        )
+    for frame_index, access_unit in enumerate(access_units):
+        keyframe_expected = frame_index % keyframe_interval == 0
+        if access_unit.is_keyframe != keyframe_expected:
+            raise RuntimeError(
+                f"frame {frame_index} from {source_video_path} has unexpected keyframe state"
+            )
+        if access_unit.is_keyframe and not access_unit.has_parameter_sets:
+            raise RuntimeError(f"keyframe {frame_index} from {source_video_path} lacks SPS/PPS")
+    return access_units
+
+
+def _episode_metadata(manifest: CorpusManifest, episode: PlannedEpisode) -> dict[str, str]:
+    return {
+        "task": episode.task,
+        "operator": "factory_051_worker_001",
+        EPISODE_KEY_ROBOT_SOFTWARE_VERSION: "build-ai-gen-1",
+        "source_dataset": manifest.dataset.repo_id,
+        "source_revision": manifest.dataset.revision,
+        "source_member": episode.source_member,
+        "source_start_s": f"{episode.source_start_s:g}",
+        "source_license": manifest.dataset.license,
+        "injected_fault": episode.fault.value,
+        "task_completion": "unlabeled",
+    }
+
+
+def _write_video_episode(
+    source_video_path: Path,
+    output_path: Path,
     manifest: CorpusManifest,
     episode: PlannedEpisode,
     episode_index: int,
-) -> hflow.testing.VideoEpisodeSpec:
-    return hflow.testing.VideoEpisodeSpec(
-        source_start_s=episode.source_start_s,
-        duration_s=episode.duration_s,
-        image_hz=EPISODE_IMAGE_HZ,
-        image_width=EPISODE_IMAGE_WIDTH,
-        image_height=EPISODE_IMAGE_HEIGHT,
-        camera_name="head_camera",
-        black_segment=(episode.fault_segment_s if episode.fault is FaultKind.BLACKOUT else None),
-        freeze_segment=episode.fault_segment_s if episode.fault is FaultKind.FREEZE else None,
-        start_time_ns=EPISODE_START_TIME_NS + episode_index * 60_000_000_000,
-        task=episode.task,
-        operator="factory_051_worker_001",
-        success=None,
-        robot_software_version="build-ai-gen-1",
-        metadata=(
-            ("source_dataset", manifest.dataset.repo_id),
-            ("source_revision", manifest.dataset.revision),
-            ("source_member", episode.source_member),
-            ("source_start_s", f"{episode.source_start_s:g}"),
-            ("source_license", manifest.dataset.license),
-            ("injected_fault", episode.fault.value),
-            ("task_completion", "unlabeled"),
-        ),
-    )
+) -> None:
+    access_units = _transcode_episode_to_h264(source_video_path, episode)
+    episode_start_time_ns = EPISODE_START_TIME_NS + episode_index * 60_000_000_000
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as output_stream:
+        writer = Writer(output_stream)
+        writer.start(profile="", library="hflow egocentric source adapter")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        channel_id = writer.register_channel(
+            topic="/head_camera/compressed",
+            message_encoding="protobuf",
+            schema_id=schema_id,
+        )
+        writer.add_metadata(name=METADATA_RECORD_EPISODE, data=_episode_metadata(manifest, episode))
+        writer.add_metadata(
+            name="source-provenance/v1",
+            data={
+                "converter_version": "1",
+                "ffmpeg_version": ffmpeg_version(),
+                "source_uri": (
+                    f"hf://datasets/{manifest.dataset.repo_id}@{manifest.dataset.revision}/"
+                    f"{episode.source_member}"
+                ),
+            },
+        )
+        for frame_index, access_unit in enumerate(access_units):
+            log_time_ns = episode_start_time_ns + round(
+                frame_index * 1_000_000_000 / EPISODE_IMAGE_HZ
+            )
+            message = CompressedVideo()
+            message.timestamp.FromNanoseconds(log_time_ns)
+            message.frame_id = "head_camera"
+            message.data = access_unit.data
+            message.format = "h264"
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=log_time_ns,
+                data=message.SerializeToString(),
+                publish_time=log_time_ns,
+                sequence=frame_index,
+            )
+        writer.finish()
 
 
 def _write_prepared_manifest(
@@ -449,10 +606,12 @@ def prepare_corpus(manifest_path: Path, source_root: Path, output_root: Path) ->
     prepared_episode_paths: list[Path] = []
     for episode_index, episode in enumerate(manifest.episodes):
         output_path = landing_root / f"{episode.episode_id}.mcap"
-        hflow.testing.write_video_episode(
+        _write_video_episode(
             source_paths[episode.source_member],
             output_path,
-            _video_episode_spec(manifest, episode, episode_index),
+            manifest,
+            episode,
+            episode_index,
         )
         prepared_episode_paths.append(output_path)
         prepared_count = episode_index + 1

--- a/tests/test_egocentric_prepare.py
+++ b/tests/test_egocentric_prepare.py
@@ -1,0 +1,147 @@
+"""The egocentric converter lands H.264 directly and preserves its planted faults."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
+from mcap.reader import make_reader
+
+from hflow import Episode, TransformConfig, write_canonical_episode
+from hflow.checks import camera_frame_stats
+from hflow.ffmpeg import ffmpeg_path
+
+
+def _load_prepare_module() -> ModuleType:
+    module_path = Path(__file__).parents[1] / "examples" / "egocentric" / "prepare.py"
+    module_spec = importlib.util.spec_from_file_location("egocentric_prepare", module_path)
+    if module_spec is None or module_spec.loader is None:
+        raise RuntimeError(f"could not load {module_path}")
+    module = importlib.util.module_from_spec(module_spec)
+    sys.modules[module_spec.name] = module
+    module_spec.loader.exec_module(module)
+    return module
+
+
+PREPARE = _load_prepare_module()
+
+
+@pytest.fixture(scope="module")
+def moving_hevc_video(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    output_path = tmp_path_factory.mktemp("egocentric-source") / "source.mp4"
+    completed = subprocess.run(
+        [
+            str(ffmpeg_path()),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x90:rate=10:duration=24",
+            "-c:v",
+            "libx265",
+            "-pix_fmt",
+            "yuv420p",
+            str(output_path),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.decode(errors="replace"))
+    return output_path
+
+
+def _manifest(episode: object) -> object:
+    dataset = PREPARE.DatasetSource(
+        repo_id="example/corpus", revision="abc123", license="apache-2.0"
+    )
+    source = PREPARE.SourceVideo(
+        member="source.mp4", sha256="unused", duration_s=24.0, task="factory_task"
+    )
+    episode_plan = PREPARE.EpisodePlan(
+        total_episodes=1,
+        duration_s=20.0,
+        first_source_start_s=1.0,
+        source_stride_s=0.0,
+        faults=(),
+    )
+    return PREPARE.CorpusManifest(
+        schema_version=2,
+        dataset=dataset,
+        archive=PREPARE.SourceArchive(path="source.tar", sha256="unused"),
+        sources=(source,),
+        episode_plan=episode_plan,
+        episodes=(episode,),
+    )
+
+
+def _video_payloads(path: Path) -> tuple[list[str], list[bytes]]:
+    schema_names: list[str] = []
+    payloads: list[bytes] = []
+    with path.open("rb") as stream:
+        for schema, _channel, message in make_reader(stream).iter_messages():
+            assert schema is not None
+            schema_names.append(schema.name)
+            decoded = CompressedVideo.FromString(message.data)
+            assert decoded.format == "h264"
+            payloads.append(bytes(decoded.data))
+    return schema_names, payloads
+
+
+@pytest.mark.parametrize(
+    ("fault", "fault_segment_s", "expected_black_frame_pct"),
+    [
+        ("blackout", (7.0, 10.0), 15.0),
+        ("freeze", (7.0, 11.0), 0.0),
+    ],
+)
+def test_egocentric_h264_lands_once_and_faults_survive_transform(
+    tmp_path: Path,
+    moving_hevc_video: Path,
+    fault: str,
+    fault_segment_s: tuple[float, float],
+    expected_black_frame_pct: float,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PREPARE, "EPISODE_IMAGE_WIDTH", 160)
+    monkeypatch.setattr(PREPARE, "EPISODE_IMAGE_HEIGHT", 90)
+    fault_kind = PREPARE.FaultKind(fault)
+    episode = PREPARE.PlannedEpisode(
+        episode_id=f"episode_{fault}",
+        source_member="source.mp4",
+        source_start_s=1.0,
+        duration_s=20.0,
+        task="factory_task",
+        fault=fault_kind,
+        fault_segment_s=fault_segment_s,
+    )
+    landing_path = tmp_path / f"{fault}.mcap"
+    canonical_path = tmp_path / f"{fault}.canonical.mcap"
+
+    PREPARE._write_video_episode(moving_hevc_video, landing_path, _manifest(episode), episode, 0)
+    write_canonical_episode(landing_path, canonical_path, TransformConfig())
+
+    landing_schemas, landing_payloads = _video_payloads(landing_path)
+    canonical_schemas, canonical_payloads = _video_payloads(canonical_path)
+    assert set(landing_schemas) == {"foxglove.CompressedVideo"}
+    assert "sensor_msgs/msg/CompressedImage" not in landing_schemas
+    assert set(canonical_schemas) == {"foxglove.CompressedVideo"}
+    assert canonical_payloads == landing_payloads
+
+    with Episode(canonical_path) as canonical_episode:
+        evidence = camera_frame_stats(canonical_episode)
+    camera_topic = "/head_camera/compressed"
+    assert evidence.measurements[f"{camera_topic}/black_frame_pct"] == pytest.approx(
+        expected_black_frame_pct, abs=0.6
+    )
+    freeze_total_seconds = evidence.measurements[f"{camera_topic}/freeze_total_s"]
+    decoded_frame_count = evidence.measurements[f"{camera_topic}/decoded_frame_count"]
+    assert isinstance(freeze_total_seconds, float)
+    assert freeze_total_seconds >= 2.0
+    assert decoded_frame_count == 200


### PR DESCRIPTION
Closes #291

## What and why

`examples/egocentric` landed its episodes through `hflow.testing.write_video_episode`, which decodes each source and re-encodes every frame as JPEG; the canonical transform then encoded those JPEGs into in-band H.264. For the Egocentric corpora, whose clips are H.265, the media went **HEVC → JPEG → H.264**: two lossy steps where one would do, and a landing file ~2.3x the size the canonical stage actually needs (#287's baseline).

`prepare.py` now transcodes each excerpt **once, directly to Annex B H.264**, and the canonical transform passes the media bytes through unmodified:

- One ffmpeg invocation per episode applies `fps`/`scale`/`pad`, plants faults in the same graph, and encodes `libx264 -preset medium -crf 23` with `-x264-params keyint=<fps>:min-keyint=<fps>:scenecut=0:bframes=0:repeat-headers=1:aud=1` — so every message is one AUD-delimited access unit and every keyframe carries SPS/PPS, which is exactly what `transform.py` needs to pass media through.
- The stream is cut with `hflow.video.split_annex_b_stream` and written as `foxglove.CompressedVideo` (`format="h264"`) on `/head_camera/compressed`.
- The example also now records an episode metadata record plus a `source-provenance/v1` record (converter version, ffmpeg version, `hf://` source URI) that the JPEG fixture path never carried.
- `hflow/testing.py` is untouched, and `examples/egocentric` no longer imports `hflow.testing`.

## Fault injection

Substituting frames after decoding is no longer possible without the JPEG step, so both faults are planted **inside the single transcode**:

- **Blackout**: `drawbox=x=0:y=0:w=iw:h=ih:color=black:t=fill:enable=between(n\,<first>\,<last>)` after the base `fps,scale,pad` chain.
- **Freeze**: the filtered source is `split=2` into a main and a replacement branch, and `freezeframes=first=<first>:last=<last>:replace=<first>` swaps the interval for its own first frame within the same decode/filter/encode invocation.

Both still land in `camera_frame_stats` with the same shape of result (black-frame percentage over the blackout window, freeze duration over the freeze window), verified by test.

## Evidence

`tests/test_egocentric_prepare.py` builds a moving HEVC source, lands it through the new path, and asserts that:

- the landing file carries only `foxglove.CompressedVideo`/`h264` (no `sensor_msgs/msg/CompressedImage`);
- after `write_canonical_episode`, the canonical payloads are **byte-identical** to the landing payloads — the canonical media bytes are the bytes the example wrote;
- `camera_frame_stats` still trips: blackout measures ~15% black frames (3 s of 20 s at 10 FPS) and freeze measures ≥ 2 s of freeze, with the expected decoded frame count.

```
uv run pytest -q tests/test_egocentric_prepare.py
2 passed in 1.20s
```

Landing size before/after, measured with the same method #287 used (profile-matched synthetic media at the Egocentric-10K profile, 1920x1080, 30 fps, 30 s HEVC source, same ffmpeg build for both paths):

| Step | Bytes |
| --- | ---: |
| Source HEVC | 18,163,522 |
| BEFORE landing (JPEG fixture) | 53,170,623 |
| BEFORE canonical (H.264 re-encode) | 22,254,824 |
| AFTER landing (direct H.264) | 19,619,759 |
| AFTER canonical (passthrough) | 19,621,030 |

The landing file drops **63%** and is now smaller than the canonical stage's own previous output; the canonical pass-through adds only MCAP framing (~1 KB).

## Real-corpus run

Not run: `builddotai/Egocentric-10K` is gated and the account used for this PR has not been granted access (`GatedRepo` 403 on the resolve endpoint; metadata is visible, files are not). The end-to-end real-shard run in the issue's validation list needs someone with accepted terms — happy to run it once access lands, or a maintainer can run `uv run python examples/egocentric/prepare.py` and paste the per-episode sizes.

## Validation

```
uv sync --locked --all-extras
uv run ruff check --fix        # All checks passed!
uv run ruff format             # 198 files left unchanged
uv run ty check                # All checks passed!
uv run pytest -q               # 1021 passed, 11 skipped (split across invocations; runtime integration skips without Docker)
```

`lychee` is not installed locally, so the Markdown link check did not run; the only Markdown change is `examples/egocentric/README.md`, whose links are unchanged relative paths.
