### PR TITLE
fix(lerobot): retain metadata chunk directories and query video windows across shards (fixes #293)

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -40,7 +40,7 @@ DEFAULT_REVISION = "main"
 DEFAULT_OUTPUT_DIR = Path("./data/lerobot_pusht")
 DEFAULT_CAMERA_KEY = "observation.image"
 
-CONVERTER_VERSION = "lerobot-converter-v3"
+CONVERTER_VERSION = "lerobot-converter-v4"
 PRESENTATION_TIMESTAMP_EPSILON_S = 0.050
 
 # Timestamp handling
@@ -357,7 +357,15 @@ def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _S
     entries = _hf_tree(dataset_source.repo_id, dataset_source.revision, "meta/episodes")
     for entry in entries:
         if entry.get("type") == "file" and entry["path"].endswith(".parquet"):
-            destination_path = episodes_metadata_directory / Path(entry["path"]).name
+            entry_path = entry["path"]
+            if entry_path.startswith("meta/episodes/"):
+                relative_entry_path = entry_path[len("meta/episodes/") :]
+            elif entry_path.startswith("meta/"):
+                relative_entry_path = entry_path[len("meta/") :]
+            else:
+                relative_entry_path = entry_path
+            destination_path = episodes_metadata_directory / relative_entry_path
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
             if not destination_path.exists():
                 _download_file(f"{dataset_base_url}/{entry['path']}", destination_path)
             episode_metadata_files.append(destination_path)
@@ -426,34 +434,39 @@ def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _S
                 f'"videos/{camera_key}/to_timestamp" as "vto_{camera_key}",',
             ]
         video_window_select_sql = "episode_index, " + " ".join(video_window_selectors).rstrip(",")
