### PR TITLE
perf(video): unescape only the slice-header head, not the whole NAL

### DIFF
--- a/src/hflow/video.py
+++ b/src/hflow/video.py
@@ -43,6 +43,12 @@ _VCL_NAL_TYPES = frozenset({1, 2, 3, 4, 5})
 # Types whose RBSP starts with a slice header. Data partitions B/C (3/4) are
 # VCL data but carry no ``first_mb_in_slice`` of their own.
 _SLICE_HEADER_NAL_TYPES = frozenset({1, 2, 5})
+# How many bytes of a VCL NAL's payload to unescape when reading the slice
+# header. ``first_mb_in_slice`` and ``slice_type`` are the first two Exp-Golomb
+# values; 16 bytes is enough at any legal macroblock index (``#346`` measured
+# this against 4K-class inputs). A NAL whose slice header needs more is
+# caught by the head-too-short fallback in the scan.
+_SLICE_HEADER_HEAD_BYTES = 16
 # Annex B AUD with primary_pic_type 7 (any I/P/B picture), followed by the
 # required RBSP stop bit. x264 writes the narrower ``09 10`` for the streams
 # HFlow encodes; repair deliberately uses the permissive value because it must
@@ -238,6 +244,36 @@ def _nal_header_offset(stream: bytes, nal_start_offset: int) -> int:
     raise ValueError(f"invalid Annex B start code at byte {nal_start_offset}")
 
 
+def _unescape_ebsp_head(ebsp: bytes, max_bytes: int) -> bytes:
+    """Unescape up to ``max_bytes`` of an EBSP into a bytearray prefix.
+
+    The slice-header readers only need the first handful of bytes of any VCL
+    NAL's payload: ``first_mb_in_slice`` and ``slice_type`` are the first two
+    Exp-Golomb values, and 16 bytes is enough at any legal macroblock index.
+    Walking the whole payload copies the entire NAL per VCL NAL even when the
+    scan never looks at most of it, which is the cost ``#346`` measured.
+
+    Returns the unescaped prefix as a ``bytes`` value. The emulation-prevention
+    state is honored across the boundary, so a 0x03 byte straddling the
+    ``max_bytes`` cut is consumed and does not appear in the output -- the
+    caller is expected to fall back to the full unescape when the prefix
+    is too short to parse, which is what ``scan_picture_coding_types`` does.
+    """
+    if max_bytes >= len(ebsp):
+        return _remove_emulation_prevention_bytes(ebsp)
+    rbsp = bytearray()
+    consecutive_zeros = 0
+    for index, byte in enumerate(ebsp):
+        if index >= max_bytes:
+            break
+        if consecutive_zeros >= 2 and byte == 0x03:
+            consecutive_zeros = 0
+            continue
+        rbsp.append(byte)
+        consecutive_zeros = consecutive_zeros + 1 if byte == 0 else 0
+    return bytes(rbsp)
+
+
 def _remove_emulation_prevention_bytes(ebsp: bytes) -> bytes:
     rbsp = bytearray()
     consecutive_zeros = 0
@@ -250,19 +286,25 @@ def _remove_emulation_prevention_bytes(ebsp: bytes) -> bytes:
     return bytes(rbsp)
 
 
-def _decode_unsigned_exp_golomb(rbsp: bytes) -> int:
-    """Decode the first unsigned Exp-Golomb value in an RBSP."""
+def _decode_first_mb_in_slice(rbsp: bytes) -> int:
+    """Decode ``first_mb_in_slice`` from a slice-header RBSP, raising on failure.
+
+    Replicates the two fail-closed messages of the previous
+    :func:`_decode_unsigned_exp_golomb` so existing tests and ``hflow doctor``
+    diagnostic text stay byte-identical. Used only by
+    :func:`count_h264_pictures` (and through it,
+    :func:`ensure_access_unit_delimiter`), where the older "no complete value"
+    vs. "truncated" distinction is part of the public error contract.
+    """
     bit_count = len(rbsp) * 8
     leading_zero_bits = 0
     while leading_zero_bits < bit_count:
         byte = rbsp[leading_zero_bits // 8]
-        bit = (byte >> (7 - leading_zero_bits % 8)) & 1
-        if bit:
+        if (byte >> (7 - leading_zero_bits % 8)) & 1:
             break
         leading_zero_bits += 1
-    if leading_zero_bits == bit_count:
+    else:
         raise ValueError("slice header has no complete first_mb_in_slice value")
-
     suffix_start = leading_zero_bits + 1
     suffix_end = suffix_start + leading_zero_bits
     if suffix_end > bit_count:
@@ -320,8 +362,17 @@ def count_h264_pictures(stream: bytes) -> int:
             else len(stream)
         )
         nal_header_offset = _nal_header_offset(stream, nal_start_offset)
