### PR TITLE
fix: accept NumPy integer frame indices

### DIFF
--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -613,7 +613,7 @@ class Episode:
         self,
         camera: str | None = None,
         *,
-        frame_indices: Sequence[int],
+        frame_indices: Sequence[int | np.integer[Any]],
     ) -> list[ExtractedFrame]:
         """Extract JPEGs at exact, ascending source-message frame indices.
 

--- a/src/hflow/episode.py
+++ b/src/hflow/episode.py
@@ -623,7 +623,10 @@ class Episode:
         unambiguous one-to-one order.
         """
 
-        selected_frame_indices = list(frame_indices)
+        selected_frame_indices = [
+            frame_index.item() if isinstance(frame_index, np.generic) else frame_index
+            for frame_index in frame_indices
+        ]
         if any(isinstance(frame_index, bool) for frame_index in selected_frame_indices):
             raise ValueError("frame indices must be integers, not booleans")
         if any(not isinstance(frame_index, int) for frame_index in selected_frame_indices):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,7 +2,7 @@
 infrastructure. Mirrors the README design-target example."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -177,7 +177,25 @@ def test_canonical_episode_extracts_exact_source_frame_indices(
             frame_indices=selected_frame_indices,
         )
 
+        numpy_frame_indices = [
+            cast(int, np.int32(0)),
+            cast(int, np.int64(1)),
+            cast(int, np.uint32(2)),
+            cast(int, np.uint64(7)),
+            cast(int, np.int64(8)),
+            cast(int, np.uint32(29)),
+        ]
+        numpy_frames = episode.frames_at_indices(
+            camera_topic,
+            frame_indices=numpy_frame_indices,
+        )
+
         assert [frame.log_time_ns for frame in selected_frames] == expected_log_times.tolist()
+        assert [frame.log_time_ns for frame in numpy_frames] == expected_log_times.tolist()
+        assert [frame.path.read_bytes() for frame in numpy_frames] == [
+            frame.path.read_bytes() for frame in selected_frames
+        ]
+        assert numpy_frames == selected_frames
         assert all(frame.path.read_bytes()[:2] == b"\xff\xd8" for frame in selected_frames)
         assert (
             episode.frames_at_indices(

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,7 +2,7 @@
 infrastructure. Mirrors the README design-target example."""
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pytest
@@ -178,12 +178,12 @@ def test_canonical_episode_extracts_exact_source_frame_indices(
         )
 
         numpy_frame_indices = [
-            cast(int, np.int32(0)),
-            cast(int, np.int64(1)),
-            cast(int, np.uint32(2)),
-            cast(int, np.uint64(7)),
-            cast(int, np.int64(8)),
-            cast(int, np.uint32(29)),
+            np.int32(0),
+            np.int64(1),
+            np.uint32(2),
+            np.uint64(7),
+            np.int64(8),
+            np.uint32(29),
         ]
         numpy_frames = episode.frames_at_indices(
             camera_topic,
@@ -204,6 +204,24 @@ def test_canonical_episode_extracts_exact_source_frame_indices(
             )
             == selected_frames
         )
+
+
+@pytest.mark.parametrize(
+    "invalid_frame_indices",
+    [[True], [np.bool_(True)], [3.0], [np.float64(3.0)]],
+)
+def test_canonical_episode_rejects_non_integer_frame_indices(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+    invalid_frame_indices: list[Any],
+) -> None:
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        camera_topic = next(topic for topic in episode.cameras if "overhead_cam" in topic)
+        with pytest.raises(ValueError):
+            episode.frames_at_indices(
+                camera_topic,
+                frame_indices=invalid_frame_indices,
+            )
 
 
 def test_arrow_export(report_and_app: tuple[hflow.TestReport, hflow.App]) -> None:


### PR DESCRIPTION
## Summary

* Normalize NumPy integer scalars before validating frame indices.
* Preserve existing boolean, ordering, bounds, and indexing behavior.
* Extend the exact-frame end-to-end test to cover signed and unsigned NumPy integer types.

Fixes #308.

## Validation

* `uv run ruff check --fix`
* `uv run ruff format`
* `uv run ty check`
* `uv run pytest -q tests/test_end_to_end.py::test_canonical_episode_extracts_exact_source_frame_indices`
* `uv run pytest -q tests/test_end_to_end.py` — 16 passed
* `uv run pytest -q` — 1251 passed, 6 skipped