-        first_episode_metadata_file = str(episode_metadata_files[0]).replace("'", "''")
-        video_window_rows = connection.execute(
-            f"SELECT {video_window_select_sql} FROM read_parquet('{first_episode_metadata_file}')"
-        ).fetchall()
-        video_window_column_names = [
-            column_description[0] for column_description in connection.description
-        ]
-        for video_window_row in video_window_rows:
-            video_window_by_column = dict(
-                zip(video_window_column_names, video_window_row, strict=True)
-            )
-            episode_index = int(video_window_by_column["episode_index"])
-            video_windows_by_episode[episode_index] = {}
-            for camera_key in video_keys:
-                video_chunk_index = video_window_by_column.get(f"vc_{camera_key}")
-                video_file_index = video_window_by_column.get(f"vf_{camera_key}")
-                video_windows_by_episode[episode_index][camera_key] = {
-                    "chunk_index": (
-                        "" if video_chunk_index is None else str(video_chunk_index).split("/")[-1]
-                    ),
-                    "file_index": (
-                        "" if video_file_index is None else str(video_file_index).split("/")[-1]
-                    ),
-                    "from_timestamp": float(
-                        video_window_by_column.get(f"vfrom_{camera_key}") or 0.0
-                    ),
-                    "to_timestamp": float(video_window_by_column.get(f"vto_{camera_key}") or 0.0),
-                }
+        for episode_metadata_file in episode_metadata_files:
+            escaped_file = str(episode_metadata_file).replace("'", "''")
+            video_window_rows = connection.execute(
+                f"SELECT {video_window_select_sql} FROM read_parquet('{escaped_file}')"
+            ).fetchall()
+            video_window_column_names = [
+                column_description[0] for column_description in connection.description
+            ]
+            for video_window_row in video_window_rows:
+                video_window_by_column = dict(
+                    zip(video_window_column_names, video_window_row, strict=True)
+                )
+                episode_index = int(video_window_by_column["episode_index"])
+                video_windows_by_episode[episode_index] = {}
+                for camera_key in video_keys:
+                    video_chunk_index = video_window_by_column.get(f"vc_{camera_key}")
+                    video_file_index = video_window_by_column.get(f"vf_{camera_key}")
+                    video_windows_by_episode[episode_index][camera_key] = {
+                        "chunk_index": (
+                            ""
+                            if video_chunk_index is None
+                            else str(video_chunk_index).split("/")[-1]
+                        ),
+                        "file_index": (
+                            "" if video_file_index is None else str(video_file_index).split("/")[-1]
+                        ),
+                        "from_timestamp": float(
+                            video_window_by_column.get(f"vfrom_{camera_key}") or 0.0
+                        ),
+                        "to_timestamp": float(
+                            video_window_by_column.get(f"vto_{camera_key}") or 0.0
+                        ),
+                    }
         for episode_row in episode_rows:
             episode_row["video_windows"] = dict(
                 video_windows_by_episode.get(episode_row["episode_index"], {})

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -704,3 +704,157 @@ def test_info_json_accepts_normal_positive_fps(
     dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
     source_archive = prep._ensure_source_archive(dataset_source, tmp_path / "cache")
     assert source_archive["fps"] == 30
+
+
+def test_index_discovery_multi_shard_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multi-shard episode metadata with identical basenames in different chunk directories
+
+    must not collide and must attach video windows from all shards.
+    """
+    import duckdb
+
+    info = {
+        "fps": 30,
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {
+            "action": {"dtype": "float32", "shape": [6]},
+            "observation.state": {"dtype": "float32", "shape": [6]},
+            "observation.images.up": {"dtype": "video", "shape": [480, 640, 3]},
+            "timestamp": {"dtype": "float32", "shape": [1]},
+        },
+        "robot_type": "so101",
+    }
+    (tmp_path / "meta").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "meta" / "info.json").write_text(json.dumps(info))
+
+    conn = duckdb.connect()
+    ep_cols = [
+        "episode_index",
+        "length",
+        "data/chunk_index",
+        "data/file_index",
+        "dataset_from_index",
+        "dataset_to_index",
+        "videos/observation.images.up/chunk_index",
+        "videos/observation.images.up/file_index",
+        "videos/observation.images.up/from_timestamp",
+        "videos/observation.images.up/to_timestamp",
+        "tasks",
+    ]
+    ep_cols_q = ",".join(f'"{c}"' for c in ep_cols)
+
+    # Shard 0: episode 0
+    row_ep0 = [
+        0,
+        60,
+        "chunk-000",
+        "file-000",
+        0,
+        60,
+        "chunk-000",
+        "file-000",
+        0.0,
+        2.0,
+        "['task-0']",
+    ]
+    p0 = tmp_path / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    p0.parent.mkdir(parents=True, exist_ok=True)
+    vals_sql0 = (
+        "("
+        + ",".join(
+            f"'{v}'" if isinstance(v, str) and not v.startswith("[") else str(v) for v in row_ep0
+        )
+        + ")"
+    )
+    p0_sql = str(p0).replace("'", "''")
+    conn.execute(
+        f"COPY (SELECT * FROM (VALUES {vals_sql0}) AS t({ep_cols_q})) TO '{p0_sql}' (FORMAT parquet)"
+    )
+
+    # Shard 1: episode 1 (same basename file-000.parquet in chunk-001)
+    row_ep1 = [
+        1,
+        65,
+        "chunk-001",
+        "file-000",
+        0,
+        65,
+        "chunk-001",
+        "file-000",
+        0.0,
+        2.166667,
+        "['task-1']",
+    ]
+    p1 = tmp_path / "meta" / "episodes" / "chunk-001" / "file-000.parquet"
+    p1.parent.mkdir(parents=True, exist_ok=True)
+    vals_sql1 = (
+        "("
+        + ",".join(
+            f"'{v}'" if isinstance(v, str) and not v.startswith("[") else str(v) for v in row_ep1
+        )
+        + ")"
+    )
+    p1_sql = str(p1).replace("'", "''")
+    conn.execute(
+        f"COPY (SELECT * FROM (VALUES {vals_sql1}) AS t({ep_cols_q})) TO '{p1_sql}' (FORMAT parquet)"
+    )
+
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, rev: {"sha": rev, "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_fetch_info_json", lambda repo, rev, cache: info)
+    monkeypatch.setattr(
+        prep,
+        "_hf_tree",
+        lambda repo, rev, path: (
+            [
+                {"path": "meta/episodes/chunk-000/file-000.parquet", "type": "file"},
+                {"path": "meta/episodes/chunk-001/file-000.parquet", "type": "file"},
+            ]
+            if "episodes" in path
+            else [{"path": "meta/info.json", "type": "file"}]
+        ),
+    )
+
+    downloaded_paths: list[Path] = []
+
+    def fake_dl(url: str, dest: Path, **kw: object) -> None:
+        import shutil
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        downloaded_paths.append(dest)
+        if "chunk-000" in url:
+            shutil.copy(str(p0), dest)
+        elif "chunk-001" in url:
+            shutil.copy(str(p1), dest)
+
+    monkeypatch.setattr(prep, "_download_file", fake_dl)
+
+    cache_dir = tmp_path / "cache"
+    ds = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
+    found = prep._ensure_source_archive(ds, cache_dir)
+
+    # Verify distinct downloaded destinations
+    assert len(downloaded_paths) == 2
+    assert downloaded_paths[0] != downloaded_paths[1]
+    assert "chunk-000" in str(downloaded_paths[0])
+    assert "chunk-001" in str(downloaded_paths[1])
+
+    # Verify episode metadata from all shards
+    assert len(found["episodes"]) == 2
+    assert found["episodes"][0]["episode_index"] == 0
+    assert found["episodes"][0]["task"] == "task-0"
+    assert found["episodes"][0]["length"] == 60
+    assert found["episodes"][0]["video_windows"]["observation.images.up"][
+        "to_timestamp"
+    ] == pytest.approx(2.0)
+
+    assert found["episodes"][1]["episode_index"] == 1
+    assert found["episodes"][1]["task"] == "task-1"
+    assert found["episodes"][1]["length"] == 65
+    assert found["episodes"][1]["video_windows"]["observation.images.up"][
+        "to_timestamp"
+    ] == pytest.approx(2.166667)


### PR DESCRIPTION
Fixes #293.

## Summary

When LeRobot Dataset v3 episode metadata is split across chunk subdirectories under meta/episodes/ (e.g. meta/episodes/chunk-000/file-000.parquet and meta/episodes/chunk-001/file-000.parquet), the importer previously flattened each file to its basename in _lerobot_cache/meta/episodes/, causing collisions and skipped downloads. Furthermore, video window columns and rows were only queried from episode_metadata_files[0], dropping video windows for episodes in later shards.

This change:
1. Preserves chunk/relative subdirectory paths under meta/episodes/ when downloading metadata parquet files so files sharing a basename in different chunk directories never collide.
2. Loops across all episode_metadata_files when querying and indexing video window rows for all episodes and cameras.
3. Bumps CONVERTER_VERSION to \"lerobot-converter-v4\".
4. Adds a synthetic multi-shard regression test 	est_index_discovery_multi_shard_metadata with two shards sharing ile-000.parquet in different chunk folders, proving distinct downloads and full video window extraction.

## Verification

- uv run ruff check (clean)
- uv run ty check --platform linux (clean)
- uv run pytest -q tests/test_lerobot_converter.py -k test_index_discovery_multi_shard_metadata (1 passed)