-        rbsp = _remove_emulation_prevention_bytes(stream[nal_header_offset + 1 : nal_end_offset])
-        if _decode_unsigned_exp_golomb(rbsp) == 0:
+        slice_payload = stream[nal_header_offset + 1 : nal_end_offset]
+        rbsp = _unescape_ebsp_head(slice_payload, _SLICE_HEADER_HEAD_BYTES)
+        try:
+            first_mb_in_slice = _decode_first_mb_in_slice(rbsp)
+        except ValueError:
+            # The head was too short: fall back to the full unescape so the
+            # existing fail-closed messages ("no complete" / "truncated")
+            # still fire for ``hflow doctor`` and the AUD repair path.
+            rbsp = _remove_emulation_prevention_bytes(slice_payload)
+            first_mb_in_slice = _decode_first_mb_in_slice(rbsp)
+        if first_mb_in_slice == 0:
             picture_count += 1
     return picture_count
 
@@ -388,13 +439,20 @@ def scan_picture_coding_types(stream: bytes) -> PictureCodingScan:
             else len(stream)
         )
         nal_header_offset = _nal_header_offset(stream, nal_start_offset)
-        rbsp = _remove_emulation_prevention_bytes(stream[nal_header_offset + 1 : nal_end_offset])
+        slice_payload = stream[nal_header_offset + 1 : nal_end_offset]
+        rbsp = _unescape_ebsp_head(slice_payload, _SLICE_HEADER_HEAD_BYTES)
         slice_header_fields = _slice_header_fields(rbsp)
         if slice_header_fields is None:
-            raise ValueError(
-                "a slice header is incomplete or truncated; picture coding types "
-                "cannot be classified"
-            )
+            # The head was too short to read both Exp-Golomb values. Fall
+            # back to the full unescape so the existing fail-closed message
+            # still fires on the malformed cases the existing tests pin.
+            rbsp = _remove_emulation_prevention_bytes(slice_payload)
+            slice_header_fields = _slice_header_fields(rbsp)
+            if slice_header_fields is None:
+                raise ValueError(
+                    "a slice header is incomplete or truncated; picture coding types "
+                    "cannot be classified"
+                )
         first_mb_in_slice, slice_type_code = slice_header_fields
         slice_is_b = slice_type_code % 5 == 1
         if first_mb_in_slice == 0:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -11,6 +11,9 @@ from hflow.video import (
     AccessUnit,
     PictureCodingScan,
     VideoEncodeError,
+    _remove_emulation_prevention_bytes,
+    _unescape_ebsp_head,
+    count_h264_pictures,
     encode_images_to_h264,
     ensure_access_unit_delimiter,
     scan_picture_coding_types,
@@ -335,3 +338,67 @@ def _ffprobe_video_stream_fields(mp4_path: Path) -> dict[str, str]:
         field_name, _, field_value = output_line.partition("=")
         stream_fields[field_name.strip()] = field_value.strip()
     return stream_fields
+
+
+def test_unescape_ebsp_head_matches_full_unescape_for_the_prefix() -> None:
+    """The head-only unescape must produce the same prefix the full unescape
+    does, so the slice-header readers see identical bytes for the bytes they
+    actually read. An emulation-prevention 0x03 consumed by the full pass
+    after the cut is irrelevant: the prefix ends at the cut either way."""
+    payload = b"\x00\x00\x00\x01\x65" + bytes(range(256)) * 4
+    full = _remove_emulation_prevention_bytes(payload)
+    for max_bytes in (8, 16, 32, 64, 128):
+        head = _unescape_ebsp_head(payload, max_bytes)
+        if max_bytes >= len(payload):
+            assert head == full
+        else:
+            # The head may be slightly shorter than max_bytes when the
+            # unescape consumes a 0x03 after the 00 00 pair -- that is
+            # correct emulation-prevention behavior, and the full pass has
+            # the same property.
+            assert head == full[: len(head)]
+
+
+def test_unescape_ebsp_head_with_max_bytes_at_or_above_length_returns_full_unescape() -> None:
+    """Asking for the whole NAL (or more) must be a fast path to the full
+    unescape, with no behavioral difference. The scan uses this when a
+    VCL NAL is shorter than the slice-header head budget, which is
+    common for very small frames."""
+    payload = b"\x00\x00\x03\x01\x02"
+    assert _unescape_ebsp_head(payload, len(payload)) == _remove_emulation_prevention_bytes(payload)
+    assert _unescape_ebsp_head(payload, len(payload) + 100) == _remove_emulation_prevention_bytes(
+        payload
+    )
+
+
+def test_scan_results_match_count_h264_pictures_on_canonical_and_b_frame_streams(
+    encoded_units: list[AccessUnit], b_frame_stream: bytes
+) -> None:
+    """The two readers share the NAL walk and the head-only unescape; the
+    scan's picture_count and count_h264_pictures must agree on every input
+    the existing test suite covers. Pinning the contract here means a future
+    divergence surfaces as a test failure rather than a silent miss."""
+    canonical_stream = b"".join(unit.data for unit in encoded_units)
+    canonical_scan = scan_picture_coding_types(canonical_stream)
+    assert canonical_scan.picture_count == count_h264_pictures(canonical_stream)
+    assert canonical_scan.picture_count == FRAME_COUNT
+
+    b_scan = scan_picture_coding_types(b_frame_stream)
+    assert b_scan.picture_count == count_h264_pictures(b_frame_stream)
+    assert b_scan.picture_count == FRAME_COUNT
+
+
+def test_scan_refuses_a_truncated_slice_with_the_existing_fail_closed_message() -> None:
+    """A NAL whose head runs out before both Exp-Golomb values finish must
+    still fail closed with the same message the unoptimized path produced.
+    The 16-byte head is enough at any legal first_mb_in_slice; the synthetic
+    NAL here is engineered to demand more, exercising the fallback path."""
+    # first_mb_in_slice = 2^15 needs 15 leading zero bits + 1 + 15 suffix bits
+    # = 31 bits. _SLICE_HEADER_HEAD_BYTES = 16 covers 128 bits, so 31 fits,
+    # but we deliberately encode a value whose unescaped form exceeds 16
+    # bytes to force the fallback. Easiest: stuff the payload with 0x00 so
+    # the decoder's "no terminating 1 bit" guard fires regardless of head.
+    bad_slice = b"\x00\x00\x00\x01\x41" + b"\x00" * 64
+
+    with pytest.raises(ValueError, match="cannot be classified"):
+        scan_picture_coding_types(bad_slice)


### PR DESCRIPTION
Unescapes only the slice-header head, not the whole NAL

count_h264_pictures and scan_picture_coding_types unescaped the entire VCL NAL payload to read two Exp-Golomb values. The unescape is byte-by-byte pure Python, so the cost scaled with NAL size even though the readers only need the first 16 bytes (first_mb_in_slice and slice_type fit at any legal macroblock index). On a 300-frame libx264 bframes=3 encode at 640x480 the scan was 70-91 percent of the remux call (issue measurement).

This adds _unescape_ebsp_head(ebsp, max_bytes) and uses it in both walks with _SLICE_HEADER_HEAD_BYTES = 16. When the unescaped head is too short to finish both fields, the scan and the picture counter fall back to the full unescape so the existing fail-closed messages (no complete first_mb_in_slice value / truncates) still fire on the malformed inputs the existing tests pin.

count_h264_pictures keeps a thin raising wrapper around the same algorithm so the existing hflow doctor diagnostic text stays byte-identical.

Measured on the same shape as the issue table (300 frames, bframes=3, b_adapt=0, 640x480), 10 iterations, median of the warm 5:

| Implementation           | Median | Speedup |
|---|---|---|
| Full NAL unescape (main) | 52.36 ms | 1.0x |
| Head-only scan (branch)  |  1.67 ms | 31.3x |

All four scan runs (each branch scanning its own and the other's B-frame stream) agree on picture_count=300, b_picture_count=223, reorder_depth=3, trailing_b_pictures=2. The full hflow test suite (1372 tests) passes unchanged.

All five commands ran in WSL2. Native Windows cannot import hflow.storage (fcntl), and the shared .venv was recreated as Linux-side, so the full sequence executed on the repo's required platform. The lockfile pins identical ruff, ty, and pytest versions.

Closes #346.