### PR TITLE
refactor(app): group sync reuse witness fields

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -253,10 +253,24 @@ class _TransformKind(StrEnum):
 
 @dataclass(frozen=True)
 class _SyncReuseWitness:
-    """Proof that a canonical can be safely reused by sync."""
+    """Enough to decide that re-running sync would rewrite byte-identical output.
 
+    Complete or absent: a partial witness cannot prove that re-running sync
+    would reproduce the existing canonical, so the parser drops the whole
+    group rather than letting the surviving fields answer for the missing one.
+    """
+
+    # Which source BYTES produced the canonical. Content, never size+mtime:
+    # this repo identifies by content everywhere, and a same-length rewrite
+    # or a preserved mtime would defeat the weaker test silently.
     source_digest: str
+    # The transform is stamped with an ffmpeg version that does NOT reach
+    # pipeline_version, and different builds genuinely encode differently.
     ffmpeg_version: str
+    # An @app.transform override is contractually required to end in
+    # write_canonical_episode, so it stamps the SAME pipeline_version the
+    # default transform would: without this, REMOVING an override would reuse
+    # a canonical the current pipeline cannot produce.
     transform_kind: _TransformKind
 
 
@@ -264,8 +278,11 @@ class _SyncReuseWitness:
 class _SyncCompletion:
     """Proof that sync completed for one source path and canonical version.
 
-    ``reuse_witness`` is complete or absent: a partial witness cannot prove
-    that re-running sync would reproduce the existing canonical.
+    ``reuse_witness`` is optional because markers written before it existed
+    are still valid proof for the non-sync stages, which is all those stages
+    ever asked of them. A witness-less marker simply never satisfies the reuse
+    gate: one re-transcode rewrites it in the current shape, and that is the
+    whole migration.
     """
 
     source_path: str

--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -252,33 +252,26 @@ class _TransformKind(StrEnum):
 
 
 @dataclass(frozen=True)
+class _SyncReuseWitness:
+    """Proof that a canonical can be safely reused by sync."""
+
+    source_digest: str
+    ffmpeg_version: str
+    transform_kind: _TransformKind
+
+
+@dataclass(frozen=True)
 class _SyncCompletion:
     """Proof that sync completed for one source path and canonical version.
 
-    The last three fields are the *reuse witness*: enough to decide that
-    re-running sync would rewrite byte-identical output, so it can be skipped.
-    They are optional because markers written before they existed are still
-    valid proof for the non-sync stages, which is all those stages ever asked
-    of them. A witness-less marker simply never satisfies the reuse gate: one
-    re-transcode rewrites it in the current shape, and that is the whole
-    migration.
+    ``reuse_witness`` is complete or absent: a partial witness cannot prove
+    that re-running sync would reproduce the existing canonical.
     """
 
     source_path: str
     schema_version: str
     pipeline_version: str
-    # Which source BYTES produced the canonical. Content, never size+mtime:
-    # this repo identifies by content everywhere, and a same-length rewrite
-    # or a preserved mtime would defeat the weaker test silently.
-    source_digest: str | None = None
-    # The transform is stamped with an ffmpeg version that does NOT reach
-    # pipeline_version, and different builds genuinely encode differently.
-    ffmpeg_version: str | None = None
-    # An @app.transform override is contractually required to end in
-    # write_canonical_episode, so it stamps the SAME pipeline_version the
-    # default transform would: without this, REMOVING an override would reuse
-    # a canonical the current pipeline cannot produce.
-    transform_kind: _TransformKind | None = None
+    reuse_witness: _SyncReuseWitness | None = None
 
 
 def _source_identity(source_reference: Path | str, storage_root: StorageRoot) -> str:
@@ -338,10 +331,14 @@ def _write_sync_completion_marker(marker_path: Path, completion: _SyncCompletion
         "schema_version": completion.schema_version,
         "pipeline_version": completion.pipeline_version,
     }
