### PR TITLE
fix: wrap Airflow response decode errors

### DIFF
--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -60,6 +60,11 @@ class BearerToken:
 AirflowAuth = PasswordCredentials | BearerToken
 
 
+def _body_excerpt(body: str) -> str:
+    """Collapse a response body to the bounded excerpt exposed to callers."""
+    return " ".join(body.split())[:200]
+
+
 @dataclass(frozen=True)
 class AirflowHealth:
     """Parsed ``/api/v2/monitor/health`` body."""
@@ -135,12 +140,12 @@ class AirflowClient:
             request.add_header("Authorization", f"Bearer {bearer_token}")
         try:
             with urllib.request.urlopen(request, timeout=self._request_timeout_s) as response:
-                response_text = response.read().decode()
+                response_body = response.read()
         except urllib.error.HTTPError as error:
             error_body = error.read().decode(errors="replace")
             # Airflow puts the useful part ("detail") in the body; surface a
             # truncated copy so failures are diagnosable from the message.
-            body_excerpt = " ".join(error_body.split())[:200]
+            body_excerpt = _body_excerpt(error_body)
             raise AirflowClientError(
                 f"{method} {url} failed with HTTP {error.code}"
                 + (f": {body_excerpt}" if body_excerpt else ""),
@@ -155,9 +160,27 @@ class AirflowClient:
             # published port before the api-server listens) must also become
             # AirflowClientError, or wait_until_healthy cannot retry them.
             raise AirflowClientError(f"{method} {url} failed: {error!r}") from error
+        try:
+            response_text = response_body.decode("utf-8")
+        except UnicodeDecodeError as error:
+            response_text = response_body.decode("utf-8", errors="replace")
+            body_excerpt = _body_excerpt(response_text)
+            raise AirflowClientError(
+                f"{method} {url} returned invalid UTF-8"
+                + (f": {body_excerpt}" if body_excerpt else ""),
+                body=response_text,
+            ) from error
         if not response_text:
             return {}
-        parsed = json.loads(response_text)
+        try:
+            parsed = json.loads(response_text)
+        except json.JSONDecodeError as error:
+            body_excerpt = _body_excerpt(response_text)
+            raise AirflowClientError(
+                f"{method} {url} returned malformed JSON"
+                + (f": {body_excerpt}" if body_excerpt else ""),
+                body=response_text,
+            ) from error
         if not isinstance(parsed, dict):
             raise AirflowClientError(f"{method} {url} returned non-object JSON: {parsed!r}")
         return parsed
@@ -192,7 +215,7 @@ class AirflowClient:
                 # A pre-issued token cannot be refreshed here; retrying with
                 # the same bytes would just 401 again. Keep the server's own
                 # explanation in the message -- it is what the CLI prints.
-                body_excerpt = " ".join(error.body.split())[:200]
+                body_excerpt = _body_excerpt(error.body)
                 raise AirflowClientError(
                     f"{method} {url} rejected the pre-issued bearer token (HTTP 401): "
                     "the token is expired or invalid -- obtain a fresh one"

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -27,6 +27,7 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
     requests_seen: ClassVar[list[tuple[str, str, dict[str, Any] | None, str | None]]] = []
     healthy: ClassVar[bool] = True
     expire_first_token: ClassVar[bool] = False
+    health_response_body: ClassVar[bytes | None] = None
 
     def _read_json(self) -> dict[str, Any] | None:
         length = int(self.headers.get("Content-Length", "0"))
@@ -35,7 +36,9 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
         return json.loads(self.rfile.read(length))
 
     def _respond(self, status: int, payload: dict[str, Any]) -> None:
-        body = json.dumps(payload).encode()
+        self._respond_bytes(status, json.dumps(payload).encode())
+
+    def _respond_bytes(self, status: int, body: bytes) -> None:
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -105,6 +108,10 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
             self._respond(200, {"dag_id": requested_dag_id})
             return
         if self.path == "/api/v2/monitor/health":
+            health_response_body = type(self).health_response_body
+            if health_response_body is not None:
+                self._respond_bytes(200, health_response_body)
+                return
             status = "healthy" if type(self).healthy else "unhealthy"
             self._respond(
                 200,  # always 200: the body is the signal
@@ -135,6 +142,7 @@ def _reset_stub_airflow_state() -> None:
     _StubAirflowHandler.requests_seen = []
     _StubAirflowHandler.healthy = True
     _StubAirflowHandler.expire_first_token = False
+    _StubAirflowHandler.health_response_body = None
 
 
 @pytest.fixture(scope="module")
@@ -257,6 +265,56 @@ def test_health_parses_body_not_status(stub_server: str) -> None:
     unhealthy = client.health()  # still HTTP 200: the body is the signal
     assert not unhealthy.healthy
     assert "scheduler=unhealthy" in unhealthy.summary()
+
+
+def test_malformed_success_response_raises_typed_client_error(stub_server: str) -> None:
+    _StubAirflowHandler.health_response_body = (
+        b"<html>\n  <body>proxy returned an invalid API response "
+        + b"x" * 250
+        + b" end-of-response</body>\n</html>"
+    )
+    url = f"{stub_server}/api/v2/monitor/health"
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(AirflowClientError) as error_info:
+        client.health()
+
+    message = str(error_info.value)
+    assert message.startswith(f"GET {url} returned malformed JSON: <html> <body>")
+    assert "proxy returned an invalid API response" in message
+    assert "end-of-response" not in message
+    assert "\n" not in message
+
+
+def test_invalid_utf8_success_response_raises_typed_client_error(stub_server: str) -> None:
+    _StubAirflowHandler.health_response_body = (
+        b'{"detail":"upstream returned invalid bytes \xff' + b"x" * 250 + b'end-of-response"}'
+    )
+    url = f"{stub_server}/api/v2/monitor/health"
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(AirflowClientError) as error_info:
+        client.health()
+
+    message = str(error_info.value)
+    assert message.startswith(f"GET {url} returned invalid UTF-8: ")
+    assert "upstream returned invalid bytes" in message
+    assert "end-of-response" not in message
+
+
+def test_empty_success_response_still_returns_an_empty_object(stub_server: str) -> None:
+    _StubAirflowHandler.health_response_body = b""
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    assert client.health().components == {}
+
+
+def test_non_object_success_response_is_still_refused(stub_server: str) -> None:
+    _StubAirflowHandler.health_response_body = b'["healthy"]'
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(AirflowClientError, match="returned non-object JSON"):
+        client.health()
 
 
 def test_bearer_token_auth_never_calls_the_token_endpoint(stub_server: str) -> None:


### PR DESCRIPTION
## Summary

`AirflowClient` currently converts HTTP and connection failures into
`AirflowClientError`, but successful HTTP responses can still leak raw
`UnicodeDecodeError` or `JSONDecodeError` exceptions when their bodies contain
invalid UTF-8 or malformed JSON.

This change keeps those failures inside the client's typed error boundary:

- convert invalid UTF-8 in HTTP 2xx responses into `AirflowClientError`
- convert malformed JSON in HTTP 2xx responses into `AirflowClientError`
- include the HTTP method, URL, and a bounded one-line response excerpt
- preserve the existing behavior for empty bodies, valid JSON objects,
  non-object JSON, HTTP status errors, connection failures, and bearer tokens

This prevents callers such as `hflow status` from exposing internal decoder
tracebacks when Airflow or an intermediate proxy returns a malformed response.

## Regression coverage

The local Airflow stub server can now return arbitrary successful response
bytes. The new outcome-focused tests exercise the public client over HTTP and
verify that:

- malformed JSON returned with HTTP 200 raises `AirflowClientError`
- invalid UTF-8 returned with HTTP 200 raises `AirflowClientError`
- error messages contain the HTTP method, URL, and a bounded response excerpt
- empty successful responses still behave as an empty JSON object
- the existing non-object JSON refusal remains unchanged

## Validation

- `UV_OFFLINE=1 uv run --locked ruff check --fix`
  - passed
- `UV_OFFLINE=1 uv run --locked ruff format`
  - passed
- `UV_OFFLINE=1 uv run --locked ty check`
  - passed
- `UV_OFFLINE=1 uv run --locked pytest -q tests/test_runtime_client.py`
  - 24 passed
- `UV_OFFLINE=1 uv run --locked pytest -q`
  - 1255 passed, 6 skipped

The Docker integration gate was not run because Docker is unavailable in the
current environment:

`HFLOW_DOCKER_TESTS=1 uv run pytest tests/test_runtime_integration.py -q`

## Documentation and versioning

No documentation update is needed because this normalizes the existing client
error boundary without introducing a new API, flag, format, or operational
requirement.

`TRANSFORM_BEHAVIOR_VERSION` is unchanged because this change does not alter
episode processing or canonical output bytes.

No runtime dependency was added.

Closes #295