### PR TITLE
Catalog UI shutdown must not auto-install the ui extension to call stop_ui_server()

### DIFF
--- a/src/hflow/catalog_ui.py
+++ b/src/hflow/catalog_ui.py
@@ -86,11 +86,22 @@ def _start_duckdb_ui_server(catalog_connection: duckdb.DuckDBPyConnection, port:
         ) from error
 
 
+def _ui_extension_is_loaded(catalog_connection: duckdb.DuckDBPyConnection) -> bool:
+    row = catalog_connection.execute(
+        "SELECT count(*) FROM duckdb_extensions() WHERE extension_name = 'ui' AND loaded"
+    ).fetchone()
+    return row is not None and int(row[0]) > 0
+
+
 def _stop_duckdb_ui_server(
     catalog_connection: duckdb.DuckDBPyConnection, server_started: bool
 ) -> None:
     try:
-        if server_started:
+        # stop_ui_server only exists once the ui extension is loaded. Calling it
+        # without the extension makes DuckDB auto-install the extension from the
+        # network -- seconds on a slow connection, and pointless: there is no
+        # server to stop if the extension was never loaded.
+        if server_started and _ui_extension_is_loaded(catalog_connection):
             catalog_connection.execute("CALL stop_ui_server()")
     except duckdb.Error:
         # The process is already leaving. A server that stopped independently

--- a/tests/test_catalog_ui.py
+++ b/tests/test_catalog_ui.py
@@ -123,6 +123,100 @@ def test_catalog_ui_refuses_a_port_of_the_wrong_type(
         replace(settings, port=port)
 
 
+class _RecordingCatalogConnection:
+    """DuckDB connection proxy that records every statement it executes."""
+
+    def __init__(self, inner: duckdb.DuckDBPyConnection) -> None:
+        self._inner = inner
+        self.executed_statements: list[str] = []
+        self.closed = False
+
+    def execute(self, sql: str, *parameters: object) -> object:
+        self.executed_statements.append(sql)
+        return self._inner.execute(sql, *parameters)
+
+    def close(self) -> None:
+        self.closed = True
+        self._inner.close()
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+
+def _serve_until_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ui_extension_loaded: bool,
+) -> _RecordingCatalogConnection:
+    shutdown_event = Event()
+    server_started_event = Event()
+    connections: list[_RecordingCatalogConnection] = []
+    background_failures: list[BaseException] = []
+
+    real_open_catalog_connection = catalog_ui.open_catalog_connection
+
+    def record_server_start(catalog_connection: duckdb.DuckDBPyConnection, port: int) -> None:
+        assert port == catalog_ui.DEFAULT_CATALOG_UI_PORT
+        server_started_event.set()
+
+    def open_recorded_connection(catalog_root: Path) -> _RecordingCatalogConnection:
+        connection = _RecordingCatalogConnection(real_open_catalog_connection(catalog_root))
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(catalog_ui, "open_catalog_connection", open_recorded_connection)
+    monkeypatch.setattr(catalog_ui, "_start_duckdb_ui_server", record_server_start)
+    monkeypatch.setattr(
+        catalog_ui,
+        "_ui_extension_is_loaded",
+        lambda _catalog_connection: ui_extension_loaded,
+    )
+
+    def run_catalog_ui() -> None:
+        try:
+            catalog_ui.serve_catalog_ui(
+                catalog_ui.CatalogUiSettings(
+                    catalog_root=tmp_path / "catalog",
+                    open_browser=False,
+                    catalog_poll_interval_seconds=0.01,
+                ),
+                shutdown_event=shutdown_event,
+            )
+        except BaseException as error:
+            background_failures.append(error)
+
+    catalog_ui_thread = Thread(target=run_catalog_ui)
+    catalog_ui_thread.start()
+    try:
+        assert server_started_event.wait(timeout=2)
+    finally:
+        shutdown_event.set()
+        catalog_ui_thread.join(timeout=2)
+
+    assert not catalog_ui_thread.is_alive()
+    assert background_failures == []
+    (connection,) = connections
+    return connection
+
+
+def test_catalog_ui_shutdown_does_not_stop_a_server_the_ui_extension_never_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _serve_until_shutdown(tmp_path, monkeypatch, ui_extension_loaded=False)
+
+    assert "CALL stop_ui_server()" not in connection.executed_statements
+    assert connection.closed
+
+
+def test_catalog_ui_shutdown_stops_the_server_when_the_ui_extension_is_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _serve_until_shutdown(tmp_path, monkeypatch, ui_extension_loaded=True)
+
+    assert "CALL stop_ui_server()" in connection.executed_statements
+    assert connection.closed
+
+
 @pytest.mark.parametrize("port", [1, 65535])
 def test_catalog_ui_accepts_port_boundaries(tmp_path: Path, port: int) -> None:
     settings = catalog_ui.CatalogUiSettings(catalog_root=tmp_path / "catalog", port=port)


### PR DESCRIPTION
Closes #336

## What and why

`serve_catalog_ui` sets `server_started = True` as soon as `_start_duckdb_ui_server` returns, and shutdown calls `stop_ui_server()` on that flag alone. `stop_ui_server()` is a function the `ui` extension provides — calling it on a connection that never loaded the extension makes DuckDB **auto-install the extension from the network at shutdown**, to run what is a no-op: there is no server to stop if the extension was never loaded.

I measured the cost with a cold extension directory (`extension_directory` pointed at an empty dir):

```
before call: ('ui', False, False)
stop_ui_server ok
elapsed: 3.16s
after call: ('ui', True, True)
```

That network fetch inside a teardown that another thread waits on with a fixed timeout is almost certainly the flaky `test_catalog_ui` timing failure three contributors reported on 2026-08-31 (#326, #327, #328) — `tests/test_catalog_ui.py` stubs `_start_duckdb_ui_server`, so the extension never loads, but `server_started` is still `True` and teardown calls `stop_ui_server()` anyway.

## The fix

Guard the call on the extension actually being loaded on that connection:

```python
def _ui_extension_is_loaded(catalog_connection: duckdb.DuckDBPyConnection) -> bool:
    row = catalog_connection.execute(
        "SELECT count(*) FROM duckdb_extensions() WHERE extension_name = 'ui' AND loaded"
    ).fetchone()
    return row is not None and int(row[0]) > 0
```

and gate `stop_ui_server()` on `server_started and _ui_extension_is_loaded(...)`. Production is unchanged: the real starter runs `INSTALL ui` / `LOAD ui` before the server starts, so the loaded check passes and the stop call still happens. A connection that never loaded the extension now closes directly.

## DoD coverage

1. **Shutdown does not call `stop_ui_server()` when `ui` is not loaded** — `test_catalog_ui_shutdown_does_not_stop_a_server_the_ui_extension_never_loaded` pins it by recording every statement executed on the connection (per the issue: recording statements is enough; DuckDB's install behavior is not the point).
2. **A session whose `ui` extension is loaded still stops its server** — `test_catalog_ui_shutdown_stops_the_server_when_the_ui_extension_is_loaded` pins the stop call on the loaded branch, and that the connection still closes.
3. Existing catalog UI startup, port-conflict, and refresh behavior is untouched — the full existing suite passes unchanged.

## Validation

```
uv sync --locked
uv run ruff check        # All checks passed!
uv run ruff format       # (check) clean
uv run ty check          # only the pre-existing cv2 optional-import diagnostic
uv run pytest -q tests/test_catalog_ui.py   # 22 passed
```

Found by me while working on #291; the reachability trace (stubbed starter → `server_started = True` → network fetch in teardown) is from the issue.