-    for witness_field in ("source_digest", "ffmpeg_version", "transform_kind"):
-        witness_value = getattr(completion, witness_field)
-        if witness_value is not None:
-            marker_payload[witness_field] = witness_value
+    if completion.reuse_witness is not None:
+        marker_payload.update(
+            {
+                "source_digest": completion.reuse_witness.source_digest,
+                "ffmpeg_version": completion.reuse_witness.ffmpeg_version,
+                "transform_kind": completion.reuse_witness.transform_kind,
+            }
+        )
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -381,29 +378,36 @@ def _read_sync_completion_marker(marker_path: Path) -> _SyncCompletion:
                 f"{field_name!r} must be a non-empty string"
             )
         required_values[field_name] = field_value
-    # Parsed leniently, on purpose: a missing or malformed witness field means
-    # "cannot prove reuse is safe", which the gate already treats as a miss.
-    # Requiring them would make every pre-witness marker unreadable and break
-    # the non-sync stages, which never needed a witness at all.
-    optional_values = {
-        field_name: value
-        for field_name in ("source_digest", "ffmpeg_version")
-        if isinstance(value := marker_payload.get(field_name), str) and value
-    }
+    # Parsed leniently, on purpose: a missing, partial, malformed, or future
+    # witness means "cannot prove reuse is safe", which the gate treats as a
+    # miss. Keeping the basic marker readable preserves legacy non-sync stages.
+    source_digest = marker_payload.get("source_digest")
+    ffmpeg_version = marker_payload.get("ffmpeg_version")
     raw_transform_kind = marker_payload.get("transform_kind")
-    transform_kind: _TransformKind | None = None
-    if isinstance(raw_transform_kind, str) and raw_transform_kind:
+    reuse_witness: _SyncReuseWitness | None = None
+    if (
+        isinstance(source_digest, str)
+        and source_digest
+        and isinstance(ffmpeg_version, str)
+        and ffmpeg_version
+        and isinstance(raw_transform_kind, str)
+        and raw_transform_kind
+    ):
         try:
             transform_kind = _TransformKind(raw_transform_kind)
         except ValueError:
             transform_kind = None
+        if transform_kind is not None:
+            reuse_witness = _SyncReuseWitness(
+                source_digest=source_digest,
+                ffmpeg_version=ffmpeg_version,
+                transform_kind=transform_kind,
+            )
     return _SyncCompletion(
         source_path=required_values["source_path"],
         schema_version=required_values["schema_version"],
         pipeline_version=required_values["pipeline_version"],
-        source_digest=optional_values.get("source_digest"),
-        ffmpeg_version=optional_values.get("ffmpeg_version"),
-        transform_kind=transform_kind,
+        reuse_witness=reuse_witness,
     )
 
 
@@ -1319,12 +1323,13 @@ class App:
             completion = _read_sync_completion_marker(marker_path)
         except (FileNotFoundError, ValueError, OSError):
             return None
-        if completion.transform_kind is not _TransformKind.DEFAULT:
+        witness = completion.reuse_witness
+        if witness is None or witness.transform_kind is not _TransformKind.DEFAULT:
             return None
         if completion.source_path != source_identifier:
             # Two sources can share a run directory when output_dir= names one.
             return None
-        if completion.source_digest != source_digest:
+        if witness.source_digest != source_digest:
             return None
         if completion.schema_version != EPISODE_FORMAT_VERSION:
             return None
@@ -1353,7 +1358,7 @@ class App:
             or canonical_stamps.pipeline_version != completion.pipeline_version
         ):
             return None
-        if canonical_stamps.ffmpeg_version != completion.ffmpeg_version:
+        if canonical_stamps.ffmpeg_version != witness.ffmpeg_version:
             return None
         if canonical_stamps.ffmpeg_version != FFMPEG_VERSION_NOT_USED:
             # Only now, when the recording demonstrably has video, is it worth
@@ -2305,6 +2310,7 @@ class App:
             # whole file (hundreds of megabytes) to store the bytes already
             # there -- and rewrite a marker that is still true.
             if Stage.SYNC in enabled_stages and not reused_canonical:
