### PR TITLE
fix: unify ingest URI validation

### DIFF
--- a/packages/hflow-server/src/hflow_server/_runtime.py
+++ b/packages/hflow-server/src/hflow_server/_runtime.py
@@ -24,7 +24,6 @@ import time
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from posixpath import normpath
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
@@ -36,6 +35,7 @@ from hflow.runtime import (
     client_for_bundle,
     client_for_endpoint,
     load_bundle,
+    parse_data_root_relative_uri,
     resolve_remote_endpoint,
     sub_dag_id_for_stage,
 )
@@ -412,20 +412,10 @@ def create_runtime_router(settings: ServerSettings, resolver: RuntimeResolver) -
     @router.post("/runtime/ingest")
     def trigger_ingest(request: IngestRequest) -> IngestTriggerResponse:
         refuse_when_read_only(settings, disabled_actions="triggering ingest runs is")
-        uris = [uri.strip() for uri in request.uris]
-        if any(not uri for uri in uris):
-            raise HTTPException(status_code=400, detail="every uri must be a non-empty string")
-        # URIs resolve against the runtime's data root; absolute host paths and
-        # ../ escapes cannot work there, so refuse them before triggering --
-        # the same guard `hflow ingest` enforces (src/hflow/cli.py).
-        for uri in uris:
-            if uri.startswith("/") or normpath(uri).startswith(".."):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"{uri!r} is not relative to the data root -- URIs are resolved "
-                    "against the runtime's configured data root (e.g. "
-                    "`episodes-in/run_0001.mcap`)",
-                )
+        try:
+            uris = [str(parse_data_root_relative_uri(uri)) for uri in request.uris]
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
         if request.profile not in RUN_PROFILES:
             raise HTTPException(
                 status_code=400,

--- a/packages/hflow-server/tests/test_server_runtime.py
+++ b/packages/hflow-server/tests/test_server_runtime.py
@@ -335,13 +335,46 @@ def test_ingest_rejects_absolute_and_escaping_uris_before_any_runtime(
     data_root = tmp_path / "bare-root"
     data_root.mkdir()
     client = _client_over(data_root, unbuilt_assets_dir)
-    for hostile_uri in ("/etc/passwd", "../../etc/shadow", "sub/../../escape.mcap"):
+    for hostile_uri in (
+        "/etc/passwd",
+        "C:/Windows/System32/config/SAM",
+        "../../etc/shadow",
+        "sub/../../escape.mcap",
+    ):
         response = client.post(
             "/api/v1/runtime/ingest",
             json={"uris": [hostile_uri], "profile": "full", "mode": "batch"},
         )
         assert response.status_code == 400, hostile_uri
         assert "not relative to the data root" in response.json()["detail"]
+
+
+def test_ingest_trims_uris_before_triggering(
+    bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_ingest(
+        self: AirflowClient,
+        dag_id: str,
+        uris: list[str],
+        *,
+        profile: str = "full",
+        online: bool = False,
+        batch_count: int | None = None,
+        dag_run_id: str | None = None,
+    ) -> dict[str, str]:
+        captured["uris"] = uris
+        return {"dag_run_id": "manual__trimmed", "state": "queued"}
+
+    monkeypatch.setattr(AirflowClient, "ingest", fake_ingest)
+    response = bundle_api.post(
+        "/api/v1/runtime/ingest",
+        json={"uris": [" episodes-in/a/../b.mcap "], "profile": "full", "mode": "batch"},
+    )
+
+    assert response.status_code == 200
+    assert captured["uris"] == ["episodes-in/a/../b.mcap"]
 
 
 def test_ingest_without_a_runtime_is_a_clear_409(

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -1111,28 +1111,28 @@ def _print_ingest_failure_hint() -> None:
 
 
 def _command_ingest(arguments: argparse.Namespace) -> int:
-    from posixpath import normpath
-
     from hflow.runtime import (
         AirflowClientError,
         client_for_bundle,
         client_for_endpoint,
         load_bundle,
+        parse_data_root_relative_uri,
     )
 
     # URIs resolve against the runtime's data root; absolute host paths and
     # ../ escapes cannot work there, so fail before triggering.
-    for uri in arguments.uris:
-        if uri.startswith("/") or normpath(uri).startswith(".."):
-            print(
-                f"ingest: {uri!r} is not relative to the data root -- URIs are "
-                f"resolved against the workspace this project uses ({_environment_data_root()}), "
-                "so name them from there (e.g. `episodes-in/run_0001.mcap`). "
-                f"Set $HFLOW_DATA_ROOT or {PROJECT_CONFIG_FILE_NAME}'s data_root "
-                "to point at another workspace",
-                file=sys.stderr,
-            )
-            return 2
+    try:
+        uris = [str(parse_data_root_relative_uri(uri)) for uri in arguments.uris]
+    except ValueError as error:
+        print(
+            f"ingest: {error} -- URIs are resolved against the workspace this project uses "
+            f"({_environment_data_root()}), so name them from there "
+            "(e.g. `episodes-in/run_0001.mcap`). "
+            f"Set $HFLOW_DATA_ROOT or {PROJECT_CONFIG_FILE_NAME}'s data_root "
+            "to point at another workspace",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         endpoint = _remote_endpoint_for_command(arguments)
@@ -1162,7 +1162,7 @@ def _command_ingest(arguments: argparse.Namespace) -> int:
     try:
         dag_run = client.ingest(
             dag_id,
-            list(arguments.uris),
+            uris,
             profile=arguments.profile,
             online=arguments.online,
         )

--- a/src/hflow/runtime/__init__.py
+++ b/src/hflow/runtime/__init__.py
@@ -56,6 +56,7 @@ from hflow.runtime._topology import (
     StageTopology,
     ingest_dag_topology,
 )
+from hflow.uri import DataRootRelativeUri, parse_data_root_relative_uri
 
 __all__ = [
     "DEFAULT_AIRFLOW_IMAGE",
@@ -68,6 +69,7 @@ __all__ = [
     "ComposeError",
     "DagTaskNode",
     "DagTopology",
+    "DataRootRelativeUri",
     "DeployConfig",
     "DeployPaths",
     "IngestTopology",
@@ -88,6 +90,7 @@ __all__ = [
     "infer_hflow_source",
     "ingest_dag_topology",
     "load_bundle",
+    "parse_data_root_relative_uri",
     "render_bundle",
     "render_deploy_bundle",
     "resolve_remote_endpoint",

--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -19,9 +19,11 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
+
+from hflow.uri import parse_data_root_relative_uri
 
 
 class AirflowClientError(RuntimeError):
@@ -312,7 +314,7 @@ class AirflowClient:
     def ingest(
         self,
         dag_id: str,
-        uris: list[str],
+        uris: Sequence[str],
         *,
         profile: str = "full",
         online: bool = False,
@@ -342,8 +344,9 @@ class AirflowClient:
             # Same wording as hflow.batching.plan_batches, the task-side owner
             # of this invariant, so both entry points say the same thing.
             raise ValueError(f"batch_count must be >= 1, got {batch_count}")
+        validated_uris = [str(parse_data_root_relative_uri(uri)) for uri in uris]
         conf: dict[str, Any] = {
-            "uris": uris,
+            "uris": validated_uris,
             "profile": profile,
             "mode": "online" if online else "batch",
         }

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -35,6 +35,7 @@ from hflow.stage_planning import (
 )
 from hflow.steps import IngestMode, Stage
 from hflow.storage import is_bucket_url, parse_storage_root
+from hflow.uri import DataRootRelativeUri, parse_data_root_relative_uri
 
 if TYPE_CHECKING:
     from hflow.app import App
@@ -121,10 +122,10 @@ def require_application_data_root(application: "App", expected_data_root: str) -
         )
 
 
-def resolve_episode_reference(data_root: str, uri: str) -> "Path | str":
+def resolve_episode_reference(data_root: str, uri: DataRootRelativeUri) -> "Path | str":
     """A conf URI (relative to the data root) as a processable reference."""
     if is_bucket_url(data_root):
-        return data_root.rstrip("/") + "/" + uri.lstrip("/")
+        return data_root.rstrip("/") + "/" + uri
     return Path(data_root) / uri
 
 
@@ -228,7 +229,9 @@ def process_stage_batch(
     with _batch_quarantine_history(application, stage) as quarantine_history:
         for uri in uris:
             try:
-                episode_reference = resolve_episode_reference(data_root, str(uri))
+                episode_reference = resolve_episode_reference(
+                    data_root, parse_data_root_relative_uri(str(uri))
+                )
                 report = application.process(
                     episode_reference,
                     record=True,
@@ -389,7 +392,9 @@ def _plan_after_sync(
 
     data_root = str(application.data_root)
     identity_by_uri = {
-        str(uri): application.source_identity(resolve_episode_reference(data_root, str(uri)))
+        str(uri): application.source_identity(
+            resolve_episode_reference(data_root, parse_data_root_relative_uri(str(uri)))
+        )
         for uri in uris
     }
     plans = plan_outstanding_stages(

--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -41,6 +41,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from hflow.steps import RAN_STATUSES, SETTLED_STATUSES, Stage
+from hflow.uri import parse_data_root_relative_uri
 
 if TYPE_CHECKING:
     import duckdb
@@ -372,7 +373,9 @@ def outstanding_stage_uris(
     from hflow.stage_execution import resolve_episode_reference
 
     identity_by_uri = {
-        uri: application.source_identity(resolve_episode_reference(data_root, str(uri)))
+        uri: application.source_identity(
+            resolve_episode_reference(data_root, parse_data_root_relative_uri(str(uri)))
+        )
         for uri in uris
     }
     plans = plan_outstanding_stages(application, list(identity_by_uri.values()), (stage,))

--- a/src/hflow/uri.py
+++ b/src/hflow/uri.py
@@ -1,0 +1,25 @@
+"""Validation for URIs relative to a runtime data root."""
+
+from pathlib import PureWindowsPath
+from posixpath import normpath
+from typing import NewType
+
+DataRootRelativeUri = NewType("DataRootRelativeUri", str)
+
+
+def parse_data_root_relative_uri(uri: str) -> DataRootRelativeUri:
+    """Trim and validate one URI before a runtime can resolve it."""
+    if not isinstance(uri, str):
+        raise ValueError("ingest URI must be a string")
+
+    candidate = uri.strip()
+    if not candidate:
+        raise ValueError("every URI must be a non-empty string")
+    if candidate.startswith("/") or PureWindowsPath(candidate).is_absolute():
+        raise ValueError(f"{candidate!r} is not relative to the data root")
+
+    normalized = normpath(candidate)
+    if normalized == ".." or normalized.startswith("../"):
+        raise ValueError(f"{candidate!r} is not relative to the data root")
+
+    return DataRootRelativeUri(candidate)

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -1038,9 +1038,19 @@ def test_ingest_rejects_unknown_profile(pipeline_file: Path, tmp_path: Path) -> 
     assert exit_info.value.code == 2
 
 
-@pytest.mark.parametrize("uri", ["/abs/x.mcap", "../x.mcap"])
+@pytest.mark.parametrize(
+    ("uri", "expected_error"),
+    [
+        ("", "non-empty"),
+        ("   ", "non-empty"),
+        ("/abs/x.mcap", "is not relative to the data root"),
+        ("../x.mcap", "is not relative to the data root"),
+        ("a/../../escape.mcap", "is not relative to the data root"),
+    ],
+)
 def test_ingest_rejects_uris_outside_data_root(
     uri: str,
+    expected_error: str,
     pipeline_file: Path,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1051,7 +1061,7 @@ def test_ingest_rejects_uris_outside_data_root(
     exit_code = main(["ingest", uri, "--bundle-dir", str(bundle_dir)])
 
     assert exit_code == 2
-    assert "is not relative to the data root" in capsys.readouterr().err
+    assert expected_error in capsys.readouterr().err
 
 
 def test_start_runtime_waits_for_all_five_dags(

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -242,6 +242,31 @@ def test_ingest_refuses_a_batch_count_the_run_could_not_honour(stub_server: str)
     assert _StubAirflowHandler.requests_seen == []
 
 
+@pytest.mark.parametrize(
+    "uri", ["", "   ", "/absolute.mcap", "../escape.mcap", "a/../../escape.mcap"]
+)
+def test_ingest_refuses_invalid_uris_before_http(stub_server: str, uri: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(ValueError, match=r"relative to the data root|non-empty"):
+        client.ingest("pipeline_ingest", [uri])
+
+    assert _StubAirflowHandler.requests_seen == []
+
+
+def test_ingest_trims_valid_uris_without_normalizing_internal_segments(stub_server: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    client.ingest("pipeline_ingest", ["  episodes-in/a/../b.mcap  "])
+
+    trigger_requests = [
+        entry for entry in _StubAirflowHandler.requests_seen if entry[1].endswith("/dagRuns")
+    ]
+    payload = trigger_requests[0][2]
+    assert payload is not None
+    assert payload["conf"]["uris"] == ["episodes-in/a/../b.mcap"]
+
+
 def test_bad_credentials_surface_clearly(stub_server: str) -> None:
     client = AirflowClient(stub_server, "airflow", "wrong-password")
     with pytest.raises(AirflowClientError) as error_info:

--- a/tests/test_stage_execution.py
+++ b/tests/test_stage_execution.py
@@ -10,6 +10,7 @@ import pytest
 
 import hflow
 from hflow import stage_execution
+from hflow.runtime import parse_data_root_relative_uri
 from hflow.stage_execution import (
     StageBatchCounts,
     load_pipeline_application,
@@ -117,13 +118,18 @@ class TestConfFlags:
 
 class TestEpisodeReferences:
     def test_bucket_root_joins_as_url_and_local_as_path(self) -> None:
+        uri = parse_data_root_relative_uri("episodes-in/a.mcap")
         assert (
-            resolve_episode_reference("gs://bucket/prefix", "episodes-in/a.mcap")
+            resolve_episode_reference("gs://bucket/prefix", uri)
             == "gs://bucket/prefix/episodes-in/a.mcap"
         )
-        assert resolve_episode_reference("/opt/airflow/data", "episodes-in/a.mcap") == Path(
+        assert resolve_episode_reference("/opt/airflow/data", uri) == Path(
             "/opt/airflow/data/episodes-in/a.mcap"
         )
+
+    def test_bucket_reference_does_not_repair_an_invalid_leading_slash(self) -> None:
+        with pytest.raises(ValueError, match="relative to the data root"):
+            parse_data_root_relative_uri("/episodes-in/a.mcap")
 
 
 class TestPipelineLoading:


### PR DESCRIPTION
## Summary
- centralize data-root-relative URI trimming and validation for the CLI, server, SDK, and stage resolution
- preserve safe internal segments while rejecting blank, absolute, and escaping URIs before dispatch
- keep existing CLI and server error status behavior and add boundary regression coverage

## Tests
- focused runtime, server, CLI, and stage tests: 151 passed
- ruff check, ruff format --check, and ty check passed
- full suite with local FFmpeg binaries: 1254 passed, 9 skipped, 5 pre-existing FFmpeg PATH failures