### PR TITLE
refactor(egosuite): make judgment outcomes exclusive

### DIFF
--- a/examples/egosuite_evaluation/judgment.py
+++ b/examples/egosuite_evaluation/judgment.py
@@ -31,12 +31,32 @@ class ResponseFormat(StrEnum):
 
 
 @dataclass(frozen=True)
-class HandCountJudgment:
-    raw_response: str
-    predicted_hand_count: int | None
+class ModelResponseMetadata:
+    """Provider response fields retained for every hand-count outcome."""
+
     response_model: str | None
     usage: dict[str, object]
-    parse_error: str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedHandCountOutcome:
+    """A model response successfully parsed as a supported hand count."""
+
+    raw_response: str
+    response_metadata: ModelResponseMetadata
+    predicted_hand_count: int
+
+
+@dataclass(frozen=True)
+class UnparsedHandCountOutcome:
+    """A completed model response outside the supported hand-count vocabulary."""
+
+    raw_response: str
+    response_metadata: ModelResponseMetadata
+    parse_error: str
+
+
+HandCountOutcome = ParsedHandCountOutcome | UnparsedHandCountOutcome
 
 
 def image_file_data_url(image_path: Path) -> str:
@@ -118,12 +138,19 @@ def _chat_completion_response_text(response: object) -> str:
     raise ValueError("endpoint returned no text completion content")
 
 
-def _response_usage(response: object) -> dict[str, object]:
+def _response_metadata(response: object) -> ModelResponseMetadata:
+    response_model = getattr(response, "model", None)
+    normalized_response_model = response_model if isinstance(response_model, str) else None
     usage = getattr(response, "usage", None)