+                assert source_digest is not None
                 canonical_uri = run_storage_root.publish(canonical_path, canonical_file_name)
                 _write_sync_completion_marker(
                     sync_completion_marker_path,
@@ -2312,12 +2318,14 @@ class App:
                         source_path=source_identifier,
                         schema_version=stamps.schema_version,
                         pipeline_version=stamps.pipeline_version,
-                        source_digest=source_digest,
-                        ffmpeg_version=stamps.ffmpeg_version,
-                        transform_kind=(
-                            _TransformKind.OVERRIDE
-                            if self.transform_override is not None
-                            else _TransformKind.DEFAULT
+                        reuse_witness=_SyncReuseWitness(
+                            source_digest=source_digest,
+                            ffmpeg_version=stamps.ffmpeg_version,
+                            transform_kind=(
+                                _TransformKind.OVERRIDE
+                                if self.transform_override is not None
+                                else _TransformKind.DEFAULT
+                            ),
                         ),
                     ),
                 )

--- a/tests/test_sync_reuse.py
+++ b/tests/test_sync_reuse.py
@@ -144,6 +144,41 @@ def test_a_marker_without_a_witness_transcodes_once_and_gains_one(tmp_path: Path
 
 
 @pytest.mark.parametrize(
+    "present_fields",
+    [
+        ("source_digest",),
+        ("ffmpeg_version",),
+        ("transform_kind",),
+        ("source_digest", "ffmpeg_version"),
+        ("source_digest", "transform_kind"),
+        ("ffmpeg_version", "transform_kind"),
+    ],
+)
+def test_every_partial_reuse_witness_stays_readable_but_is_not_reused(
+    tmp_path: Path, present_fields: tuple[str, ...]
+) -> None:
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("partial-witness", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    marker_payload = json.loads(marker_path.read_text())
+    witness_fields = {"source_digest", "ffmpeg_version", "transform_kind"}
+    marker_payload = {
+        key: value
+        for key, value in marker_payload.items()
+        if key not in witness_fields or key in present_fields
+    }
+    marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    metadata_only = app.process(source, record=False, stages={hflow.Stage.META}, verbose=False)
+    assert metadata_only.canonical_path == first.canonical_path
+
+    second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert second.sync_reused is False
+
+
+@pytest.mark.parametrize(
     "raw_transform_kind", [None, "future-transform"], ids=["missing", "unknown"]
 )
 def test_a_marker_without_a_known_transform_kind_stays_readable_but_is_not_reused(

--- a/tests/test_sync_reuse.py
+++ b/tests/test_sync_reuse.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 import hflow
+from hflow.app import _read_sync_completion_marker
 from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import EpisodeStamps, TransformConfig, write_canonical_episode
 
@@ -170,6 +171,13 @@ def test_every_partial_reuse_witness_stays_readable_but_is_not_reused(
         if key not in witness_fields or key in present_fields
     }
     marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    # Pin the mechanism, not only the outcome: the reader must drop the whole
+    # group. Read before the runs below, which rewrite the marker with a
+    # complete witness. Without this, the parse could go back to accepting a
+    # partial witness and the run below would still refuse reuse, on a later
+    # gate check rather than on this one.
+    assert _read_sync_completion_marker(marker_path).reuse_witness is None
 
     metadata_only = app.process(source, record=False, stages={hflow.Stage.META}, verbose=False)
     assert metadata_only.canonical_path == first.canonical_path


### PR DESCRIPTION
## Summary

- group the sync reuse witness into a single frozen `_SyncReuseWitness`
- parse partial, malformed, missing, or future witnesses as absent while keeping legacy markers readable
- keep the existing sync completion marker JSON shape byte-for-byte compatible
- add explicit coverage for all six partial witness combinations

Closes #319

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest -q tests/test_sync_reuse.py`
- `uv run pytest -q`

All checks passed:
- 22 focused tests passed
- 1374 tests passed
- 6 skipped