### PR TITLE
fix(lerobot): follow paginated tree listings

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -27,6 +27,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NotRequired, TypedDict
+from urllib.parse import urlsplit
 
 from mcap.writer import Writer as McapWriter
 
@@ -248,10 +249,32 @@ def _hf_repo_info(repo_id: str, revision: str) -> _DatasetRepositoryInformation:
 def _hf_tree(repo_id: str, revision: str, path: str) -> list[dict]:
     """List files under a HF dataset tree path (recursive)."""
     url = f"https://huggingface.co/api/datasets/{repo_id}/tree/{revision}/{path}?recursive=true"
+    initial_url_parts = urlsplit(url)
+    initial_origin = (initial_url_parts.scheme, initial_url_parts.netloc)
     all_tree_entries: list[dict] = []
     seen_paths: set[str] = set()
+    visited_urls: set[str] = set()
     next_url: str | None = url
     while next_url is not None:
+        if next_url in visited_urls:
+            raise ValueError(
+                f"Hugging Face tree response for {repo_id}@{revision} path {path!r} "
+                f"repeated an already fetched pagination URL: {next_url!r}"
+            )
+        try:
+            next_url_parts = urlsplit(next_url)
+        except ValueError as error:
+            raise ValueError(
+                f"Hugging Face tree response for {repo_id}@{revision} path {path!r} "
+                f"contains an invalid pagination URL: {next_url!r}"
+            ) from error
+        next_origin = (next_url_parts.scheme, next_url_parts.netloc)
+        if next_origin != initial_origin:
+            raise ValueError(
+                f"Hugging Face tree response for {repo_id}@{revision} path {path!r} "
+                f"contains a pagination URL with a different scheme and host: {next_url!r}"
+            )
+        visited_urls.add(next_url)
         with urllib.request.urlopen(_hugging_face_request(next_url), timeout=60) as response:
             try:
                 tree_entries = json.loads(response.read().decode())

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -248,19 +248,41 @@ def _hf_repo_info(repo_id: str, revision: str) -> _DatasetRepositoryInformation:
 def _hf_tree(repo_id: str, revision: str, path: str) -> list[dict]:
     """List files under a HF dataset tree path (recursive)."""
     url = f"https://huggingface.co/api/datasets/{repo_id}/tree/{revision}/{path}?recursive=true"
-    with urllib.request.urlopen(_hugging_face_request(url), timeout=60) as response:
-        try:
-            tree_entries = json.loads(response.read().decode())
-        except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise ValueError(
-                f"Hugging Face tree response for {repo_id}@{revision} path {path!r} is not "
-                f"valid JSON: {error}"
-            ) from error
-    if not isinstance(tree_entries, list) or not all(
-        isinstance(tree_entry, dict) for tree_entry in tree_entries
-    ):
-        raise ValueError(f"Hugging Face tree response for {path!r} is not a list of objects")
-    return tree_entries
+    all_tree_entries: list[dict] = []
+    next_url: str | None = url
+    while next_url is not None:
+        with urllib.request.urlopen(_hugging_face_request(next_url), timeout=60) as response:
+            try:
+                tree_entries = json.loads(response.read().decode())
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise ValueError(
+                    f"Hugging Face tree response for {repo_id}@{revision} path {path!r} is not "
+                    f"valid JSON: {error}"
+                ) from error
+            link_header = response.headers.get("Link")
+        if not isinstance(tree_entries, list) or not all(
+            isinstance(tree_entry, dict) for tree_entry in tree_entries
+        ):
+            raise ValueError(f"Hugging Face tree response for {path!r} is not a list of objects")
+        all_tree_entries.extend(tree_entries)
+
+        next_url = None
+        for link_entry in (link_header or "").split(","):
+            link_match = re.fullmatch(r"\s*<([^>]+)>\s*;\s*(.*)", link_entry)
+            if link_match is None:
+                continue
+            relation_match = re.search(
+                r"(?:^|;)\s*rel\s*=\s*(?:\"([^\"]+)\"|([^;\s]+))",
+                link_match.group(2),
+                flags=re.IGNORECASE,
+            )
+            if relation_match is None:
+                continue
+            relations = (relation_match.group(1) or relation_match.group(2)).split()
+            if any(relation.lower() == "next" for relation in relations):
+                next_url = link_match.group(1)
+                break
+    return all_tree_entries
 
 
 def _hugging_face_request(url: str) -> urllib.request.Request:

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -249,6 +249,7 @@ def _hf_tree(repo_id: str, revision: str, path: str) -> list[dict]:
     """List files under a HF dataset tree path (recursive)."""
     url = f"https://huggingface.co/api/datasets/{repo_id}/tree/{revision}/{path}?recursive=true"
     all_tree_entries: list[dict] = []
+    seen_paths: set[str] = set()
     next_url: str | None = url
     while next_url is not None:
         with urllib.request.urlopen(_hugging_face_request(next_url), timeout=60) as response:
@@ -264,7 +265,13 @@ def _hf_tree(repo_id: str, revision: str, path: str) -> list[dict]:
             isinstance(tree_entry, dict) for tree_entry in tree_entries
         ):
             raise ValueError(f"Hugging Face tree response for {path!r} is not a list of objects")
-        all_tree_entries.extend(tree_entries)
+        for tree_entry in tree_entries:
+            tree_entry_path = tree_entry.get("path")
+            if isinstance(tree_entry_path, str):
+                if tree_entry_path in seen_paths:
+                    continue
+                seen_paths.add(tree_entry_path)
+            all_tree_entries.append(tree_entry)
 
         next_url = None
         for link_entry in (link_header or "").split(","):

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -620,11 +620,16 @@ def test_hf_tree_valid_json_still_returns_entries(monkeypatch: pytest.MonkeyPatc
     assert len(stub.requests) == 1
 
 
-def test_hf_tree_follows_next_link_and_preserves_request_headers(
+def test_hf_tree_follows_next_link_preserves_headers_and_deduplicates_entries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     first_page = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
-    second_page = json.dumps([{"path": "meta/episodes/file-000.parquet", "type": "file"}]).encode()
+    second_page = json.dumps(
+        [
+            {"path": "meta/info.json", "type": "file"},
+            {"path": "meta/episodes/file-000.parquet", "type": "file"},
+        ]
+    ).encode()
     next_url = (
         "https://huggingface.co/api/datasets/lerobot/pusht/tree/main/meta"
         "?recursive=true&cursor=page-2"

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -495,15 +495,21 @@ class _StubUrlopen:
     """Routes urlopen calls to fixed bytes by a marker in the request URL."""
 
     def __init__(
-        self, routes: dict[str, bytes], response_headers: dict[str, dict[str, str]] | None = None
+        self,
+        routes: dict[str, bytes],
+        response_headers: dict[str, dict[str, str]] | None = None,
+        max_requests: int | None = None,
     ) -> None:
         self._routes = routes
         self._response_headers = response_headers or {}
+        self._max_requests = max_requests
         self.requests: list[urllib.request.Request] = []
 
     def __call__(self, request: urllib.request.Request, timeout: int = 60) -> _StubResponse:
         url = request.full_url
         self.requests.append(request)
+        if self._max_requests is not None and len(self.requests) > self._max_requests:
+            raise AssertionError(f"urlopen exceeded test request limit: {self._max_requests}")
         for marker, body in self._routes.items():
             if marker in url:
                 return _StubResponse(body, self._response_headers.get(marker))
@@ -514,8 +520,9 @@ def _stub_urlopen(
     monkeypatch: pytest.MonkeyPatch,
     routes: dict[str, bytes],
     response_headers: dict[str, dict[str, str]] | None = None,
+    max_requests: int | None = None,
 ) -> _StubUrlopen:
-    stub = _StubUrlopen(routes, response_headers)
+    stub = _StubUrlopen(routes, response_headers, max_requests)
     monkeypatch.setattr(urllib.request, "urlopen", stub)
     return stub
 
@@ -652,6 +659,43 @@ def test_hf_tree_follows_next_link_preserves_headers_and_deduplicates_entries(
     for request in stub.requests:
         assert request.get_header("User-agent") == "hflow-lerobot"
         assert request.get_header("Authorization") == "Bearer test-token"
+
+
+def test_hf_tree_rejects_next_link_with_different_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_page = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
+    unsafe_next_url = "https://attacker.example/tree/secret?cursor=page-2"
+    stub = _stub_urlopen(
+        monkeypatch,
+        {"/tree/": first_page},
+        {"/tree/": {"Link": f'<{unsafe_next_url}>; rel="next"'}},
+        max_requests=1,
+    )
+    monkeypatch.setenv("HF_TOKEN", "secret-user-token")
+
+    with pytest.raises(ValueError, match="different scheme and host"):
+        prep._hf_tree("lerobot/pusht", "main", "meta")
+
+    assert len(stub.requests) == 1
+
+
+def test_hf_tree_rejects_a_repeated_next_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_page = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
+    page_url = "https://huggingface.co/api/datasets/lerobot/pusht/tree/main/meta?recursive=true"
+    stub = _stub_urlopen(
+        monkeypatch,
+        {"/tree/": first_page},
+        {"/tree/": {"Link": f'<{page_url}>; rel="next"'}},
+        max_requests=1,
+    )
+
+    with pytest.raises(ValueError, match="already fetched"):
+        prep._hf_tree("lerobot/pusht", "main", "meta")
+
+    assert len(stub.requests) == 1
 
 
 def test_hf_tree_malformed_later_page_raises_contextual_value_error(

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -477,8 +477,9 @@ def test_converter_output_remuxes_without_tail_loss(
 class _StubResponse:
     """Minimal urlopen response double: a context manager with read()."""
 
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None) -> None:
         self._body = body
+        self.headers = headers or {}
 
     def __enter__(self) -> "_StubResponse":
         return self
@@ -493,19 +494,30 @@ class _StubResponse:
 class _StubUrlopen:
     """Routes urlopen calls to fixed bytes by a marker in the request URL."""
 
-    def __init__(self, routes: dict[str, bytes]) -> None:
+    def __init__(
+        self, routes: dict[str, bytes], response_headers: dict[str, dict[str, str]] | None = None
+    ) -> None:
         self._routes = routes
+        self._response_headers = response_headers or {}
+        self.requests: list[urllib.request.Request] = []
 
     def __call__(self, request: urllib.request.Request, timeout: int = 60) -> _StubResponse:
         url = request.full_url
+        self.requests.append(request)
         for marker, body in self._routes.items():
             if marker in url:
-                return _StubResponse(body)
+                return _StubResponse(body, self._response_headers.get(marker))
         raise AssertionError(f"unexpected urlopen URL: {url}")
 
 
-def _stub_urlopen(monkeypatch: pytest.MonkeyPatch, routes: dict[str, bytes]) -> None:
-    monkeypatch.setattr(urllib.request, "urlopen", _StubUrlopen(routes))
+def _stub_urlopen(
+    monkeypatch: pytest.MonkeyPatch,
+    routes: dict[str, bytes],
+    response_headers: dict[str, dict[str, str]] | None = None,
+) -> _StubUrlopen:
+    stub = _StubUrlopen(routes, response_headers)
+    monkeypatch.setattr(urllib.request, "urlopen", stub)
+    return stub
 
 
 _INVALID_UTF8 = b"\xff\xfe\x00"
@@ -601,10 +613,63 @@ def test_hf_repo_info_valid_json_still_resolves(monkeypatch: pytest.MonkeyPatch)
 
 def test_hf_tree_valid_json_still_returns_entries(monkeypatch: pytest.MonkeyPatch) -> None:
     body = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
-    _stub_urlopen(monkeypatch, {"/tree/": body})
+    stub = _stub_urlopen(monkeypatch, {"/tree/": body})
     assert prep._hf_tree("lerobot/pusht", "main", "meta") == [
         {"path": "meta/info.json", "type": "file"}
     ]
+    assert len(stub.requests) == 1
+
+
+def test_hf_tree_follows_next_link_and_preserves_request_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_page = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
+    second_page = json.dumps([{"path": "meta/episodes/file-000.parquet", "type": "file"}]).encode()
+    next_url = (
+        "https://huggingface.co/api/datasets/lerobot/pusht/tree/main/meta"
+        "?recursive=true&cursor=page-2"
+    )
+    stub = _stub_urlopen(
+        monkeypatch,
+        {"cursor=page-2": second_page, "/tree/": first_page},
+        {"/tree/": {"Link": f'<{next_url}>; rel="next"'}},
+    )
+    monkeypatch.setenv("HF_TOKEN", "test-token")
+
+    assert prep._hf_tree("lerobot/pusht", "main", "meta") == [
+        {"path": "meta/info.json", "type": "file"},
+        {"path": "meta/episodes/file-000.parquet", "type": "file"},
+    ]
+    assert [request.full_url for request in stub.requests] == [
+        "https://huggingface.co/api/datasets/lerobot/pusht/tree/main/meta?recursive=true",
+        next_url,
+    ]
+    for request in stub.requests:
+        assert request.get_header("User-agent") == "hflow-lerobot"
+        assert request.get_header("Authorization") == "Bearer test-token"
+
+
+def test_hf_tree_malformed_later_page_raises_contextual_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_page = json.dumps([{"path": "meta/info.json", "type": "file"}]).encode()
+    next_url = (
+        "https://huggingface.co/api/datasets/lerobot/pusht/tree/main/meta"
+        "?recursive=true&cursor=page-2"
+    )
+    _stub_urlopen(
+        monkeypatch,
+        {"cursor=page-2": _MALFORMED_JSON, "/tree/": first_page},
+        {"/tree/": {"Link": f'<{next_url}>; rel="next"'}},
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        prep._hf_tree("lerobot/pusht", "main", "meta")
+
+    message = str(excinfo.value)
+    assert "lerobot/pusht@main" in message
+    assert "'meta'" in message
+    assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
 
 
 def test_hf_repo_info_wrong_shape_refusal_unchanged(


### PR DESCRIPTION
## Summary

- Follow Hugging Face tree pagination through `Link` headers.
- Combine validated entries from every page.
- Preserve the HFlow User-Agent and optional authentication token.
- Add regression coverage for pagination and malformed later pages.

## Why

The LeRobot importer previously read only the first Hugging Face tree page. Repositories with more than 1,000 tree entries could silently omit metadata or episode files.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ty check`
- `uv run pytest -q tests/test_lerobot_converter.py`
- `uv run pytest -q`
- `uv run --python 3.14 --locked pytest -q`

Results:

- Python 3.11: 1,370 passed, 6 skipped
- Python 3.14: 1,370 passed, 6 skipped

## Checklist

- [x] Added outcome-focused regression tests.
- [x] Ran Ruff check, Ruff format, and ty.
- [x] Ran the relevant and full test suites.
- [x] Added no recordings, generated media, credentials, or private URLs.
- [x] No canonical transform behavior changed, so no behavior-version bump is needed.

Closes #296.