-    if usage is None or not callable(getattr(usage, "model_dump", None)):
-        return {}
-    dumped_usage = usage.model_dump(exclude_none=True)
-    return dumped_usage if isinstance(dumped_usage, dict) else {}
+    parsed_usage: dict[str, object] = {}
+    if usage is not None and callable(getattr(usage, "model_dump", None)):
+        dumped_usage = usage.model_dump(exclude_none=True)
+        if isinstance(dumped_usage, dict):
+            parsed_usage = dumped_usage
+    return ModelResponseMetadata(
+        response_model=normalized_response_model,
+        usage=parsed_usage,
+    )
 
 
 def evaluate_image_with_model(
@@ -135,7 +162,7 @@ def evaluate_image_with_model(
     response_format: ResponseFormat,
     temperature: float | None,
     max_tokens: int,
-) -> HandCountJudgment:
+) -> HandCountOutcome:
     """Run one hand-count request through an OpenAI-compatible client."""
 
     request_parameters: dict[str, object] = {
@@ -158,32 +185,25 @@ def evaluate_image_with_model(
         request_parameters["temperature"] = temperature
 
     response = client.chat.completions.create(**request_parameters)
-    response_model = getattr(response, "model", None)
-    normalized_response_model = response_model if isinstance(response_model, str) else None
-    usage = _response_usage(response)
+    response_metadata = _response_metadata(response)
     try:
         raw_response = _chat_completion_response_text(response)
     except ValueError as error:
-        return HandCountJudgment(
+        return UnparsedHandCountOutcome(
             raw_response="",
-            predicted_hand_count=None,
-            response_model=normalized_response_model,
-            usage=usage,
+            response_metadata=response_metadata,
             parse_error=str(error),
         )
     try:
         predicted_hand_count = parse_hand_count_response(raw_response)
     except ValueError as error:
-        return HandCountJudgment(
+        return UnparsedHandCountOutcome(
             raw_response=raw_response,
-            predicted_hand_count=None,
-            response_model=normalized_response_model,
-            usage=usage,
+            response_metadata=response_metadata,
             parse_error=str(error),
         )
-    return HandCountJudgment(
+    return ParsedHandCountOutcome(
         raw_response=raw_response,
+        response_metadata=response_metadata,
         predicted_hand_count=predicted_hand_count,
-        response_model=normalized_response_model,
-        usage=usage,
     )

--- a/examples/egosuite_evaluation/pipeline.py
+++ b/examples/egosuite_evaluation/pipeline.py
@@ -18,7 +18,7 @@ import threading
 from collections import Counter
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, assert_never
 
 import hflow
 from examples.egosuite_evaluation.evaluate import (
@@ -30,8 +30,10 @@ from examples.egosuite_evaluation.evaluate import (
 )
 from examples.egosuite_evaluation.judgment import (
     DEFAULT_PROMPT_PATH,
-    HandCountJudgment,
+    HandCountOutcome,
+    ParsedHandCountOutcome,
     ResponseFormat,
+    UnparsedHandCountOutcome,
     evaluate_image_with_model,
     image_file_data_url,
 )
@@ -190,7 +192,7 @@ def _client_for_current_thread() -> Any:
     return _client_by_thread.client
 
 
-def _evaluate_frame(extracted_frame: hflow.ExtractedFrame) -> HandCountJudgment:
+def _evaluate_frame(extracted_frame: hflow.ExtractedFrame) -> HandCountOutcome:
     return evaluate_image_with_model(
         client=_client_for_current_thread(),
         model=pipeline_configuration.model,
@@ -205,7 +207,7 @@ def _evaluate_frame(extracted_frame: hflow.ExtractedFrame) -> HandCountJudgment:
 def hand_visibility_check_result(
     labels: Sequence[ProjectedHandFrameLabel],
     extracted_frames: Sequence[hflow.ExtractedFrame],
-    judgments: Sequence[HandCountJudgment],
+    judgments: Sequence[HandCountOutcome],
     *,
     requested_model: str,
 ) -> hflow.CheckResult:
@@ -214,17 +216,19 @@ def hand_visibility_check_result(
     if not (len(labels) == len(extracted_frames) == len(judgments)):
         raise ValueError("labels, extracted frames, and judgments must have equal lengths")
     reference_counts = Counter(label.expected_hand_count for label in labels)
-    predicted_counts = Counter(
-        judgment.predicted_hand_count
-        for judgment in judgments
-        if judgment.predicted_hand_count is not None
-    )
-    valid_count = sum(judgment.predicted_hand_count is not None for judgment in judgments)
-    agreement_count = sum(
-        judgment.predicted_hand_count == label.expected_hand_count
-        for label, judgment in zip(labels, judgments, strict=True)
-        if judgment.predicted_hand_count is not None
-    )
+    predicted_counts: Counter[int] = Counter()
+    valid_count = 0
+    agreement_count = 0
+    for label, judgment in zip(labels, judgments, strict=True):
+        match judgment:
+            case ParsedHandCountOutcome(predicted_hand_count=predicted_hand_count):
+                predicted_counts[predicted_hand_count] += 1
+                valid_count += 1
+                agreement_count += predicted_hand_count == label.expected_hand_count
+            case UnparsedHandCountOutcome():
+                pass
+            case unexpected_judgment:
+                assert_never(unexpected_judgment)
     attempted_count = len(labels)
     measurements: dict[str, hflow.MeasurementValue] = {
         f"{MEASUREMENT_PREFIX}/attempted_count": attempted_count,
@@ -249,40 +253,68 @@ def hand_visibility_check_result(
         measurements[f"{MEASUREMENT_PREFIX}/predicted/{hand_count}"] = predicted_counts[hand_count]
 
     response_models = sorted(
-        {judgment.response_model for judgment in judgments if judgment.response_model is not None}
+        {
+            judgment.response_metadata.response_model
+            for judgment in judgments
+            if judgment.response_metadata.response_model is not None
+        }
     )
     if response_models:
         measurements[f"{MEASUREMENT_PREFIX}/response_models"] = ",".join(response_models)
     usage_totals: dict[str, float] = {}
     for judgment in judgments:
-        for usage_name, usage_value in judgment.usage.items():
+        for usage_name, usage_value in judgment.response_metadata.usage.items():
             if isinstance(usage_value, int | float) and not isinstance(usage_value, bool):
                 usage_totals[usage_name] = usage_totals.get(usage_name, 0.0) + usage_value
     for usage_name, usage_total in usage_totals.items():
         measurements[f"{MEASUREMENT_PREFIX}/usage/{usage_name}"] = usage_total
 
     observations: list[hflow.Observation] = []
+    intervals: list[hflow.Interval] = []
     for label, extracted_frame, judgment in zip(labels, extracted_frames, judgments, strict=True):
         observation_values: dict[str, hflow.MeasurementValue] = {
             "frame_index": label.frame_index,
             "reference_hand_count": label.expected_hand_count,
-            "valid": judgment.predicted_hand_count is not None,
-            "agreement": judgment.predicted_hand_count == label.expected_hand_count,
             "raw_response": judgment.raw_response,
             "requested_model": requested_model,
             "left_in_frame_joint_count": label.left_in_frame_joint_count,
             "right_in_frame_joint_count": label.right_in_frame_joint_count,
             "pose_issue": bool(label.left_hand_issue_reasons or label.right_hand_issue_reasons),
         }
-        if judgment.predicted_hand_count is not None:
-            observation_values["predicted_hand_count"] = judgment.predicted_hand_count
-        if judgment.response_model is not None:
-            observation_values["response_model"] = judgment.response_model
-        if judgment.parse_error is not None:
-            observation_values["parse_error"] = judgment.parse_error
-        for usage_name, usage_value in judgment.usage.items():
+        if judgment.response_metadata.response_model is not None:
+            observation_values["response_model"] = judgment.response_metadata.response_model
+        for usage_name, usage_value in judgment.response_metadata.usage.items():
             if isinstance(usage_value, int | float | str | bool):
                 observation_values[f"usage/{usage_name}"] = usage_value
+        match judgment:
+            case ParsedHandCountOutcome(predicted_hand_count=predicted_hand_count):
+                observation_values["predicted_hand_count"] = predicted_hand_count
+                observation_values["valid"] = True
+                observation_values["agreement"] = predicted_hand_count == label.expected_hand_count
+                if predicted_hand_count != label.expected_hand_count:
+                    intervals.append(
+                        hflow.Interval(
+                            start_ns=extracted_frame.log_time_ns,
+                            end_ns=extracted_frame.log_time_ns,
+                            label=(
+                                f"{MEASUREMENT_PREFIX}/reference_{label.expected_hand_count}_"
+                                f"predicted_{predicted_hand_count}"
+                            ),
+                        )
+                    )
+            case UnparsedHandCountOutcome(parse_error=parse_error):
+                observation_values["valid"] = False
+                observation_values["agreement"] = False
+                observation_values["parse_error"] = parse_error
+                intervals.append(
+                    hflow.Interval(
+                        start_ns=extracted_frame.log_time_ns,
+                        end_ns=extracted_frame.log_time_ns,
+                        label=f"{MEASUREMENT_PREFIX}/unparsed",
+                    )
+                )
+            case unexpected_judgment:
+                assert_never(unexpected_judgment)
         observations.append(
             hflow.Observation(
                 observation_id=f"frame:{label.frame_index}",
@@ -291,24 +323,6 @@ def hand_visibility_check_result(
             )
         )
 
-    intervals: list[hflow.Interval] = []
-    for label, extracted_frame, judgment in zip(labels, extracted_frames, judgments, strict=True):
-        if judgment.predicted_hand_count is None:
-            interval_label = f"{MEASUREMENT_PREFIX}/unparsed"
-        elif judgment.predicted_hand_count != label.expected_hand_count:
-            interval_label = (
-                f"{MEASUREMENT_PREFIX}/reference_{label.expected_hand_count}_"
-                f"predicted_{judgment.predicted_hand_count}"
-            )
-        else:
-            continue
-        intervals.append(
-            hflow.Interval(
-                start_ns=extracted_frame.log_time_ns,
-                end_ns=extracted_frame.log_time_ns,
-                label=interval_label,
-            )
-        )
     tags = [f"{MEASUREMENT_PREFIX}/has_unparsed_output"] if valid_count < attempted_count else []
     return hflow.CheckResult(
         measurements=measurements,

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -30,8 +30,10 @@ from examples.egosuite_evaluation.geometry import (
     project_world_joints,
 )
 from examples.egosuite_evaluation.judgment import (
-    HandCountJudgment,
+    ModelResponseMetadata,
+    ParsedHandCountOutcome,
     ResponseFormat,
+    UnparsedHandCountOutcome,
     evaluate_image_with_model,
 )
 from examples.egosuite_evaluation.pipeline import (
@@ -129,11 +131,12 @@ def test_model_response_without_text_is_a_recoverable_invalid_judgment() -> None
         max_tokens=512,
     )
 
-    assert judgment == HandCountJudgment(
+    assert judgment == UnparsedHandCountOutcome(
         raw_response="",
-        predicted_hand_count=None,
-        response_model="routed-model",
-        usage={"total_tokens": 17},
+        response_metadata=ModelResponseMetadata(
+            response_model="routed-model",
+            usage={"total_tokens": 17},
+        ),
         parse_error="endpoint returned no text completion content",
     )
 
@@ -200,23 +203,28 @@ def test_pipeline_records_agreement_output_validity_and_frame_intervals() -> Non
         for frame_index in range(3)
     ]
     judgments = [
-        HandCountJudgment(
+        ParsedHandCountOutcome(
             raw_response='{"hand_count": 1}',
+            response_metadata=ModelResponseMetadata(
+                response_model="routed-model",
+                usage={"prompt_tokens": 10, "completion_tokens": 2},
+            ),
             predicted_hand_count=1,
-            response_model="routed-model",
-            usage={"prompt_tokens": 10, "completion_tokens": 2},
         ),
-        HandCountJudgment(
+        ParsedHandCountOutcome(
             raw_response='{"hand_count": 1}',
+            response_metadata=ModelResponseMetadata(
+                response_model="routed-model",
+                usage={"prompt_tokens": 11, "completion_tokens": 2},
+            ),
             predicted_hand_count=1,
-            response_model="routed-model",
-            usage={"prompt_tokens": 11, "completion_tokens": 2},
         ),
-        HandCountJudgment(
+        UnparsedHandCountOutcome(
             raw_response="not a count",
-            predicted_hand_count=None,
-            response_model="routed-model",
-            usage={"prompt_tokens": 12, "completion_tokens": 2},
+            response_metadata=ModelResponseMetadata(
+                response_model="routed-model",
+                usage={"prompt_tokens": 12, "completion_tokens": 2},
+            ),
             parse_error="hand count must be 0, 1, or 2",
         ),
     ]


### PR DESCRIPTION
## Summary

- replace the optional-field `HandCountJudgment` with parsed and unparsed outcome variants
- keep response model and usage data in shared `ModelResponseMetadata`
- handle every outcome exhaustively while preserving the existing HFlow measurements, observations, intervals, and tags

Closes #318

## Why

The previous shape allowed a prediction and parse error together, or neither. Typed variants make those invalid states unrepresentable and let the pipeline prove that every outcome is handled, following the neighboring Build AI example.

This changes check/example code only. It does not change canonical episode bytes, so no transform behavior-version bump is needed.

## Validation

- `uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests` — 15 passed
- `uv run --locked --project examples/egosuite_evaluation ruff check examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation ruff format --check examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . examples/egosuite_evaluation` — passed
- `uv run ruff check --fix && uv run ruff format` — passed
- `uv run ty check` — passed
- `uv run pytest -q` — 1245 passed, 11 skipped; one unrelated catalog UI thread-shutdown timeout failed
- `uv run pytest -q tests/test_catalog_ui.py::test_catalog_ui_starts_empty_then_exposes_the_first_completed_append` — passed on immediate rerun

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] Documentation is unchanged because the emitted evidence contract and user workflow are unchanged.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is preserved; this check-only refactor does not change canonical output bytes.