### PR TITLE
refactor(app): type the sync-reuse witness as one all-or-nothing value

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType, ModuleType
-from typing import TYPE_CHECKING, Generic, NewType, TypeVar, assert_never
+from typing import TYPE_CHECKING, Generic, Never, NewType, TypeVar, assert_never, cast
 
 if TYPE_CHECKING:
     from hflow.runtime import BundlePaths
@@ -252,33 +252,47 @@ class _TransformKind(StrEnum):
 
 
 @dataclass(frozen=True)
+class _SyncReuseWitness:
+    """Everything the reuse gate needs to prove byte-identical output.
+
+    The witness is the typed grouping of the three fields the gate checks
+    together; promoting them to a single value is what lets a JSON parser
+    fail closed: missing any one of them means the gate cannot prove reuse
+    is safe, so the whole witness is dropped to ``None`` rather than letting
+    a partial record silently satisfy the gate. Mirrors
+    :class:`hflow.snapshot.RetainedDatasetSnapshotBackup` in shape, not in
+    import, so the two halves of the codebase stay decoupled.
+    """
+
+    # Which source BYTES produced the canonical. Content, never size+mtime:
+    # this repo identifies by content everywhere, and a same-length rewrite
+    # or a preserved mtime would defeat the weaker test silently.
+    source_digest: str
+    # The transform is stamped with an ffmpeg version that does NOT reach
+    # pipeline_version, and different builds genuinely encode differently.
+    ffmpeg_version: str
+    # An @app.transform override is contractually required to end in
+    # write_canonical_episode, so it stamps the SAME pipeline_version the
+    # default transform would: without this, REMOVING an override would reuse
+    # a canonical the current pipeline cannot produce.
+    transform_kind: _TransformKind
+
+
+@dataclass(frozen=True)
 class _SyncCompletion:
     """Proof that sync completed for one source path and canonical version.
 
-    The last three fields are the *reuse witness*: enough to decide that
-    re-running sync would rewrite byte-identical output, so it can be skipped.
-    They are optional because markers written before they existed are still
-    valid proof for the non-sync stages, which is all those stages ever asked
-    of them. A witness-less marker simply never satisfies the reuse gate: one
-    re-transcode rewrites it in the current shape, and that is the whole
-    migration.
+    The reuse witness is optional because markers written before it existed
+    are still valid proof for the non-sync stages, which is all those stages
+    ever asked of them. A witness-less marker simply never satisfies the
+    reuse gate: one re-transcode rewrites it in the current shape, and that
+    is the whole migration.
     """
 
     source_path: str
     schema_version: str
     pipeline_version: str
-    # Which source BYTES produced the canonical. Content, never size+mtime:
-    # this repo identifies by content everywhere, and a same-length rewrite
-    # or a preserved mtime would defeat the weaker test silently.
-    source_digest: str | None = None
-    # The transform is stamped with an ffmpeg version that does NOT reach
-    # pipeline_version, and different builds genuinely encode differently.
-    ffmpeg_version: str | None = None
-    # An @app.transform override is contractually required to end in
-    # write_canonical_episode, so it stamps the SAME pipeline_version the
-    # default transform would: without this, REMOVING an override would reuse
-    # a canonical the current pipeline cannot produce.
-    transform_kind: _TransformKind | None = None
+    reuse_witness: _SyncReuseWitness | None = None
 
 
 def _source_identity(source_reference: Path | str, storage_root: StorageRoot) -> str:
@@ -338,10 +352,10 @@ def _write_sync_completion_marker(marker_path: Path, completion: _SyncCompletion
         "schema_version": completion.schema_version,
         "pipeline_version": completion.pipeline_version,
     }
-    for witness_field in ("source_digest", "ffmpeg_version", "transform_kind"):
-        witness_value = getattr(completion, witness_field)
-        if witness_value is not None:
-            marker_payload[witness_field] = witness_value
+    if completion.reuse_witness is not None:
+        marker_payload["source_digest"] = completion.reuse_witness.source_digest
+        marker_payload["ffmpeg_version"] = completion.reuse_witness.ffmpeg_version
+        marker_payload["transform_kind"] = completion.reuse_witness.transform_kind.value
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -381,29 +395,40 @@ def _read_sync_completion_marker(marker_path: Path) -> _SyncCompletion:
                 f"{field_name!r} must be a non-empty string"
             )
         required_values[field_name] = field_value
-    # Parsed leniently, on purpose: a missing or malformed witness field means
+    # Parsed leniently, on purpose: a missing or malformed witness means
     # "cannot prove reuse is safe", which the gate already treats as a miss.
-    # Requiring them would make every pre-witness marker unreadable and break
-    # the non-sync stages, which never needed a witness at all.
-    optional_values = {
-        field_name: value
-        for field_name in ("source_digest", "ffmpeg_version")
-        if isinstance(value := marker_payload.get(field_name), str) and value
-    }
+    # Requiring the witness would make every pre-witness marker unreadable
+    # and break the non-sync stages, which never needed one at all. The
+    # witness is an all-or-nothing value: a partial one would silently pass
+    # the gate on three independent field checks, so the whole group is
+    # dropped together on any missing or malformed field.
+    reuse_witness: _SyncReuseWitness | None = None
+    source_digest = marker_payload.get("source_digest")
+    ffmpeg_version = marker_payload.get("ffmpeg_version")
     raw_transform_kind = marker_payload.get("transform_kind")
