### PR TITLE
fix(lerobot): separate video cache files by index

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -41,7 +41,7 @@ DEFAULT_REVISION = "main"
 DEFAULT_OUTPUT_DIR = Path("./data/lerobot_pusht")
 DEFAULT_CAMERA_KEY = "observation.image"
 
-CONVERTER_VERSION = "lerobot-converter-v3"
+CONVERTER_VERSION = "lerobot-converter-v4"
 PRESENTATION_TIMESTAMP_EPSILON_S = 0.050
 
 # Timestamp handling
@@ -835,7 +835,10 @@ def _convert_single_episode(
         local_video_path = (
             cache_directory
             / "videos"
-            / (f"{camera_key.replace('/', '_').replace('.', '_')}-chunk{video_chunk_index}.mp4")
+            / (
+                f"{camera_key.replace('/', '_').replace('.', '_')}"
+                f"-chunk{video_chunk_index}-file{video_file_index}.mp4"
+            )
         )
         if not local_video_path.exists():
             _download_file(f"{dataset_base_url}/{video_relative_path}", local_video_path)

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import urllib.request
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -255,6 +256,98 @@ def test_index_discovery_multi_camera_metadata(
     assert found["episodes"][0]["video_windows"]["observation.images.up"][
         "to_timestamp"
     ] == pytest.approx(2.0)
+
+
+def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    corpus = _build_fake_corpus(tmp_path)
+    camera_key = "observation.images.up"
+    dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
+
+    def episode_row(episode_index: int, video_file_index: int) -> dict:
+        return {
+            "episode_index": episode_index,
+            "task": f"task-{episode_index}",
+            "length": 1,
+            "data_chunk": "000",
+            "data_file": "000",
+            "data_from": 0,
+            "data_to": 1,
+            "video_windows": {
+                camera_key: {
+                    "chunk_index": "000",
+                    "file_index": f"{video_file_index:03d}",
+                    "from_timestamp": 0.0,
+                    "to_timestamp": 0.0,
+                }
+            },
+        }
+
+    source_archive = cast(
+        prep._SourceArchive,
+        {
+            **corpus,
+            "episodes": [episode_row(0, 0), episode_row(1, 1)],
+            "video_keys": [camera_key],
+        },
+    )
+    numeric_schemas = {
+        "observation.state": prep._NumericSchema(name="observation.state", dim=6),
+        "action": prep._NumericSchema(name="action", dim=6),
+    }
+    video_downloaded_urls: set[str] = set()
+    cache_path_by_url: dict[str, Path] = {}
+    converted_sources: list[bytes] = []
+
+    def fake_download(url: str, destination_path: Path, **_kwargs: object) -> None:
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        if "/videos/" in url:
+            if url in video_downloaded_urls:
+                raise AssertionError(f"source was downloaded twice: {url}")
+            video_downloaded_urls.add(url)
+            cache_path_by_url[url] = destination_path
+            destination_path.write_bytes(url.encode())
+            return
+        shutil.copy(tmp_path / "data" / "chunk-000" / "file-000.parquet", destination_path)
+
+    def fake_transcode(mp4_path: Path, *_args: object, **_kwargs: object) -> list[bytes]:
+        converted_sources.append(mp4_path.read_bytes())
+        return [b"access-unit"]
+
+    monkeypatch.setattr(prep, "_download_file", fake_download)
+    monkeypatch.setattr(prep, "_transcode_mp4_to_h264", fake_transcode)
+    monkeypatch.setattr(prep, "_get_video_pts_times", lambda path: [0])
+    monkeypatch.setattr(prep, "ffmpeg_version", lambda: "test-ffmpeg")
+    monkeypatch.setattr(
+        prep,
+        "write_canonical_episode",
+        lambda source_path, output_path, *_args, **_kwargs: shutil.copy(source_path, output_path),
+    )
+
+    for episode_index in (0, 1, 0):
+        prep._convert_single_episode(
+            source_archive=source_archive,
+            dataset_source=dataset_source,
+            output_dir=tmp_path / "output",
+            episode_index=episode_index,
+            camera_keys=(camera_key,),
+            numeric_schemas=numeric_schemas,
+            frames_per_second=30,
+        )
+
+    video_urls = [
+        "https://huggingface.co/datasets/fake/repo/resolve/abc/videos/"
+        "observation.images.up/chunk-000/file-000.mp4",
+        "https://huggingface.co/datasets/fake/repo/resolve/abc/videos/"
+        "observation.images.up/chunk-000/file-001.mp4",
+    ]
+    assert converted_sources == [
+        video_urls[0].encode(),
+        video_urls[1].encode(),
+        video_urls[0].encode(),
+    ]
+    assert cache_path_by_url[video_urls[0]] != cache_path_by_url[video_urls[1]]
 
 
 def test_camera_selection_validates_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #292.

## Summary

Make LeRobot video cache paths unique by camera key, video chunk index, and video file index. This prevents different MP4 source files from sharing one cache entry while preserving reuse for the same source.

## Why

The previous cache filename omitted `file_index`. Two episodes using the same camera and chunk but different video files could therefore be converted from the wrong cached MP4. The converter version is bumped to `lerobot-converter-v4` so previously prepared outputs are distinguished.

## Validation

- `uv run --python 3.11 --locked pytest -q tests/test_lerobot_converter.py` — 35 passed
- `uv run --python 3.11 --locked pytest -q` — 1,382 passed, 6 skipped
- `uv run --python 3.14 --locked pytest -q` — 1,382 passed, 6 skipped
- `uv run --python 3.11 --locked ruff check .` — passed
- `uv run --python 3.11 --locked ruff format --check .` — passed
- `uv run --python 3.11 --locked ty check` — passed

## Checklist

- [x] Added outcome-focused regression coverage for distinct video file indices and cache reuse.
- [x] Bumped the converter version for affected cached imports.
- [x] Ran Ruff check and format validation.
- [x] Ran type checking.
- [x] Ran the focused and full test suites on Python 3.11 and 3.14.
- [x] Added no runtime dependencies or generated artifacts.
