### PR TITLE
fix(video): refuse B-frame streams whose reorder tail a remux drops

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -153,6 +153,14 @@ A file claiming this convention must satisfy, in increasing strictness:
 4. **Video constraints**: every `foxglove.CompressedVideo` message is one Annex B access unit beginning with an AUD; every IDR access unit contains SPS and PPS; no B-frames; `format="h264"`.
 5. **Stamps**: `provenance/v1` present with `schema_version` and `pipeline_version`.
 
+The no-B-frame constraint is enforced by refusal at two boundaries, because a `-c:v copy` remux
+to MP4 cannot represent the reorder tail: the trailing B frames are silently undecodable from
+the muxed file (measured in [#250](https://github.com/Hebbian-Robotics/hflow/issues/250): 303
+samples in, 301 decoded). The transform refuses pass-through video that carries B-frames, and
+the MP4 remux behind `Episode.video` refuses any B-frame payload outright, with an error naming
+the observed reorder depth and the frames at risk. `hflow doctor` still does not classify
+picture coding types (below), so a clean report does not prove this constraint; the refusals do.
+
 `hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,

--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -509,6 +509,14 @@ def _validate_passthrough_video_payload(
             f"pass-through video topic {topic!r} starts mid-GOP: its first message "
             "is not a keyframe, so the stream is not decodable from the start"
         )
+    coding_types = video_module.scan_picture_coding_types(message.data)
+    if coding_types.b_picture_count:
+        raise SourceNotConforming(
+            f"pass-through video topic {topic!r} carries B-frames (reorder depth "
+            f"{coding_types.reorder_depth}); the canonical convention requires "
+            "bframes=0 because a -c:v copy MP4 remux drops the reorder tail "
+            "(measured 301 of 303 in #250) -- re-encode upstream with bframes=0"
+        )
 
 
 def _decode_compressed_images(

--- a/src/hflow/video.py
+++ b/src/hflow/video.py
@@ -274,6 +274,34 @@ def _decode_unsigned_exp_golomb(rbsp: bytes) -> int:
     return (1 << leading_zero_bits) - 1 + suffix
 
 
+def _decode_unsigned_exp_golomb_at(rbsp: bytes, bit_offset: int) -> tuple[int, int] | None:
+    """Offset-aware form of :func:`_decode_unsigned_exp_golomb`.
+
+    Returns ``(value, next_bit_offset)``, or ``None`` when the value is
+    incomplete or truncated. Returning ``None`` instead of raising lets
+    callers count unparseable slice headers and refuse fail-closed rather
+    than guess a picture type.
+    """
+    bit_count = len(rbsp) * 8
+    leading_zero_bits = 0
+    while True:
+        if bit_offset + leading_zero_bits >= bit_count:
+            return None
+        byte = rbsp[(bit_offset + leading_zero_bits) // 8]
+        if (byte >> (7 - (bit_offset + leading_zero_bits) % 8)) & 1:
+            break
+        leading_zero_bits += 1
+    suffix_start = bit_offset + leading_zero_bits + 1
+    suffix_end = suffix_start + leading_zero_bits
+    if suffix_end > bit_count:
+        return None
+    suffix = 0
+    for bit_position in range(suffix_start, suffix_end):
+        byte = rbsp[bit_position // 8]
+        suffix = (suffix << 1) | ((byte >> (7 - bit_position % 8)) & 1)
+    return (1 << leading_zero_bits) - 1 + suffix, suffix_end
+
+
 def count_h264_pictures(stream: bytes) -> int:
     """Count coded pictures in one Annex B payload from its slice headers.
 
@@ -296,6 +324,104 @@ def count_h264_pictures(stream: bytes) -> int:
         if _decode_unsigned_exp_golomb(rbsp) == 0:
             picture_count += 1
     return picture_count
+
+
+def _slice_header_fields(rbsp: bytes) -> tuple[int, int] | None:
+    """Return ``(first_mb_in_slice, slice_type)`` from a slice header RBSP.
+
+    Both fields are unsigned Exp-Golomb values per the H.264 slice header
+    syntax. Returning ``None`` when either is incomplete or truncated lets
+    callers treat an unparseable slice header fail-closed instead of guessing
+    a picture type.
+    """
+    first_field = _decode_unsigned_exp_golomb_at(rbsp, 0)
+    if first_field is None:
+        return None
+    slice_type_field = _decode_unsigned_exp_golomb_at(rbsp, first_field[1])
+    if slice_type_field is None:
+        return None
+    return first_field[0], slice_type_field[0]
+
+
+@dataclass(frozen=True)
+class PictureCodingScan:
+    """Picture coding-type evidence parsed from one Annex B payload's slice headers.
+
+    A picture is B when any of its slices declares ``slice_type`` B (codes 1
+    and 6, H.264 spec Table 7-6; 0/5 are P and 2/7 are I). Pictures group on
+    ``first_mb_in_slice == 0``, exactly as :func:`count_h264_pictures` groups
+    them.
+    """
+
+    picture_count: int
+    b_picture_count: int
+    # A B picture cannot be presented before the next non-B picture arrives,
+    # so a run of D consecutive B pictures needs D frames of decoder reorder
+    # buffering: the longest such run is the reorder depth this stream needs.
+    reorder_depth: int
+    # The B pictures after the last non-B picture. With no anchor behind them,
+    # a ``-c:v copy`` MP4 remux drops exactly this tail at end of stream
+    # (#250 measured 303 samples in, 301 decoded).
+    trailing_b_pictures: int
+
+
+def scan_picture_coding_types(stream: bytes) -> PictureCodingScan:
+    """Classify the pictures in one Annex B payload as B or not B.
+
+    Detection reads slice headers, not AUD ``primary_pic_type`` values: the
+    AUD repair path (:func:`ensure_access_unit_delimiter`) deliberately writes
+    the permissive type-7 delimiter without knowing the real picture type, so
+    only slice headers tell the truth. Data partitions B/C (NAL types 3/4)
+    carry no slice header of their own and are skipped, as in
+    :func:`count_h264_pictures`. A slice header that cannot be parsed is
+    fail-closed as an error: an uncountable slice means the stream's B-frame
+    freedom cannot be proven.
+    """
+    nal_offsets_and_types = _annex_b_nal_offsets_and_types(stream)
+    picture_is_b: list[bool] = []
+    for nal_index, (nal_start_offset, nal_type) in enumerate(nal_offsets_and_types):
+        if nal_type not in _SLICE_HEADER_NAL_TYPES:
+            continue
+        nal_end_offset = (
+            nal_offsets_and_types[nal_index + 1][0]
+            if nal_index + 1 < len(nal_offsets_and_types)
+            else len(stream)
+        )
+        nal_header_offset = _nal_header_offset(stream, nal_start_offset)
+        rbsp = _remove_emulation_prevention_bytes(stream[nal_header_offset + 1 : nal_end_offset])
+        slice_header_fields = _slice_header_fields(rbsp)
+        if slice_header_fields is None:
+            raise ValueError(
+                "a slice header is incomplete or truncated; picture coding types "
+                "cannot be classified"
+            )
+        first_mb_in_slice, slice_type_code = slice_header_fields
+        slice_is_b = slice_type_code % 5 == 1
+        if first_mb_in_slice == 0:
+            picture_is_b.append(slice_is_b)
+        elif picture_is_b:
+            picture_is_b[-1] = picture_is_b[-1] or slice_is_b
+        else:
+            raise ValueError(
+                "a slice header claims first_mb_in_slice > 0 before any picture starts; "
+                "picture coding types cannot be classified"
+            )
+    reorder_depth = 0
+    current_run = 0
+    for picture_is_b_flag in picture_is_b:
+        current_run = current_run + 1 if picture_is_b_flag else 0
+        reorder_depth = max(reorder_depth, current_run)
+    trailing_b_pictures = 0
+    for picture_is_b_flag in reversed(picture_is_b):
+        if not picture_is_b_flag:
+            break
+        trailing_b_pictures += 1
+    return PictureCodingScan(
+        picture_count=len(picture_is_b),
+        b_picture_count=sum(picture_is_b),
+        reorder_depth=reorder_depth,
+        trailing_b_pictures=trailing_b_pictures,
+    )
 
 
 def ensure_access_unit_delimiter(access_unit: bytes) -> bytes:
@@ -400,8 +526,25 @@ def write_access_units_to_mp4(
     ``ffmpeg -r {fps} -f h264 -i - -c:v copy -movflags +faststart``. The
     resulting file plays in anything; frame timing is constant-rate ``fps``
     (callers needing exact per-frame log times use the message timestamps).
+
+    Raises ``ValueError`` on a stream carrying B-frames: a ``-c:v copy`` remux
+    cannot represent the reorder tail, and the trailing frames are silently
+    undecodable from the muxed file (#250 measured 303 samples in, 301
+    decoded). Canonical video requires ``bframes=0`` (docs/FORMAT.md, "The
+    H.264 bitstream constraints").
     """
     annex_b_stream = b"".join(units)
+    coding_types = scan_picture_coding_types(annex_b_stream)
+    if coding_types.b_picture_count:
+        raise ValueError(
+            f"cannot remux to MP4 without dropping frames: the stream carries "
+            f"{coding_types.b_picture_count} B picture(s) across "
+            f"{coding_types.picture_count} (reorder depth "
+            f"{coding_types.reorder_depth}); a -c:v copy remux drops the reorder "
+            f"tail, putting the last {coding_types.trailing_b_pictures} frame(s) at "
+            "risk (measured 301 of 303 in #250). Canonical video requires "
+            "bframes=0; re-encode upstream -- see docs/FORMAT.md item 4"
+        )
     # Write to a sibling temp path and replace atomically: callers cache on
     # bare file existence, so the final path must never hold a partial MP4.
     temporary_output = output.with_name(output.name + ".tmp")

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -41,6 +41,12 @@ KEYFRAME_WITHOUT_AUD = b"".join(
     for nal_type in (0x67, 0x68, 0x65)
 )
 NON_KEYFRAME_WITHOUT_AUD = ANNEX_B_START_CODE + b"\x41\x80payload"
+# A non-IDR slice whose slice header parses as slice_type 1 (B): first_mb_in_slice
+# ue(0) is bit '1', slice_type ue(1) is bits '010'.
+B_FRAME_ACCESS_UNIT = b"".join(
+    ANNEX_B_START_CODE + bytes([nal_type]) + (b"\xa0payload" if nal_type == 0x41 else b"payload")
+    for nal_type in (0x09, 0x41)
+)
 ROS2_COMPRESSED_VIDEO_SCHEMA = "\n".join(
     [
         "builtin_interfaces/Time timestamp",
@@ -159,6 +165,17 @@ def _write_passthrough_video_source(
             payloads_by_topic.setdefault(topic, []).append(payload)
         writer.finish()
     return payloads_by_topic
+
+
+def test_transform_rejects_passthrough_video_carrying_b_frames(tmp_path: Path) -> None:
+    source = tmp_path / "bframe.mcap"
+    _write_passthrough_video_source(
+        source,
+        [("/cam", 1, KEYFRAME_ACCESS_UNIT), ("/cam", 2, B_FRAME_ACCESS_UNIT)],
+    )
+
+    with pytest.raises(SourceNotConforming, match=r"/cam.*B-frames"):
+        write_canonical_episode(source, tmp_path / "out.mcap")
 
 
 def test_transform_rejects_each_passthrough_video_channel_starting_mid_gop(

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -9,9 +9,11 @@ import pytest
 from hflow.ffmpeg import ffmpeg_path, ffprobe_path
 from hflow.video import (
     AccessUnit,
+    PictureCodingScan,
     VideoEncodeError,
     encode_images_to_h264,
     ensure_access_unit_delimiter,
+    scan_picture_coding_types,
     split_annex_b_stream,
     write_access_units_to_mp4,
 )
@@ -123,6 +125,110 @@ def test_remux_to_mp4_preserves_every_frame(
     # be confused with a copy on this hardware.
     assert stream_fields["profile"] not in ("", "unknown")
     assert remux_elapsed_seconds < 5.0
+
+
+@pytest.fixture(scope="module")
+def b_frame_stream(jpeg_frames: list[bytes]) -> bytes:
+    """The same frames re-encoded with libx264 defaults (B-frames enabled)."""
+    command: list[str] = [
+        str(ffmpeg_path()),
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "image2pipe",
+        "-framerate",
+        str(FPS),
+        "-c:v",
+        "mjpeg",
+        "-i",
+        "-",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-pix_fmt",
+        "yuv420p",
+        "-x264-params",
+        "bframes=3:b_adapt=0",
+        "-f",
+        "h264",
+        "-",
+    ]
+    completed = subprocess.run(command, input=b"".join(jpeg_frames), capture_output=True)
+    assert completed.returncode == 0, completed.stderr.decode()
+    return completed.stdout
+
+
+def _slice_header_rbsp(first_mb_in_slice: int, slice_type_code: int) -> bytes:
+    """Pack first_mb_in_slice and slice_type as consecutive Exp-Golomb values."""
+
+    def exp_golomb_bits(value: int) -> str:
+        return "0" * ((value + 1).bit_length() - 1) + bin(value + 1)[2:]
+
+    bits = exp_golomb_bits(first_mb_in_slice) + exp_golomb_bits(slice_type_code) + "1"
+    bits += "0" * (-len(bits) % 8)
+    return bytes(int(bits[index : index + 8], 2) for index in range(0, len(bits), 8))
+
+
+def test_scan_reports_b_pictures_in_a_real_b_frame_stream(b_frame_stream: bytes) -> None:
+    scan = scan_picture_coding_types(b_frame_stream)
+
+    assert scan.picture_count == FRAME_COUNT
+    assert scan.b_picture_count > 0
+    assert scan.reorder_depth >= 1
+
+
+def test_scan_reports_no_b_pictures_for_the_canonical_stream(
+    encoded_units: list[AccessUnit],
+) -> None:
+    canonical_stream = b"".join(unit.data for unit in encoded_units)
+
+    scan = scan_picture_coding_types(canonical_stream)
+
+    assert scan == PictureCodingScan(
+        picture_count=FRAME_COUNT, b_picture_count=0, reorder_depth=0, trailing_b_pictures=0
+    )
+
+
+def test_scan_measures_reorder_depth_and_trailing_tail() -> None:
+    non_idr_nal = b"\x00\x00\x00\x01\x41"
+    stream = b"".join(
+        non_idr_nal + _slice_header_rbsp(0, slice_type_code)
+        for slice_type_code in (0, 1, 1, 0, 1)  # P, B, B, P, B in decode order
+    )
+
+    scan = scan_picture_coding_types(stream)
+
+    assert scan == PictureCodingScan(
+        picture_count=5, b_picture_count=3, reorder_depth=2, trailing_b_pictures=1
+    )
+
+
+def test_scan_refuses_an_unparseable_slice_header() -> None:
+    # An all-zero RBSP never terminates the first Exp-Golomb value, so the
+    # slice header cannot be classified and the scan must fail closed.
+    unparseable_slice = b"\x00\x00\x00\x01\x41\x00"
+
+    with pytest.raises(ValueError, match="cannot be classified"):
+        scan_picture_coding_types(unparseable_slice)
+
+
+def test_remux_refuses_a_b_frame_stream_naming_the_tail(
+    b_frame_stream: bytes, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "bframe.mp4"
+
+    with pytest.raises(ValueError, match="reorder depth") as error:
+        write_access_units_to_mp4((b_frame_stream,), fps=FPS, output=output_path)
+
+    message = str(error.value)
+    assert "B picture" in message
+    assert "at risk" in message
+    assert "docs/FORMAT.md" in message
+    # The refusal fires before ffmpeg runs, so no partial MP4 is left behind.
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
 
 
 def test_split_rejects_garbage_without_aud() -> None:


### PR DESCRIPTION
Supersedes #341, which the pr-limit workflow auto-closed while #338 was still open; same branch, same commit, nothing changed.

Implements option 2 from #255. A `-c:v copy` remux of a raw Annex B stream to MP4 cannot represent the B-frame reorder tail: the container holds every sample and the decoder emits fewer. #250 measured it at 303 samples in, 301 decoded, with no flag combination restoring the tail.

`scan_picture_coding_types` classifies each picture from its slice headers: `first_mb_in_slice` then `slice_type`, both Exp-Golomb. Codes 1 and 6 name B slices. It reports the B-picture count, the longest consecutive B run (the reorder depth the stream needs), and the trailing B run (the frames a remux drops). Detection reads slice headers rather than AUD primary_pic_type, because the AUD repair path deliberately writes the permissive type-7 delimiter without knowing the real picture type. An unparseable slice header fails closed.

`write_access_units_to_mp4` refuses a B-frame payload with an error naming the depth and the frames at risk. The transform refuses pass-through video carrying B-frames, alongside its other canonical-constraint refusals. docs/FORMAT.md documents both.

Streams without B-frames are untouched: the canonical fixture scans to zero B pictures and the remux path is unchanged. SPS VUI max_num_reorder_frames was deliberately not used: VUI parsing is a larger surface and the slice-header evidence is sufficient and local.

All five commands ran in WSL2 per the fcntl requirement. Lockfile-pinned ruff, ty, and pytest. Full suite: 1347 passed, 6 skipped.

Closes #255.