-    transform_kind: _TransformKind | None = None
-    if isinstance(raw_transform_kind, str) and raw_transform_kind:
+    if (
+        isinstance(source_digest, str)
+        and source_digest
+        and isinstance(ffmpeg_version, str)
+        and ffmpeg_version
+        and isinstance(raw_transform_kind, str)
+        and raw_transform_kind
+    ):
         try:
-            transform_kind = _TransformKind(raw_transform_kind)
+            reuse_witness = _SyncReuseWitness(
+                source_digest=source_digest,
+                ffmpeg_version=ffmpeg_version,
+                transform_kind=_TransformKind(raw_transform_kind),
+            )
         except ValueError:
-            transform_kind = None
+            # An unknown transform_kind is a forward-compatible future value,
+            # not a malformed record: the gate treats it as no witness.
+            reuse_witness = None
     return _SyncCompletion(
         source_path=required_values["source_path"],
         schema_version=required_values["schema_version"],
         pipeline_version=required_values["pipeline_version"],
-        source_digest=optional_values.get("source_digest"),
-        ffmpeg_version=optional_values.get("ffmpeg_version"),
-        transform_kind=transform_kind,
+        reuse_witness=reuse_witness,
     )
 
 
@@ -1319,13 +1344,28 @@ class App:
             completion = _read_sync_completion_marker(marker_path)
         except (FileNotFoundError, ValueError, OSError):
             return None
-        if completion.transform_kind is not _TransformKind.DEFAULT:
-            return None
-        if completion.source_path != source_identifier:
-            # Two sources can share a run directory when output_dir= names one.
-            return None
-        if completion.source_digest != source_digest:
-            return None
+        # The witness is the gate's only reuse evidence. A reader that built
+        # ``None`` (missing / partial / unknown kind) has already said it
+        # cannot prove anything, so there is nothing to check downstream.
+        match completion.reuse_witness:
+            case None:
+                return None
+            case _SyncReuseWitness(transform_kind=_TransformKind.DEFAULT) as witness:
+                if completion.source_path != source_identifier:
+                    # Two sources can share a run directory when output_dir= names one.
+                    return None
+                if witness.source_digest != source_digest:
+                    return None
+            case _SyncReuseWitness(transform_kind=_TransformKind.OVERRIDE):
+                # An override has no explicit version, so nothing here can
+                # tell an edited override from an unchanged one.
+                return None
+            # ``_TransformKind`` has no other members, and ``None`` is matched
+            # above, so this branch is unreachable. The cast pins the residual
+            # type to ``Never`` so a future enum member added without extending
+            # the gate becomes a static error here, not a silent miss.
+            case _:
+                assert_never(cast(Never, completion.reuse_witness))
         if completion.schema_version != EPISODE_FORMAT_VERSION:
             return None
         if completion.pipeline_version != self.pipeline_version:
@@ -1353,7 +1393,7 @@ class App:
             or canonical_stamps.pipeline_version != completion.pipeline_version
         ):
             return None
-        if canonical_stamps.ffmpeg_version != completion.ffmpeg_version:
+        if canonical_stamps.ffmpeg_version != completion.reuse_witness.ffmpeg_version:
             return None
         if canonical_stamps.ffmpeg_version != FFMPEG_VERSION_NOT_USED:
             # Only now, when the recording demonstrably has video, is it worth
@@ -2305,6 +2345,11 @@ class App:
             # whole file (hundreds of megabytes) to store the bytes already
             # there -- and rewrite a marker that is still true.
             if Stage.SYNC in enabled_stages and not reused_canonical:
+                # The reuse path always sets ``source_digest``; the non-reuse
+                # path (this one) computed it above. Either way, reaching
+                # here with ``None`` would mean writing a marker with a None
+                # witness, which is exactly what the gate refuses to read.
+                assert source_digest is not None
                 canonical_uri = run_storage_root.publish(canonical_path, canonical_file_name)
                 _write_sync_completion_marker(
                     sync_completion_marker_path,
@@ -2312,12 +2357,14 @@ class App:
                         source_path=source_identifier,
                         schema_version=stamps.schema_version,
                         pipeline_version=stamps.pipeline_version,
-                        source_digest=source_digest,
-                        ffmpeg_version=stamps.ffmpeg_version,
-                        transform_kind=(
-                            _TransformKind.OVERRIDE
-                            if self.transform_override is not None
-                            else _TransformKind.DEFAULT
+                        reuse_witness=_SyncReuseWitness(
+                            source_digest=source_digest,
+                            ffmpeg_version=stamps.ffmpeg_version,
+                            transform_kind=(
+                                _TransformKind.OVERRIDE
+                                if self.transform_override is not None
+                                else _TransformKind.DEFAULT
+                            ),
                         ),
                     ),
                 )

