### PR TITLE
fix(egosuite): validate saved label report envelope before parsing frames (fixes #307)

### DIFF
--- a/examples/egosuite_evaluation/evaluate.py
+++ b/examples/egosuite_evaluation/evaluate.py
@@ -65,6 +65,7 @@ from examples.egosuite_evaluation.judgment import (  # noqa: E402
 )
 
 SCHEMA_VERSION = 1
+PROJECTED_HAND_LABEL_TYPE = "projected-hand-joints"
 EXPECTED_HAND_JOINT_COUNT = 21
 DEFAULT_RUNS_DIRECTORY = Path("data/egosuite-evaluation/runs")
 DEFAULT_LABELS_DIRECTORY = Path("data/egosuite-evaluation/labels")
@@ -151,6 +152,30 @@ def load_projected_hand_label_report(
         ) from error
     if not isinstance(report_payload, dict):
         raise ValueError(f"projected-hand label report {report_path} must contain a JSON object")
+
+    schema_version = report_payload.get("schema_version")
+    if (
+        schema_version is None
+        or isinstance(schema_version, bool)
+        or not isinstance(schema_version, int)
+        or schema_version != SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"projected-hand label report {report_path} field 'schema_version' has invalid "
+            f"value {schema_version!r}; supported schema_version is {SCHEMA_VERSION}"
+        )
+
+    label_type = report_payload.get("label_type")
+    if (
+        label_type is None
+        or not isinstance(label_type, str)
+        or label_type != PROJECTED_HAND_LABEL_TYPE
+    ):
+        raise ValueError(
+            f"projected-hand label report {report_path} field 'label_type' has invalid "
+            f"value {label_type!r}; supported label_type is {PROJECTED_HAND_LABEL_TYPE!r}"
+        )
+
     raw_frame_records = report_payload.get("frames")
     if not isinstance(raw_frame_records, list):
         raise ValueError(f"projected-hand label report {report_path} must contain a 'frames' array")
@@ -889,7 +914,7 @@ def write_label_report(
     all_labels = [label for labels in labels_by_source.values() for label in labels]
     report = {
         "schema_version": SCHEMA_VERSION,
-        "label_type": "projected-hand-joints",
+        "label_type": PROJECTED_HAND_LABEL_TYPE,
         "camera_view": camera_view.value,
         "frame_stride": frame_stride,
         "limit_per_episode": limit_per_episode,

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -15,6 +15,8 @@ from inspect_ai.model import ModelOutput, ModelUsage
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from examples.egosuite_evaluation.evaluate import (
+    PROJECTED_HAND_LABEL_TYPE,
+    SCHEMA_VERSION,
     CameraView,
     EvaluatedSample,
     EvaluationConfiguration,
@@ -35,6 +37,7 @@ from examples.egosuite_evaluation.evaluate import (
     select_episode_paths,
     select_stratified_labels,
     summarize_evaluation_results,
+    write_label_report,
 )
 from examples.egosuite_evaluation.geometry import (
     CameraPoseInWorld,
@@ -168,6 +171,8 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
     report_path.write_text(
         json.dumps(
             {
+                "schema_version": SCHEMA_VERSION,
+                "label_type": PROJECTED_HAND_LABEL_TYPE,
                 "frames": [
                     {
                         "source_path": str(source_path),
@@ -181,7 +186,7 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
                         "right_hand_issue_reasons": ["occlusion"] if frame_index == 8 else [],
                     }
                     for frame_index in (8, 3)
-                ]
+                ],
             }
         )
     )
@@ -194,6 +199,87 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
     assert [label.frame_index for label in selected_labels] == [3, 8]
     assert [label.expected_hand_count for label in selected_labels] == [1, 2]
     assert selected_labels[1].right_hand_issue_reasons == ("occlusion",)
+
+
+def test_write_label_report_round_trips_through_loader(tmp_path: Path) -> None:
+    source_path = tmp_path / "episode-1.mcap"
+    label = ProjectedHandFrameLabel(
+        source_path=source_path,
+        source_episode="episode-1",
+        camera_view=CameraView.HEAD_LEFT,
+        frame_index=0,
+        left_in_frame_joint_count=21,
+        right_in_frame_joint_count=0,
+        expected_hand_count=1,
+        left_hand_issue_reasons=(),
+        right_hand_issue_reasons=(),
+    )
+    report_path = tmp_path / "written_report.json"
+    write_label_report(
+        {source_path: [label]},
+        camera_view=CameraView.HEAD_LEFT,
+        frame_stride=1,
+        limit_per_episode=None,
+        episode_count=1,
+        samples_per_episode=None,
+        samples_per_hand_count=None,
+        sample_seed=42,
+        output_path=report_path,
+    )
+    loaded = load_projected_hand_label_report(report_path)
+    assert "episode-1" in loaded
+    assert len(loaded["episode-1"]) == 1
+    assert loaded["episode-1"][0].frame_index == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_schema_version",
+    [None, True, False, "1", 1.5, 0, -1, 2, 99],
+)
+def test_load_projected_hand_label_report_refuses_invalid_schema_version(
+    tmp_path: Path, invalid_schema_version: object
+) -> None:
+    report_path = tmp_path / "invalid_version.json"
+    payload: dict[str, object] = {
+        "label_type": PROJECTED_HAND_LABEL_TYPE,
+        "frames": [],
+    }
+    if invalid_schema_version is not None:
+        payload["schema_version"] = invalid_schema_version
+    report_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError) as exc_info:
+        load_projected_hand_label_report(report_path)
+
+    message = str(exc_info.value)
+    assert str(report_path) in message
+    assert "schema_version" in message
+    assert f"supported schema_version is {SCHEMA_VERSION}" in message
+
+
+@pytest.mark.parametrize(
+    "invalid_label_type",
+    [None, 1, True, ["projected-hand-joints"], {}, "unsupported-label-type", ""],
+)
+def test_load_projected_hand_label_report_refuses_invalid_label_type(
+    tmp_path: Path, invalid_label_type: object
+) -> None:
+    report_path = tmp_path / "invalid_type.json"
+    payload: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "frames": [],
+    }
+    if invalid_label_type is not None:
+        payload["label_type"] = invalid_label_type
+    report_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError) as exc_info:
+        load_projected_hand_label_report(report_path)
+
+    message = str(exc_info.value)
+    assert str(report_path) in message
+    assert "label_type" in message
+    assert f"supported label_type is {PROJECTED_HAND_LABEL_TYPE!r}" in message
 
 
 def test_pipeline_records_agreement_output_validity_and_frame_intervals() -> None:


### PR DESCRIPTION
Fixes #307.

## Summary

write_label_report records schema_version (1) and label_type (\\"projected-hand-joints\"\) in the saved label report envelope. However, load_projected_hand_label_report previously parsed the \rames\ array directly without validating the top-level envelope fields.

This change:
1. Validates that schema_version is an integer equal to SCHEMA_VERSION before parsing frame records.
2. Validates that label_type is a string equal to PROJECTED_HAND_LABEL_TYPE (\\"projected-hand-joints\"\) before parsing frame records.
3. Formats errors to name the report path, the invalid field, the value found, and the supported value.
4. Updates existing happy-path test fixtures to include the real envelope.
5. Adds boundary test parameterized coverage for missing, invalid type, older, and future schema versions and invalid label types.
6. Adds a full round-trip test from write_label_report through load_projected_hand_label_report.

## Verification

- uv run --locked --project examples/egosuite_evaluation ruff check examples/egosuite_evaluation
- uv run --locked --project examples/egosuite_evaluation ruff format --check examples/egosuite_evaluation
- uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . --platform linux examples/egosuite_evaluation (clean)
- uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests -k "label_report or round_trip" (18 passed)
