### PR TITLE
fix(runtime): centralize ingest URI validation

### DIFF
--- a/packages/hflow-server/src/hflow_server/_runtime.py
+++ b/packages/hflow-server/src/hflow_server/_runtime.py
@@ -414,7 +414,11 @@ def create_runtime_router(settings: ServerSettings, resolver: RuntimeResolver) -
         try:
             uris = [str(parse_data_root_relative_uri(uri)) for uri in request.uris]
         except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error)) from error
+            detail = (
+                f"{error} -- URIs are resolved against the runtime's configured data root "
+                "(e.g. episodes-in/run_0001.mcap)"
+            )
+            raise HTTPException(status_code=400, detail=detail) from error
         if request.profile not in RUN_PROFILES:
             raise HTTPException(
                 status_code=400,

--- a/packages/hflow-server/src/hflow_server/_runtime.py
+++ b/packages/hflow-server/src/hflow_server/_runtime.py
@@ -24,7 +24,6 @@ import time
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from posixpath import normpath
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -36,6 +35,7 @@ from hflow.runtime import (
     client_for_bundle,
     client_for_endpoint,
     load_bundle,
+    parse_data_root_relative_uri,
     resolve_remote_endpoint,
     sub_dag_id_for_stage,
 )
@@ -411,20 +411,10 @@ def create_runtime_router(settings: ServerSettings, resolver: RuntimeResolver) -
     @router.post("/runtime/ingest")
     def trigger_ingest(request: IngestRequest) -> IngestTriggerResponse:
         refuse_when_read_only(settings, disabled_actions="triggering ingest runs is")
-        uris = [uri.strip() for uri in request.uris]
-        if any(not uri for uri in uris):
-            raise HTTPException(status_code=400, detail="every uri must be a non-empty string")
-        # URIs resolve against the runtime's data root; absolute host paths and
-        # ../ escapes cannot work there, so refuse them before triggering --
-        # the same guard `hflow ingest` enforces (src/hflow/cli.py).
-        for uri in uris:
-            if uri.startswith("/") or normpath(uri).startswith(".."):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"{uri!r} is not relative to the data root -- URIs are resolved "
-                    "against the runtime's configured data root (e.g. "
-                    "`episodes-in/run_0001.mcap`)",
-                )
+        try:
+            uris = [str(parse_data_root_relative_uri(uri)) for uri in request.uris]
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
         if request.profile not in RUN_PROFILES:
             raise HTTPException(
                 status_code=400,

--- a/packages/hflow-server/tests/test_server_runtime.py
+++ b/packages/hflow-server/tests/test_server_runtime.py
@@ -327,6 +327,7 @@ def test_ingest_validates_profile_and_mode_before_touching_any_runtime(
         "/api/v1/runtime/ingest", json={"uris": ["   "], "profile": "full", "mode": "batch"}
     )
     assert blank_uri.status_code == 400
+    assert "configured data root" in blank_uri.json()["detail"]
 
     no_uris = client.post(
         "/api/v1/runtime/ingest", json={"uris": [], "profile": "full", "mode": "batch"}

--- a/packages/hflow-server/tests/test_server_runtime.py
+++ b/packages/hflow-server/tests/test_server_runtime.py
@@ -396,7 +396,7 @@ def test_ingest_triggers_the_master_dag(
     monkeypatch.setattr(AirflowClient, "ingest", fake_ingest)
     response = bundle_api.post(
         "/api/v1/runtime/ingest",
-        json={"uris": ["a.mcap", "sub/b.mcap"], "profile": "relabel", "mode": "online"},
+        json={"uris": ["  a.mcap  ", "sub/b.mcap"], "profile": "relabel", "mode": "online"},
     )
     assert response.status_code == 200
     assert response.json() == {"dag_run_id": "manual__ui", "state": "queued"}

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -1150,28 +1150,27 @@ def _print_ingest_failure_hint() -> None:
 
 
 def _command_ingest(arguments: argparse.Namespace) -> int:
-    from posixpath import normpath
-
     from hflow.runtime import (
         AirflowClientError,
         client_for_bundle,
         client_for_endpoint,
         load_bundle,
+        parse_data_root_relative_uri,
     )
 
     # URIs resolve against the runtime's data root; absolute host paths and
     # ../ escapes cannot work there, so fail before triggering.
-    for uri in arguments.uris:
-        if uri.startswith("/") or normpath(uri).startswith(".."):
-            print(
-                f"ingest: {uri!r} is not relative to the data root -- URIs are "
-                f"resolved against the workspace this project uses ({_environment_data_root()}), "
-                "so name them from there (e.g. `episodes-in/run_0001.mcap`). "
-                f"Set $HFLOW_DATA_ROOT or {PROJECT_CONFIG_FILE_NAME}'s data_root "
-                "to point at another workspace",
-                file=sys.stderr,
-            )
-            return 2
+    try:
+        uris = [parse_data_root_relative_uri(uri) for uri in arguments.uris]
+    except ValueError as error:
+        print(
+            f"ingest: {error} -- URIs are resolved against the workspace this project uses "
+            f"({_environment_data_root()}), so name them from there "
+            "(e.g. `episodes-in/run_0001.mcap`). "
+            f"Set $HFLOW_DATA_ROOT or {PROJECT_CONFIG_FILE_NAME}'s data_root",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         endpoint = _remote_endpoint_for_command(arguments)
@@ -1189,6 +1188,7 @@ def _command_ingest(arguments: argparse.Namespace) -> int:
             # Airflow is several GB of images and services, far too much to
             # do on someone's behalf inside an ordinary ingest, and far more
             # than a handful of episodes needs.
+            arguments.uris = uris
             return _ingest_in_process(arguments)
         try:
             paths = load_bundle(bundle_dir)
@@ -1202,14 +1202,14 @@ def _command_ingest(arguments: argparse.Namespace) -> int:
         if arguments.step_names is None:
             dag_run = client.ingest(
                 dag_id,
-                list(arguments.uris),
+                [str(uri) for uri in uris],
                 profile=arguments.profile,
                 online=arguments.online,
             )
         else:
             dag_run = client.ingest(
                 dag_id,
-                list(arguments.uris),
+                [str(uri) for uri in uris],
                 profile=arguments.profile,
                 online=arguments.online,
                 step_names=arguments.step_names,

--- a/src/hflow/runtime/__init__.py
+++ b/src/hflow/runtime/__init__.py
@@ -58,6 +58,7 @@ from hflow.runtime._topology import (
     StageTopology,
     ingest_dag_topology,
 )
+from hflow.uri import DataRootRelativeUri, parse_data_root_relative_uri
 
 __all__ = [
     "DEFAULT_AIRFLOW_IMAGE",
@@ -72,6 +73,7 @@ __all__ = [
     "ComposeError",
     "DagTaskNode",
     "DagTopology",
+    "DataRootRelativeUri",
     "DeployConfig",
     "DeployPaths",
     "IngestTopology",
@@ -92,6 +94,7 @@ __all__ = [
     "infer_hflow_source",
     "ingest_dag_topology",
     "load_bundle",
+    "parse_data_root_relative_uri",
     "render_bundle",
     "render_deploy_bundle",
     "resolve_remote_endpoint",

--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -19,9 +19,11 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
+
+from hflow.uri import parse_data_root_relative_uri
 
 
 class AirflowClientError(RuntimeError):
@@ -415,7 +417,7 @@ class AirflowClient:
     def ingest(
         self,
         dag_id: str,
-        uris: list[str],
+        uris: Sequence[str],
         *,
         profile: str = "full",
         online: bool = False,
@@ -448,8 +450,9 @@ class AirflowClient:
             # Same wording as hflow.batching.plan_batches, the task-side owner
             # of this invariant, so both entry points say the same thing.
             raise ValueError(f"batch_count must be >= 1, got {batch_count}")
+        validated_uris = [str(parse_data_root_relative_uri(uri)) for uri in uris]
         conf: dict[str, Any] = {
-            "uris": uris,
+            "uris": validated_uris,
             "profile": profile,
             "mode": "online" if online else "batch",
         }

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -42,6 +42,7 @@ from hflow.step_selection import (
 )
 from hflow.steps import IngestMode, Stage
 from hflow.storage import is_bucket_url, parse_storage_root
+from hflow.uri import DataRootRelativeUri, parse_data_root_relative_uri
 
 if TYPE_CHECKING:
     from hflow.app import App
@@ -128,10 +129,10 @@ def require_application_data_root(application: "App", expected_data_root: str) -
         )
 
 
-def resolve_episode_reference(data_root: str, uri: str) -> "Path | str":
+def resolve_episode_reference(data_root: str, uri: DataRootRelativeUri) -> "Path | str":
     """A conf URI (relative to the data root) as a processable reference."""
     if is_bucket_url(data_root):
-        return data_root.rstrip("/") + "/" + uri.lstrip("/")
+        return data_root.rstrip("/") + "/" + uri
     return Path(data_root) / uri
 
 
@@ -286,7 +287,9 @@ def process_stage_batch(
     ) as quarantine_history:
         for uri in uris:
             try:
-                episode_reference = resolve_episode_reference(data_root, str(uri))
+                episode_reference = resolve_episode_reference(
+                    data_root, parse_data_root_relative_uri(str(uri))
+                )
                 if isinstance(registered_step_selection, AllRegisteredSteps):
                     report = application.process(
                         episode_reference,
@@ -487,7 +490,9 @@ def _plan_after_sync(
 
     data_root = str(application.data_root)
     identity_by_uri = {
-        str(uri): application.source_identity(resolve_episode_reference(data_root, str(uri)))
+        str(uri): application.source_identity(
+            resolve_episode_reference(data_root, parse_data_root_relative_uri(str(uri)))
+        )
         for uri in uris
     }
     plans = plan_outstanding_stages(

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -217,9 +217,11 @@ def plan_stage_batches(
     if ingest_mode is IngestMode.ONLINE:
         return [{"items": [str(uri) for uri in validated_uris], "start_delay_s": 0.0}]
     data_root_storage = parse_storage_root(data_root)
+    # The conf keeps the URI's own spelling, so `a/../b.mcap` stays the
+    # identity; only the size lookup normalizes, because a storage key is
+    # validated for containment and would refuse the literal segments.
     item_sizes = {
-        str(uri): data_root_storage.file_size(normpath(str(uri).replace("\\", "/")))
-        for uri in validated_uris
+        str(uri): data_root_storage.file_size(normpath(str(uri))) for uri in validated_uris
     }
     resolved_batch_count = (
         int(batch_count)

--- a/src/hflow/stage_execution.py
+++ b/src/hflow/stage_execution.py
@@ -23,6 +23,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from posixpath import normpath
 from typing import TYPE_CHECKING, TypedDict
 
 from hflow.batching import plan_batches
@@ -210,12 +211,16 @@ def plan_stage_batches(
         ingest_mode = IngestMode(mode)
     except ValueError:
         raise ValueError(f"unknown mode {mode!r}; valid modes: {', '.join(IngestMode)}") from None
-    if not uris:
+    validated_uris = [parse_data_root_relative_uri(str(uri)) for uri in uris]
+    if not validated_uris:
         return []
     if ingest_mode is IngestMode.ONLINE:
-        return [{"items": [str(uri) for uri in uris], "start_delay_s": 0.0}]
+        return [{"items": [str(uri) for uri in validated_uris], "start_delay_s": 0.0}]
     data_root_storage = parse_storage_root(data_root)
-    item_sizes = {str(uri): data_root_storage.file_size(str(uri)) for uri in uris}
+    item_sizes = {
+        str(uri): data_root_storage.file_size(normpath(str(uri).replace("\\", "/")))
+        for uri in validated_uris
+    }
     resolved_batch_count = (
         int(batch_count)
         if batch_count is not None

--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -426,7 +426,7 @@ def outstanding_stage_uris(
         step_names=step_names,
     )
     return [
-        uri
+        str(uri)
         for uri in validated_uris
         if not isinstance(plan := plans.get(identity_by_uri[uri]), OutstandingStages)
         or stage in plan.stages

--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -45,6 +45,7 @@ from hflow.step_selection import (
     registered_step_is_selected,
 )
 from hflow.steps import RAN_STATUSES, SETTLED_STATUSES, Stage
+from hflow.uri import parse_data_root_relative_uri
 
 if TYPE_CHECKING:
     import duckdb
@@ -414,7 +415,9 @@ def outstanding_stage_uris(
     from hflow.stage_execution import resolve_episode_reference
 
     identity_by_uri = {
-        uri: application.source_identity(resolve_episode_reference(data_root, str(uri)))
+        uri: application.source_identity(
+            resolve_episode_reference(data_root, parse_data_root_relative_uri(str(uri)))
+        )
         for uri in uris
     }
     plans = plan_outstanding_stages(

--- a/src/hflow/stage_planning.py
+++ b/src/hflow/stage_planning.py
@@ -414,11 +414,10 @@ def outstanding_stage_uris(
         return []
     from hflow.stage_execution import resolve_episode_reference
 
+    validated_uris = [parse_data_root_relative_uri(str(uri)) for uri in uris]
     identity_by_uri = {
-        uri: application.source_identity(
-            resolve_episode_reference(data_root, parse_data_root_relative_uri(str(uri)))
-        )
-        for uri in uris
+        uri: application.source_identity(resolve_episode_reference(data_root, uri))
+        for uri in validated_uris
     }
     plans = plan_outstanding_stages(
         application,
@@ -428,7 +427,7 @@ def outstanding_stage_uris(
     )
     return [
         uri
-        for uri in uris
+        for uri in validated_uris
         if not isinstance(plan := plans.get(identity_by_uri[uri]), OutstandingStages)
         or stage in plan.stages
     ]

--- a/src/hflow/uri.py
+++ b/src/hflow/uri.py
@@ -21,10 +21,13 @@ def parse_data_root_relative_uri(uri: str) -> DataRootRelativeUri:
     if not candidate:
         raise ValueError("every uri must be a non-empty string")
     windows_path = PureWindowsPath(candidate)
-    if candidate.startswith("/") or windows_path.drive:
+    if candidate.startswith("/") or windows_path.anchor:
         raise ValueError(f"{candidate!r} is not relative to the data root")
 
-    normalized = normpath(candidate)
+    # URI separators are POSIX-style, but accepting a Windows spelling on one
+    # machine must not turn into a parent escape on another. Preserve the
+    # candidate itself; normalize only this containment check.
+    normalized = normpath(candidate.replace("\\", "/"))
     if normalized == ".." or normalized.startswith("../"):
         raise ValueError(f"{candidate!r} is not relative to the data root")
 

--- a/src/hflow/uri.py
+++ b/src/hflow/uri.py
@@ -12,7 +12,8 @@ def parse_data_root_relative_uri(uri: str) -> DataRootRelativeUri:
 
     The returned value keeps safe internal segments such as ``a/../b``
     unchanged. Only surrounding whitespace is normalized; the parser rejects
-    paths that are empty, anchored, or escape above the data root.
+    paths that are empty, anchored, use Windows separators, or escape above
+    the data root.
     """
     if not isinstance(uri, str):
         raise ValueError("ingest URI must be a string")
@@ -20,14 +21,15 @@ def parse_data_root_relative_uri(uri: str) -> DataRootRelativeUri:
     candidate = uri.strip()
     if not candidate:
         raise ValueError("every uri must be a non-empty string")
+    if "\\" in candidate:
+        raise ValueError("ingest URIs must use '/' as a separator")
+
     windows_path = PureWindowsPath(candidate)
     if candidate.startswith("/") or windows_path.anchor:
         raise ValueError(f"{candidate!r} is not relative to the data root")
 
-    # URI separators are POSIX-style, but accepting a Windows spelling on one
-    # machine must not turn into a parent escape on another. Preserve the
-    # candidate itself; normalize only this containment check.
-    normalized = normpath(candidate.replace("\\", "/"))
+    # Preserve the candidate itself; normalize only this containment check.
+    normalized = normpath(candidate)
     if normalized == ".." or normalized.startswith("../"):
         raise ValueError(f"{candidate!r} is not relative to the data root")
 

--- a/src/hflow/uri.py
+++ b/src/hflow/uri.py
@@ -1,0 +1,31 @@
+"""Validation for episode URIs relative to a runtime data root."""
+
+from pathlib import PureWindowsPath
+from posixpath import normpath
+from typing import NewType
+
+DataRootRelativeUri = NewType("DataRootRelativeUri", str)
+
+
+def parse_data_root_relative_uri(uri: str) -> DataRootRelativeUri:
+    """Trim and validate one URI before a runtime can resolve it.
+
+    The returned value keeps safe internal segments such as ``a/../b``
+    unchanged. Only surrounding whitespace is normalized; the parser rejects
+    paths that are empty, anchored, or escape above the data root.
+    """
+    if not isinstance(uri, str):
+        raise ValueError("ingest URI must be a string")
+
+    candidate = uri.strip()
+    if not candidate:
+        raise ValueError("every uri must be a non-empty string")
+    windows_path = PureWindowsPath(candidate)
+    if candidate.startswith("/") or windows_path.drive:
+        raise ValueError(f"{candidate!r} is not relative to the data root")
+
+    normalized = normpath(candidate)
+    if normalized == ".." or normalized.startswith("../"):
+        raise ValueError(f"{candidate!r} is not relative to the data root")
+
+    return DataRootRelativeUri(candidate)

--- a/tests/test_ingest_in_process.py
+++ b/tests/test_ingest_in_process.py
@@ -50,7 +50,7 @@ def test_ingest_without_a_runtime_processes_and_records(
     monkeypatch.delenv("HFLOW_AIRFLOW_URL", raising=False)
     monkeypatch.chdir(project)
 
-    assert cli_main(["ingest", "episodes-in/episode_0001.mcap"]) == 0
+    assert cli_main(["ingest", "  episodes-in/episode_0001.mcap  "]) == 0
 
     printed = capsys.readouterr()
     assert "no runtime addressed" in printed.err

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -670,7 +670,7 @@ def test_ingest_uses_env_credentials_and_dag_id(
         )
 
     monkeypatch.setattr(AirflowClient, "ingest", fake_ingest)
-    exit_code = main(["ingest", "a.mcap", "sub/b.mcap", "--bundle-dir", str(bundle_dir)])
+    exit_code = main(["ingest", "  a.mcap  ", "sub/b.mcap", "--bundle-dir", str(bundle_dir)])
     assert exit_code == 0
     assert captured["credentials"] == ("airflow", env_values["AIRFLOW_ADMIN_PASSWORD"])
     assert captured["dag_id"] == "demo_pipeline_ingest"
@@ -930,6 +930,42 @@ def test_ingest_rejects_uris_outside_data_root(
 
     assert exit_code == 2
     assert "is not relative to the data root" in capsys.readouterr().err
+
+
+def test_ingest_rejects_blank_uri_before_triggering(
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline_file: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = _rendered_bundle(tmp_path, pipeline_file)
+    called = False
+
+    def fake_ingest(
+        self: AirflowClient,
+        dag_id: str,
+        uris: list[str],
+        *,
+        profile: str = "full",
+        online: bool = False,
+        dag_run_id: str | None = None,
+    ) -> AirflowDagRun:
+        nonlocal called
+        called = True
+        return AirflowDagRun(
+            dag_run_id="manual__unexpected",
+            state="queued",
+            logical_date=None,
+            start_date=None,
+            end_date=None,
+            conf={},
+        )
+
+    monkeypatch.setattr(AirflowClient, "ingest", fake_ingest)
+
+    assert main(["ingest", "   ", "--bundle-dir", str(bundle_dir)]) == 2
+    assert not called
+    assert "non-empty" in capsys.readouterr().err
 
 
 def test_start_runtime_waits_for_all_five_dags(

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -374,7 +374,14 @@ def test_ingest_refuses_a_batch_count_the_run_could_not_honour(stub_server: str)
 
 @pytest.mark.parametrize(
     "uri",
-    ["   ", "/etc/passwd", "../outside.mcap", r"\episodes-in\a.mcap", r"a\..\..\outside.mcap"],
+    [
+        "   ",
+        "/etc/passwd",
+        "../outside.mcap",
+        r"\episodes-in\a.mcap",
+        r"episodes-in\a.mcap",
+        r"a\..\..\outside.mcap",
+    ],
 )
 def test_ingest_rejects_invalid_uri_before_making_http_requests(stub_server: str, uri: str) -> None:
     client = AirflowClient(stub_server, "airflow", "right-password")

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -372,6 +372,30 @@ def test_ingest_refuses_a_batch_count_the_run_could_not_honour(stub_server: str)
     assert _StubAirflowHandler.requests_seen == []
 
 
+@pytest.mark.parametrize("uri", ["   ", "/etc/passwd", "../outside.mcap"])
+def test_ingest_rejects_invalid_uri_before_making_http_requests(stub_server: str, uri: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(ValueError):
+        client.ingest("pipeline_ingest", [uri])
+
+    assert _StubAirflowHandler.requests_seen == []
+
+
+def test_ingest_trims_surrounding_uri_whitespace_in_trigger_conf(stub_server: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    client.ingest("pipeline_ingest", ["  a.mcap  "])
+
+    trigger_request = next(
+        entry for entry in _StubAirflowHandler.requests_seen if entry[1].endswith("/dagRuns")
+    )
+    assert trigger_request[2] == {
+        "logical_date": None,
+        "conf": {"uris": ["a.mcap"], "profile": "full", "mode": "batch"},
+    }
+
+
 def test_ingest_serializes_selected_step_names(stub_server: str) -> None:
     client = AirflowClient(stub_server, "airflow", "right-password")
 

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -372,7 +372,10 @@ def test_ingest_refuses_a_batch_count_the_run_could_not_honour(stub_server: str)
     assert _StubAirflowHandler.requests_seen == []
 
 
-@pytest.mark.parametrize("uri", ["   ", "/etc/passwd", "../outside.mcap"])
+@pytest.mark.parametrize(
+    "uri",
+    ["   ", "/etc/passwd", "../outside.mcap", r"\episodes-in\a.mcap", r"a\..\..\outside.mcap"],
+)
 def test_ingest_rejects_invalid_uri_before_making_http_requests(stub_server: str, uri: str) -> None:
     client = AirflowClient(stub_server, "airflow", "right-password")
 

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -381,6 +381,12 @@ def test_ingest_refuses_a_batch_count_the_run_could_not_honour(stub_server: str)
         r"\episodes-in\a.mcap",
         r"episodes-in\a.mcap",
         r"a\..\..\outside.mcap",
+        # Windows anchors with forward slashes: no backslash to catch them, so
+        # these reach the anchor check rather than the separator check. Main
+        # accepted all three at every entry point.
+        "C:/windows/system32/a.mcap",
+        "C:a.mcap",
+        "//server/share/a.mcap",
     ],
 )
 def test_ingest_rejects_invalid_uri_before_making_http_requests(stub_server: str, uri: str) -> None:
@@ -390,6 +396,34 @@ def test_ingest_rejects_invalid_uri_before_making_http_requests(stub_server: str
         client.ingest("pipeline_ingest", [uri])
 
     assert _StubAirflowHandler.requests_seen == []
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "episodes-in/run_0001.mcap",
+        # Not a drive: two letters before the colon. A coarser "contains a
+        # colon" or "second character is a colon" rule would refuse these,
+        # and they are legal relative paths on a POSIX data root.
+        "CC:/notadrive/a.mcap",
+        "file:with:colons.mcap",
+        # A safe internal segment: refused would be wrong, and rewriting it to
+        # 'b.mcap' would change the persisted identity (#314 non-goal).
+        "a/../b.mcap",
+    ],
+)
+def test_ingest_accepts_safe_uris_unchanged(stub_server: str, uri: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    client.ingest("pipeline_ingest", [uri])
+
+    trigger_request = next(
+        entry for entry in _StubAirflowHandler.requests_seen if entry[1].endswith("/dagRuns")
+    )
+    assert trigger_request[2] == {
+        "logical_date": None,
+        "conf": {"uris": [uri], "profile": "full", "mode": "batch"},
+    }
 
 
 def test_ingest_trims_surrounding_uri_whitespace_in_trigger_conf(stub_server: str) -> None:

--- a/tests/test_stage_execution.py
+++ b/tests/test_stage_execution.py
@@ -86,6 +86,15 @@ class TestLanePlanning:
         assert sorted(items_by_batch[1]["items"]) == ["small-1.mcap", "small-2.mcap"]
         assert {batch["start_delay_s"] for batch in batches} == {0.0, 2.0}
 
+    def test_batch_lane_trims_uri_and_sizes_safe_internal_segments(self, tmp_path: Path) -> None:
+        (tmp_path / "b.mcap").write_bytes(b"episode")
+
+        batches = plan_stage_batches(
+            ["  a/../b.mcap  "], mode="batch", batch_count=None, data_root=str(tmp_path)
+        )
+
+        assert batches == [{"items": ["a/../b.mcap"], "start_delay_s": 0.0}]
+
     def test_empty_uris_plan_nothing(self, tmp_path: Path) -> None:
         assert plan_stage_batches([], mode="batch", batch_count=None, data_root=str(tmp_path)) == []
 

--- a/tests/test_stage_execution.py
+++ b/tests/test_stage_execution.py
@@ -10,6 +10,7 @@ import pytest
 
 import hflow
 from hflow import stage_execution
+from hflow.runtime import parse_data_root_relative_uri
 from hflow.stage_execution import (
     StageBatchCounts,
     load_pipeline_application,
@@ -117,13 +118,18 @@ class TestConfFlags:
 
 class TestEpisodeReferences:
     def test_bucket_root_joins_as_url_and_local_as_path(self) -> None:
+        uri = parse_data_root_relative_uri("episodes-in/a.mcap")
         assert (
-            resolve_episode_reference("gs://bucket/prefix", "episodes-in/a.mcap")
+            resolve_episode_reference("gs://bucket/prefix", uri)
             == "gs://bucket/prefix/episodes-in/a.mcap"
         )
-        assert resolve_episode_reference("/opt/airflow/data", "episodes-in/a.mcap") == Path(
+        assert resolve_episode_reference("/opt/airflow/data", uri) == Path(
             "/opt/airflow/data/episodes-in/a.mcap"
         )
+
+    def test_a_leading_slash_is_rejected_before_resolution(self) -> None:
+        with pytest.raises(ValueError, match="relative to the data root"):
+            parse_data_root_relative_uri("/episodes-in/a.mcap")
 
 
 class TestPipelineLoading:

--- a/tests/test_stage_planning.py
+++ b/tests/test_stage_planning.py
@@ -586,6 +586,9 @@ class TestFilteringAScheduledStagesUris:
 
         assert self._filter(project, hflow.Stage.META) == [EPISODE_URI]
 
+    def test_filter_returns_trimmed_uris(self, project: Path) -> None:
+        assert self._filter(project, hflow.Stage.META, f"  {EPISODE_URI}  ") == [EPISODE_URI]
+
     def test_a_check_added_afterwards_makes_it_outstanding_again(self, project: Path) -> None:
         _ingest(project)
         (project / "pipeline.py").write_text(


### PR DESCRIPTION
## Summary

Fixes #314.

- Add one shared parser returning `DataRootRelativeUri`.
- Apply the same trimming and safety checks in the CLI, workspace server, and `AirflowClient.ingest()`.
- Pass normalized URIs through in-process execution, scheduled planning, and batch sizing.
- Make `resolve_episode_reference()` consume the refined value without repairing leading slashes.
- Reject POSIX and Windows-anchored/traversal paths while preserving safe internal segments such as `a/../b`.

## Why

Previously, the server trimmed URI whitespace while the CLI and SDK forwarded it unchanged, and each entry point maintained its own validation logic. Scheduled planning also sent raw URI spellings through storage-key validation, so accepted internal path segments could fail before execution.

The shared boundary trims only surrounding whitespace, rejects blank/absolute/parent-escaping paths, and preserves the original safe URI spelling for trigger configuration and identity. Physical batch-size lookup uses the safely resolved relative path.

## Validation

- `uvx pre-commit run --all-files`
- `uv run --python 3.14 --locked ruff check --fix`
- `uv run --python 3.14 --locked ruff format`
- `uv run --python 3.14 --locked ty check`
- Python 3.11: `1,401 passed, 6 skipped`
- Python 3.14: `1,401 passed, 6 skipped`
- Focused boundary/regression suite: `124 passed`

## Checklist

- [x] Existing CLI exit code 2 and server HTTP 400 behavior preserved.
- [x] SDK rejects invalid URIs before making HTTP requests.
- [x] POSIX and Windows URI boundary cases are covered.
- [x] Scheduled planning trims URIs and supports safe internal segments.
- [x] No trigger configuration keys or response schemas changed.
- [x] No generated artifacts, credentials, or recordings added.