### PR TITLE
fix(catalog): reject timestamps outside BIGINT range

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -111,6 +111,11 @@ _reconciled_append_stems: set[tuple[str, str]] = set()
 
 _FORMAT_MARKER_NAME = "format_version"
 
+# DuckDB BIGINT columns store signed 64-bit integers. Validate timestamp
+# evidence before any catalog files are committed so callers get contextual
+# errors instead of a late database conversion failure.
+_MAX_CATALOG_TIMESTAMP_NS = 2**63 - 1
+
 # The quarantine state rendered as a queryable column by the curation
 # views (curation.py builds both episodes views with it). Declared here
 # because measurement keys are validated against the episodes view's full
@@ -437,6 +442,11 @@ def _normalized_intervals(check_name: str, intervals: list[Interval]) -> list[In
                     f"check {check_name!r} set interval {bound_name} as "
                     f"{type(value).__name__}: interval bounds are int nanoseconds"
                 )
+            if value > _MAX_CATALOG_TIMESTAMP_NS:
+                raise ValueError(
+                    f"check {check_name!r} interval {interval.label!r} set "
+                    f"{bound_name}={value}: interval bounds must fit a DuckDB BIGINT"
+                )
             bounds[bound_name] = value
         start_ns = bounds["start_ns"]
         end_ns = bounds["end_ns"]
@@ -498,6 +508,11 @@ def _normalized_observations(check_name: str, observations: list[Observation]) -
             raise ValueError(
                 f"check {check_name!r} observation {observation_id!r} set timestamp_ns "
                 f"as {type(timestamp_ns).__name__}: observation timestamps are int nanoseconds"
+            )
+        if timestamp_ns > _MAX_CATALOG_TIMESTAMP_NS:
+            raise ValueError(
+                f"check {check_name!r} observation {observation_id!r} set "
+                f"timestamp_ns={timestamp_ns}: timestamps must fit a DuckDB BIGINT"
             )
         if timestamp_ns < 0:
             raise ValueError(

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import cast
 
 import duckdb
+import numpy as np
 import pytest
 
 import hflow
@@ -1532,6 +1533,101 @@ def test_same_interval_bound_in_a_numpy_or_python_scalar_replays_as_one_run(
     ]
     assert [attempt.written for attempt in attempts] == [True, False]
     assert len({attempt.run_fingerprint for attempt in attempts}) == 1
+
+
+def test_catalog_timestamp_bigint_boundaries_round_trip(tmp_path: Path) -> None:
+    """The complete non-negative BIGINT domain survives catalog storage."""
+    maximum = 2**63 - 1
+    row = CheckRunRow(
+        check_name="range_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        observations=[
+            hflow.Observation("zero", 0, {"score": 0}),
+            hflow.Observation("maximum", cast(int, np.int64(maximum)), {"score": 1}),
+        ],
+        intervals=[
+            hflow.Interval(start_ns=0, end_ns=0, label="zero"),
+            hflow.Interval(start_ns=cast(int, np.int64(maximum)), end_ns=maximum, label="maximum"),
+        ],
+    )
+    catalog = Catalog(tmp_path / "catalog")
+    catalog.append_episode(
+        canonical_path=_fake_canonical(tmp_path),
+        stamps=FAKE_STAMPS,
+        episode_metadata={},
+        check_rows=[row],
+    )
+
+    connection = open_catalog_connection(tmp_path / "catalog")
+    try:
+        assert connection.execute(
+            "SELECT observation_id, timestamp_ns FROM observations_latest ORDER BY timestamp_ns"
+        ).fetchall() == [("zero", 0), ("maximum", maximum)]
+        assert connection.execute(
+            "SELECT label, start_ns, end_ns FROM intervals ORDER BY start_ns"
+        ).fetchall() == [("zero", 0, 0), ("maximum", maximum, maximum)]
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("timestamp_ns", [2**63, np.uint64(2**63)])
+def test_out_of_range_observation_timestamp_is_refused_before_catalog_writes(
+    tmp_path: Path, timestamp_ns: object
+) -> None:
+    row = CheckRunRow(
+        check_name="range_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        observations=[hflow.Observation("frame:1", cast(int, timestamp_ns), {"score": 1})],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"range_check.*'frame:1'.*timestamp_ns=9223372036854775808.*BIGINT",
+    ):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=_fake_canonical(tmp_path),
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+    assert not list((tmp_path / "catalog").rglob("*.parquet"))
+
+
+@pytest.mark.parametrize("bound_name", ["start_ns", "end_ns"])
+@pytest.mark.parametrize("bound", [2**63, np.uint64(2**63)])
+def test_out_of_range_interval_bound_is_refused_before_catalog_writes(
+    tmp_path: Path, bound_name: str, bound: object
+) -> None:
+    bounds = {"start_ns": 0, "end_ns": 10}
+    bounds[bound_name] = cast(int, bound)
+    row = CheckRunRow(
+        check_name="range_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        intervals=[hflow.Interval(**bounds, label="segment")],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"range_check.*'segment'.*{bound_name}=9223372036854775808.*BIGINT",
+    ):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=_fake_canonical(tmp_path),
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+    assert not list((tmp_path / "catalog").rglob("*.parquet"))
 
 
 def test_non_scalar_measurement_is_refused_naming_the_check_and_key(


### PR DESCRIPTION
## Summary

Reject observation timestamps and interval bounds above DuckDB's signed 64-bit `BIGINT` maximum before a catalog append writes any Parquet files.

Closes #309.

## Why

Catalog evidence timestamps are normalized before the run fingerprint is computed, but values above `2**63 - 1` previously remained valid Python integers. They then failed later at the DuckDB insert boundary with a context-free `ConversionException`; for an oversized interval start, the existing inverted-interval check could mask the storage constraint instead.

The validation now runs immediately after Python/NumPy integer normalization and reports the check, evidence identifier, offending field/value, and `BIGINT` constraint. Existing handling of booleans, floats, negative values, and inverted intervals is unchanged.

## Validation

- Before the fix: the focused regression selection produced 6 failures; oversized Python and NumPy integers reached DuckDB (or the inverted-interval check).
- After the fix: `uv run pytest -q tests/test_catalog_curation.py` — 85 passed.
- After rebasing onto current `main`: `uv run pytest -q` — 1294 passed, 6 skipped.
- `uv run ruff check --fix` — passed.
- `uv run ruff format` — passed.
- `uv run ty check` — passed.
- `git diff --check` — passed.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] Documentation is not required: this enforces the existing catalog `BIGINT` schema and does not change flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility; no format version change is required.