### PR TITLE
fix(catalog-ui): reject invalid numeric settings

### DIFF
--- a/src/hflow/catalog_ui.py
+++ b/src/hflow/catalog_ui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 import webbrowser
 from dataclasses import dataclass
@@ -32,10 +33,26 @@ class CatalogUiSettings:
     catalog_poll_interval_seconds: float = DEFAULT_CATALOG_POLL_INTERVAL_SECONDS
 
     def __post_init__(self) -> None:
+        if isinstance(self.port, bool) or not isinstance(self.port, int):
+            raise ValueError(f"port must be an int, got {type(self.port).__name__}")
         if not 1 <= self.port <= 65535:
             raise ValueError("port must be between 1 and 65535")
-        if self.catalog_poll_interval_seconds <= 0:
-            raise ValueError("catalog poll interval must be greater than zero")
+
+        if isinstance(self.catalog_poll_interval_seconds, bool) or not isinstance(
+            self.catalog_poll_interval_seconds, int | float
+        ):
+            raise ValueError(
+                "catalog_poll_interval_seconds must be an int or float, got "
+                f"{type(self.catalog_poll_interval_seconds).__name__}"
+            )
+        if (
+            not math.isfinite(self.catalog_poll_interval_seconds)
+            or self.catalog_poll_interval_seconds <= 0
+        ):
+            raise ValueError(
+                "catalog_poll_interval_seconds must be positive and finite, got "
+                f"{self.catalog_poll_interval_seconds}"
+            )
 
 
 def _raise_if_loopback_port_is_unavailable(port: int) -> None:

--- a/tests/test_catalog_ui.py
+++ b/tests/test_catalog_ui.py
@@ -1,5 +1,7 @@
 """The local DuckDB catalog browser lifecycle."""
 
+from dataclasses import replace
+from enum import IntEnum
 from pathlib import Path
 from socket import AF_INET, SOCK_STREAM, socket
 from threading import Event, Thread
@@ -116,8 +118,6 @@ def test_catalog_ui_refuses_an_invalid_port(tmp_path: Path, port: int) -> None:
 def test_catalog_ui_refuses_a_port_of_the_wrong_type(
     tmp_path: Path, port: object, type_name: str
 ) -> None:
-    from dataclasses import replace
-
     settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog")
     with pytest.raises(ValueError, match=f"port must be an int, got {type_name}"):
         replace(settings, port=port)
@@ -131,8 +131,6 @@ def test_catalog_ui_accepts_port_boundaries(tmp_path: Path, port: int) -> None:
 
 
 def test_catalog_ui_accepts_an_int_enum_port(tmp_path: Path) -> None:
-    from enum import IntEnum
-
     class Port(IntEnum):
         CATALOG_UI = 4213
 
@@ -148,8 +146,6 @@ def test_catalog_ui_accepts_an_int_enum_port(tmp_path: Path) -> None:
 def test_catalog_ui_refuses_a_poll_interval_of_the_wrong_type(
     tmp_path: Path, poll_interval: object, type_name: str
 ) -> None:
-    from dataclasses import replace
-
     settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog")
     with pytest.raises(
         ValueError,

--- a/tests/test_catalog_ui.py
+++ b/tests/test_catalog_ui.py
@@ -109,6 +109,84 @@ def test_catalog_ui_refuses_an_invalid_port(tmp_path: Path, port: int) -> None:
         catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog", port=port)
 
 
+@pytest.mark.parametrize(
+    ("port", "type_name"),
+    [(True, "bool"), (4213.0, "float"), ("4213", "str")],
+)
+def test_catalog_ui_refuses_a_port_of_the_wrong_type(
+    tmp_path: Path, port: object, type_name: str
+) -> None:
+    from dataclasses import replace
+
+    settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog")
+    with pytest.raises(ValueError, match=f"port must be an int, got {type_name}"):
+        replace(settings, port=port)
+
+
+@pytest.mark.parametrize("port", [1, 65535])
+def test_catalog_ui_accepts_port_boundaries(tmp_path: Path, port: int) -> None:
+    settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog", port=port)
+
+    assert settings.port == port
+
+
+def test_catalog_ui_accepts_an_int_enum_port(tmp_path: Path) -> None:
+    from enum import IntEnum
+
+    class Port(IntEnum):
+        CATALOG_UI = 4213
+
+    settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog", port=Port.CATALOG_UI)
+
+    assert settings.port == Port.CATALOG_UI
+
+
+@pytest.mark.parametrize(
+    ("poll_interval", "type_name"),
+    [(True, "bool"), ("0.5", "str"), (None, "NoneType")],
+)
+def test_catalog_ui_refuses_a_poll_interval_of_the_wrong_type(
+    tmp_path: Path, poll_interval: object, type_name: str
+) -> None:
+    from dataclasses import replace
+
+    settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog")
+    with pytest.raises(
+        ValueError,
+        match=f"catalog_poll_interval_seconds must be an int or float, got {type_name}",
+    ):
+        replace(settings, catalog_poll_interval_seconds=poll_interval)
+
+
+@pytest.mark.parametrize(
+    "poll_interval",
+    [0, -0.5, float("nan"), float("inf"), float("-inf")],
+)
+def test_catalog_ui_refuses_a_nonpositive_or_nonfinite_poll_interval(
+    tmp_path: Path, poll_interval: float
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="catalog_poll_interval_seconds must be positive and finite",
+    ):
+        catalog_ui.CatalogUiSettings(
+            catalog_root=tmp_path / "catalog",
+            catalog_poll_interval_seconds=poll_interval,
+        )
+
+
+@pytest.mark.parametrize("poll_interval", [1, 0.001])
+def test_catalog_ui_accepts_a_positive_finite_poll_interval(
+    tmp_path: Path, poll_interval: float
+) -> None:
+    settings = catalog_ui.CatalogUiSettings(
+        catalog_root=tmp_path / "catalog",
+        catalog_poll_interval_seconds=poll_interval,
+    )
+
+    assert settings.catalog_poll_interval_seconds == poll_interval
+
+
 def test_catalog_ui_refuses_a_port_owned_by_another_process() -> None:
     with socket(AF_INET, SOCK_STREAM) as occupied_port_socket:
         occupied_port_socket.bind(("127.0.0.1", 0))


### PR DESCRIPTION
## Summary

Reject invalid Catalog UI numeric settings at construction, before they can reach socket setup or the polling wait loop.

Closes #297

## Why

`CatalogUiSettings` previously relied only on range comparisons. Because `bool` subclasses `int`, `port=True` was accepted as port 1; floating-point ports were also accepted. For the polling interval, `NaN`, positive infinity, and `True` bypassed the existing non-positive check. Positive infinity can later raise `OverflowError` inside `Event.wait`.

This change keeps valid behavior unchanged while enforcing the field contracts described in the issue:

- `port` is an `int` other than `bool`, in the inclusive range 1-65535.
- `catalog_poll_interval_seconds` is an `int` or `float` other than `bool`, finite, and greater than zero.
- `IntEnum` port values remain accepted.

## Validation

- `python -m pytest -q tests/test_catalog_ui.py` — 20 passed
- `ruff check src/hflow/catalog_ui.py tests/test_catalog_ui.py` — passed
- `ruff format --check src/hflow/catalog_ui.py tests/test_catalog_ui.py` — 2 files already formatted
- `ty check src/hflow/catalog_ui.py tests/test_catalog_ui.py` — passed
- The new validation cases were run against unmodified `main` first and failed for the reported boundaries.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] Documentation is unchanged because valid behavior, flags, formats, and requirements are unchanged.
- [x] I ran Ruff check/format and ty in the WSL development environment.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility; this only validates settings at construction.