--- a/tests/test_sync_reuse.py
+++ b/tests/test_sync_reuse.py
@@ -274,3 +274,86 @@ def test_reuse_never_leaves_the_marker_missing(
     app.process(source, record=False, stages=stage_set, verbose=False)
 
     assert marker_path.read_bytes() == marker_before
+
+
+def test_a_complete_witness_round_trips_through_the_marker(tmp_path: Path) -> None:
+    """Reading the marker the writer just wrote must rebuild a complete
+    ``_SyncReuseWitness``: same source_digest, same ffmpeg_version, same
+    transform_kind. Catches any future refactor that drops a field from the
+    wire shape or splits the witness back into scattered optionals."""
+    from hflow.app import _read_sync_completion_marker, _SyncReuseWitness, _TransformKind
+
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("witness-rt", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+
+    completion = _read_sync_completion_marker(marker_path)
+    assert completion.reuse_witness == _SyncReuseWitness(
+        source_digest=f"sha256:{hashlib.sha256(source.read_bytes()).hexdigest()}",
+        ffmpeg_version=first.stamps.ffmpeg_version,
+        transform_kind=_TransformKind.DEFAULT,
+    )
+
+
+@pytest.mark.parametrize(
+    "missing_witness_field",
+    ["source_digest", "ffmpeg_version", "transform_kind"],
+)
+def test_a_marker_missing_any_one_witness_field_drops_the_whole_witness(
+    tmp_path: Path, missing_witness_field: str
+) -> None:
+    """A partial witness must NOT satisfy the gate: the three fields are an
+    all-or-nothing group, because a partial record would silently pass the
+    gate on three independent field checks."""
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("partial", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    marker_payload = json.loads(marker_path.read_text())
+    marker_payload.pop(missing_witness_field)
+    marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    # Non-sync stages still see the marker as valid basic proof.
+    metadata_only = app.process(source, record=False, stages={hflow.Stage.META}, verbose=False)
+    assert metadata_only.canonical_path == first.canonical_path
+
+    # Sync refuses to reuse: the witness is gone, the gate cannot prove
+    # anything, the next run will transcode and re-stamp a complete witness.
+    second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert second.sync_reused is False
+
+
+def test_a_malformed_witness_field_drops_the_whole_witness(tmp_path: Path) -> None:
+    """A non-string witness value is the same as a missing one: the gate
+    cannot prove reuse is safe on it, and a partial read that filled in the
+    others would still let the gate pass on three independent field checks."""
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("malformed", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    marker_payload = json.loads(marker_path.read_text())
+    marker_payload["ffmpeg_version"] = 12345  # wrong type, would have parsed
+    marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert second.sync_reused is False
+
+    third = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert third.sync_reused is True
+
+
+def test_a_witness_with_no_transform_kind_record_drops_to_no_witness(tmp_path: Path) -> None:
+    """Empty-string witness fields are the same as missing ones: a record
+    that claims "I proved reuse" while providing nothing to check against
+    cannot pass the gate."""
+    source = _episode(tmp_path / "episode_0001.mcap")
+    app = hflow.App("empty", data_root=tmp_path / "data", default_checks=())
+    first = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    marker_path = first.canonical_path.parent / ".sync-complete.json"
+    marker_payload = json.loads(marker_path.read_text())
+    marker_payload["source_digest"] = ""
+    marker_path.write_text(json.dumps(marker_payload, sort_keys=True) + "\n")
+
+    second = app.process(source, record=False, stages=SYNC_ONLY, verbose=False)
+    assert second.sync_reused is False


### PR DESCRIPTION
refactor(app): type the sync-reuse witness as one all-or-nothing value

Closes #319.

The reuse witness (source_digest, ffmpeg_version, transform_kind) lived 
as three scattered optional fields on _SyncCompletion, and the reader 
dropped each field independently on a malformed value. A partial 
record, any one of the three missing or wrong-typed, would silently 
pass the gate on the surviving two checks.

This groups the three into a single _SyncReuseWitness dataclass 
mirroring RetainedDatasetSnapshotBackup. The reader builds the witness 
all-or-nothing: any missing or non-string field, or any unknown 
_TransformKind value, drops the whole group to None. The writer 
serializes it back into the same 6 JSON keys, so the marker is 
byte-for-byte identical to main.

The gate now matches on the None | DEFAULT | OVERRIDE union with 
assert_never on the residual, so a future _TransformKind member added 
without extending the gate is a static error, not a silent miss.

The JSON marker shape is unchanged: same 6 keys, same sort order, same 
trailing newline. Existing markers stay readable. A legacy marker with 
no witness fields still parses, reuse is refused, and the marker is 
rewritten with the full witness on the next sync pass.

All five commands ran in WSL2. Native Windows cannot import 
hflow.storage (fcntl), and the shared .venv was recreated as Linux-side, 
so the full sequence executed on the repo's required platform. The 
lockfile pins identical ruff, ty, and pytest versions.