### PR TITLE
fix(egosuite): match saved labels by source provenance

### DIFF
--- a/docs/how-to/run-egosuite-hand-evaluation.md
+++ b/docs/how-to/run-egosuite-hand-evaluation.md
@@ -148,10 +148,26 @@ export EGOSUITE_LABEL_MANIFEST='data/egosuite-evaluation/labels/natural-1000.jso
 ```
 
 The pipeline validates every manifest record, selects its declared source
-frame indices for each canonical episode, and includes the manifest digest in
-the HFlow check version. Missing or malformed model content is retained as a
+frame indices only when the report's `source_uri` matches the canonical
+episode's HFlow provenance, and includes the manifest digest in the HFlow
+check version. Missing or mismatched provenance fails before frame extraction
+or a model request. Missing or malformed model content is retained as a
 `valid=false` observation so provider output failures lower end-to-end
 accuracy instead of discarding the episode's evidence.
+
+Current label reports record the same source identity returned by
+`App.source_identity()`. Set `HFLOW_DATA_ROOT` consistently when creating the
+report and running the pipeline. When the dataset lives below that root, the
+identity is root-relative and remains stable across equivalent host and
+container mount paths. For the layout in this guide, use:
+
+```bash
+export HFLOW_DATA_ROOT='data/egosuite-evaluation'
+```
+
+Reports created before `source_uri` was added remain usable when each
+`source_episode` basename refers to exactly one source path. An older report
+that uses one basename for multiple paths is ambiguous and must be regenerated.
 
 Use this entrypoint when the judgment belongs in an HFlow episode pipeline.
 Use `evaluate.py` below when comparing models over a declared dataset slice;
@@ -172,8 +188,9 @@ uv run --project examples/egosuite_evaluation \
 
 The terminal table reports the number of frames labeled 0, 1, or 2. The JSON
 file records the projected joint count for each hand, the resulting hand count,
-the exact source frame index, and any pose-quality reasons. Run `labels` first
-on a new corpus to inspect class balance before interpreting model accuracy.
+the exact source frame index, HFlow's canonical `source_uri`, and any
+pose-quality reasons. Run `labels` first on a new corpus to inspect class
+balance before interpreting model accuracy.
 
 For a naturally distributed random sample, select episodes and then select
 temporally separated frames within each episode:

--- a/examples/egosuite_evaluation/evaluate.py
+++ b/examples/egosuite_evaluation/evaluate.py
@@ -68,6 +68,7 @@ SCHEMA_VERSION = 1
 EXPECTED_HAND_JOINT_COUNT = 21
 DEFAULT_RUNS_DIRECTORY = Path("data/egosuite-evaluation/runs")
 DEFAULT_LABELS_DIRECTORY = Path("data/egosuite-evaluation/labels")
+DEFAULT_HFLOW_DATA_ROOT = Path("data/egosuite-evaluation/hflow")
 INSPECT_LOGS_DIRECTORY_NAME = "logs"
 RUN_METADATA_FILE_NAME = "run.json"
 SUMMARY_FILE_NAME = "summary.json"
@@ -109,6 +110,12 @@ class ProjectedHandFrameLabel:
     right_hand_issue_reasons: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class ProjectedHandLabelReport:
+    labels_by_source_identity: dict[str, list[ProjectedHandFrameLabel]]
+    uses_legacy_episode_names: bool
+
+
 def _required_label_record_string(
     frame_record: Mapping[str, object], field_name: str, record_context: str
 ) -> str:
@@ -140,8 +147,8 @@ def _label_record_issue_reasons(
 
 def load_projected_hand_label_report(
     report_path: Path,
-) -> dict[str, list[ProjectedHandFrameLabel]]:
-    """Parse a saved label report, keyed by its stable source episode name."""
+) -> ProjectedHandLabelReport:
+    """Parse a saved label report, keyed by source URI or a legacy episode name."""
 
     try:
         report_payload = json.loads(report_path.read_text())
@@ -155,8 +162,10 @@ def load_projected_hand_label_report(
     if not isinstance(raw_frame_records, list):
         raise ValueError(f"projected-hand label report {report_path} must contain a 'frames' array")
 
-    labels_by_source_episode: dict[str, list[ProjectedHandFrameLabel]] = defaultdict(list)
+    labels_by_source_identity: dict[str, list[ProjectedHandFrameLabel]] = defaultdict(list)
     seen_frame_keys: set[tuple[str, int]] = set()
+    legacy_source_path_by_episode: dict[str, Path] = {}
+    uses_legacy_episode_names: bool | None = None
     for record_index, raw_frame_record in enumerate(raw_frame_records):
         record_context = f"{report_path} frame record {record_index}"
         if not isinstance(raw_frame_record, dict):
@@ -172,6 +181,28 @@ def load_projected_hand_label_report(
                 f"{record_context} source_episode {source_episode!r} does not match "
                 f"source_path stem {source_path.stem!r}"
             )
+        record_uses_legacy_episode_name = "source_uri" not in raw_frame_record
+        if uses_legacy_episode_names is None:
+            uses_legacy_episode_names = record_uses_legacy_episode_name
+        elif uses_legacy_episode_names is not record_uses_legacy_episode_name:
+            raise ValueError(
+                f"{record_context} mixes legacy records without source_uri with current records"
+            )
+        source_identity = (
+            source_episode
+            if record_uses_legacy_episode_name
+            else _required_label_record_string(raw_frame_record, "source_uri", record_context)
+        )
+        if record_uses_legacy_episode_name:
+            previous_source_path = legacy_source_path_by_episode.setdefault(
+                source_episode, source_path
+            )
+            if previous_source_path != source_path:
+                raise ValueError(
+                    f"{record_context} uses legacy source episode {source_episode!r} for both "
+                    f"{previous_source_path} and {source_path}; regenerate the report to record "
+                    "source_uri provenance"
+                )
         try:
             camera_view = CameraView(
                 _required_label_record_string(raw_frame_record, "camera_view", record_context)
@@ -198,13 +229,14 @@ def load_projected_hand_label_report(
             raise ValueError(f"{record_context} right joint count must be between 0 and 21")
         if expected_hand_count not in {0, 1, 2}:
             raise ValueError(f"{record_context} expected_hand_count must be 0, 1, or 2")
-        frame_key = (source_episode, frame_index)
+        frame_key = (source_identity, frame_index)
         if frame_key in seen_frame_keys:
             raise ValueError(
-                f"{record_context} duplicates source episode {source_episode!r} frame {frame_index}"
+                f"{record_context} duplicates source identity {source_identity!r} "
+                f"frame {frame_index}"
             )
         seen_frame_keys.add(frame_key)
-        labels_by_source_episode[source_episode].append(
+        labels_by_source_identity[source_identity].append(
             ProjectedHandFrameLabel(
                 source_path=source_path,
                 source_episode=source_episode,
@@ -222,9 +254,12 @@ def load_projected_hand_label_report(
             )
         )
 
-    for source_labels in labels_by_source_episode.values():
+    for source_labels in labels_by_source_identity.values():
         source_labels.sort(key=lambda label: label.frame_index)
-    return dict(labels_by_source_episode)
+    return ProjectedHandLabelReport(
+        labels_by_source_identity=dict(labels_by_source_identity),
+        uses_legacy_episode_names=bool(uses_legacy_episode_names),
+    )
 
 
 @dataclass(frozen=True)
@@ -303,9 +338,19 @@ def _source_episode_name(source_path: Path) -> str:
     return source_path.stem
 
 
+def _source_uri_by_path(source_paths: Sequence[Path]) -> dict[Path, str]:
+    identity_app = hflow.App(
+        "egosuite-projected-hand-label-source-identity",
+        data_root=os.environ.get("HFLOW_DATA_ROOT", str(DEFAULT_HFLOW_DATA_ROOT)),
+        default_checks=(),
+    )
+    return {source_path: identity_app.source_identity(source_path) for source_path in source_paths}
+
+
 def select_episode_paths(
     source_paths: Sequence[Path],
     *,
+    source_uri_by_path: Mapping[Path, str],
     episode_count: int | None,
     sample_seed: int,
 ) -> tuple[Path, ...]:
@@ -319,7 +364,7 @@ def select_episode_paths(
         raise ValueError("sample seed must be nonnegative")
     ranked_source_paths = sorted(
         source_paths,
-        key=lambda source_path: _sha256_text(f"{sample_seed}\0{_source_episode_name(source_path)}"),
+        key=lambda source_path: _sha256_text(f"{sample_seed}\0{source_uri_by_path[source_path]}"),
     )
     selected_source_paths = set(ranked_source_paths[:episode_count])
     return tuple(
@@ -331,6 +376,7 @@ def _selected_frame_indices(
     source_path: Path,
     source_frame_count: int,
     *,
+    source_uri: str,
     frame_stride: int,
     limit_per_episode: int | None,
     samples_per_episode: int | None,
@@ -349,9 +395,7 @@ def _selected_frame_indices(
         raise ValueError("sample seed must be nonnegative")
     ranked_frame_indices = sorted(
         eligible_frame_indices,
-        key=lambda frame_index: _sha256_text(
-            f"{sample_seed}\0{_source_episode_name(source_path)}\0{frame_index}"
-        ),
+        key=lambda frame_index: _sha256_text(f"{sample_seed}\0{source_uri}\0{frame_index}"),
     )
     return sorted(ranked_frame_indices[:samples_per_episode])
 
@@ -524,6 +568,7 @@ def _complete_projected_label(
 def load_projected_hand_labels(
     source_path: Path,
     *,
+    source_uri: str,
     camera_view: CameraView,
     frame_stride: int,
     limit_per_episode: int | None,
@@ -554,6 +599,7 @@ def load_projected_hand_labels(
         selected_frame_indices = _selected_frame_indices(
             source_path,
             source_frame_count,
+            source_uri=source_uri,
             frame_stride=frame_stride,
             limit_per_episode=limit_per_episode,
             samples_per_episode=samples_per_episode,
@@ -616,6 +662,7 @@ def load_projected_hand_labels(
 def select_stratified_labels(
     labels_by_source: Mapping[Path, Sequence[ProjectedHandFrameLabel]],
     *,
+    source_uri_by_path: Mapping[Path, str],
     samples_per_hand_count: int | None,
     sample_seed: int,
 ) -> dict[Path, list[ProjectedHandFrameLabel]]:
@@ -639,7 +686,7 @@ def select_stratified_labels(
         ]
         matching_labels.sort(
             key=lambda label: _sha256_text(
-                f"{sample_seed}\0{label.source_path}\0{label.frame_index}"
+                f"{sample_seed}\0{source_uri_by_path[label.source_path]}\0{label.frame_index}"
             )
         )
         selected_frame_keys.update(
@@ -802,10 +849,11 @@ def _inspect_generate_config(configuration: EvaluationConfiguration) -> Generate
     )
 
 
-def _label_record(label: ProjectedHandFrameLabel) -> dict[str, object]:
+def _label_record(label: ProjectedHandFrameLabel, *, source_uri: str) -> dict[str, object]:
     return {
         **asdict(label),
         "source_path": str(label.source_path),
+        "source_uri": source_uri,
         "camera_view": label.camera_view.value,
         "left_hand_issue_reasons": list(label.left_hand_issue_reasons),
         "right_hand_issue_reasons": list(label.right_hand_issue_reasons),
@@ -887,6 +935,7 @@ def write_label_report(
     output_path: Path,
 ) -> None:
     all_labels = [label for labels in labels_by_source.values() for label in labels]
+    source_uri_by_path = _source_uri_by_path(tuple(labels_by_source))
     report = {
         "schema_version": SCHEMA_VERSION,
         "label_type": "projected-hand-joints",
@@ -900,7 +949,10 @@ def write_label_report(
         "projection_rule": "hand is in frame when at least one labeled joint has positive depth and projects inside the image bounds",
         "summary": summarize_reference_labels(all_labels),
         "sources": [str(path) for path in labels_by_source],
-        "frames": [_label_record(label) for label in all_labels],
+        "frames": [
+            _label_record(label, source_uri=source_uri_by_path[label.source_path])
+            for label in all_labels
+        ],
     }
     _write_json_atomically(output_path, report)
 
@@ -1328,9 +1380,11 @@ def run_evaluation(configuration: EvaluationConfiguration) -> dict[str, object]:
             "only for an endpoint that does not authenticate"
         )
     run_metadata = _prepare_output_directory(configuration)
+    source_uri_by_path = _source_uri_by_path(configuration.source_paths)
     candidate_labels_by_source = {
         source_path: load_projected_hand_labels(
             source_path,
+            source_uri=source_uri_by_path[source_path],
             camera_view=configuration.camera_view,
             frame_stride=configuration.frame_stride,
             limit_per_episode=configuration.limit_per_episode,
@@ -1341,6 +1395,7 @@ def run_evaluation(configuration: EvaluationConfiguration) -> dict[str, object]:
     }
     labels_by_source = select_stratified_labels(
         candidate_labels_by_source,
+        source_uri_by_path=source_uri_by_path,
         samples_per_hand_count=configuration.samples_per_hand_count,
         sample_seed=configuration.sample_seed,
     )
@@ -1464,8 +1519,11 @@ def _default_output_directory(model: str, camera_view: CameraView) -> Path:
 def _labels_by_source_from_arguments(
     arguments: argparse.Namespace,
 ) -> dict[Path, list[ProjectedHandFrameLabel]]:
+    resolved_source_paths = _resolved_mcap_paths(arguments.inputs)
+    source_uri_by_path = _source_uri_by_path(resolved_source_paths)
     source_paths = select_episode_paths(
-        _resolved_mcap_paths(arguments.inputs),
+        resolved_source_paths,
+        source_uri_by_path=source_uri_by_path,
         episode_count=arguments.episode_count,
         sample_seed=arguments.sample_seed,
     )
@@ -1473,6 +1531,7 @@ def _labels_by_source_from_arguments(
     candidate_labels_by_source = {
         source_path: load_projected_hand_labels(
             source_path,
+            source_uri=source_uri_by_path[source_path],
             camera_view=camera_view,
             frame_stride=arguments.frame_stride,
             limit_per_episode=arguments.limit_per_episode,
@@ -1483,6 +1542,7 @@ def _labels_by_source_from_arguments(
     }
     return select_stratified_labels(
         candidate_labels_by_source,
+        source_uri_by_path=source_uri_by_path,
         samples_per_hand_count=arguments.samples_per_hand_count,
         sample_seed=arguments.sample_seed,
     )
@@ -1495,8 +1555,10 @@ def _run_configuration_from_arguments(arguments: argparse.Namespace) -> Evaluati
         raise ValueError("--base-url or OPENAI_BASE_URL is required")
     camera_view = CameraView(arguments.camera)
     output_directory = arguments.output or _default_output_directory(arguments.model, camera_view)
+    resolved_source_paths = _resolved_mcap_paths(arguments.inputs)
     source_paths = select_episode_paths(
-        _resolved_mcap_paths(arguments.inputs),
+        resolved_source_paths,
+        source_uri_by_path=_source_uri_by_path(resolved_source_paths),
         episode_count=arguments.episode_count,
         sample_seed=arguments.sample_seed,
     )

--- a/examples/egosuite_evaluation/pipeline.py
+++ b/examples/egosuite_evaluation/pipeline.py
@@ -15,14 +15,16 @@ import importlib
 import os
 import threading
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple, assert_never
 
 import hflow
 from examples.egosuite_evaluation.evaluate import (
+    DEFAULT_HFLOW_DATA_ROOT,
     CameraView,
     ProjectedHandFrameLabel,
+    ProjectedHandLabelReport,
     camera_topics,
     load_projected_hand_label_report,
     load_projected_hand_labels,
@@ -37,7 +39,6 @@ from examples.egosuite_evaluation.judgment import (
     image_file_data_url,
 )
 
-DEFAULT_HFLOW_DATA_ROOT = Path("data/egosuite-evaluation/hflow")
 DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:8000/v1"
 DEFAULT_MODEL_NAME = "model-not-configured"
 MEASUREMENT_PREFIX = "egosuite/hand_count"
@@ -109,7 +110,7 @@ def _pipeline_configuration() -> PipelineConfiguration:
 
 
 pipeline_configuration = _pipeline_configuration()
-manifest_labels_by_source_episode = (
+manifest_label_report = (
     load_projected_hand_label_report(pipeline_configuration.label_manifest_path)
     if pipeline_configuration.label_manifest_path is not None
     else None
@@ -140,28 +141,33 @@ def _check_version() -> hflow.StepVersion:
         ),
     }
     return hflow.step_version_from_contract(
-        "egosuite-projected-hand-visibility-v1",
+        "egosuite-projected-hand-visibility-v2",
         version_contract,
     )
 
 
 def labels_for_pipeline_episode(
     episode_path: Path,
-    labels_by_source_episode: dict[str, list[ProjectedHandFrameLabel]],
+    episode_metadata: Mapping[str, object],
+    label_report: ProjectedHandLabelReport,
 ) -> list[ProjectedHandFrameLabel]:
     """Select one canonical episode's declared frames from a label manifest."""
 
+    source_uri = episode_metadata.get("source_uri")
+    if not isinstance(source_uri, str) or not source_uri:
+        raise ValueError(f"canonical episode {episode_path} has no source_uri provenance")
     canonical_suffix = ".canonical.mcap"
     source_episode = (
         episode_path.name[: -len(canonical_suffix)]
         if episode_path.name.endswith(canonical_suffix)
         else episode_path.stem
     )
+    source_identity = source_episode if label_report.uses_legacy_episode_names else source_uri
     try:
-        return labels_by_source_episode[source_episode]
+        return label_report.labels_by_source_identity[source_identity]
     except KeyError:
         raise ValueError(
-            f"label manifest has no frames for source episode {source_episode!r}"
+            f"label manifest has no frames for source identity {source_identity!r}"
         ) from None
 
 
@@ -337,8 +343,11 @@ def hand_visibility_check_result(
 def egosuite_projected_hand_visibility(episode: hflow.Episode) -> hflow.CheckResult:
     """Compare image-only VLM hand counts with projected EgoSuite joints."""
 
-    if manifest_labels_by_source_episode is not None:
-        labels = labels_for_pipeline_episode(episode.path, manifest_labels_by_source_episode)
+    source_uri = episode.metadata.get("source_uri")
+    if not isinstance(source_uri, str) or not source_uri:
+        raise ValueError(f"canonical episode {episode.path} has no source_uri provenance")
+    if manifest_label_report is not None:
+        labels = labels_for_pipeline_episode(episode.path, episode.metadata, manifest_label_report)
         mismatched_camera_views = sorted(
             {
                 label.camera_view.value
@@ -354,6 +363,7 @@ def egosuite_projected_hand_visibility(episode: hflow.Episode) -> hflow.CheckRes
     else:
         labels = load_projected_hand_labels(
             episode.path,
+            source_uri=source_uri,
             camera_view=pipeline_configuration.camera_view,
             frame_stride=pipeline_configuration.frame_stride,
             limit_per_episode=pipeline_configuration.limit_per_episode,

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -35,6 +35,7 @@ from examples.egosuite_evaluation.evaluate import (
     select_episode_paths,
     select_stratified_labels,
     summarize_evaluation_results,
+    write_label_report,
 )
 from examples.egosuite_evaluation.geometry import (
     CameraPoseInWorld,
@@ -289,14 +290,165 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
         )
     )
 
-    labels_by_source_episode = load_projected_hand_label_report(report_path)
+    label_report = load_projected_hand_label_report(report_path)
     selected_labels = labels_for_pipeline_episode(
-        tmp_path / "episode-123.canonical.mcap", labels_by_source_episode
+        tmp_path / "episode-123.canonical.mcap",
+        {"source_uri": "run-a/episode-123.mcap"},
+        label_report,
     )
 
     assert [label.frame_index for label in selected_labels] == [3, 8]
     assert [label.expected_hand_count for label in selected_labels] == [1, 2]
     assert selected_labels[1].right_hand_issue_reasons == ("occlusion",)
+
+
+def test_legacy_label_report_rejects_one_basename_for_multiple_sources(tmp_path: Path) -> None:
+    report_path = tmp_path / "labels.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "frames": [
+                    {
+                        "source_path": str(tmp_path / run_name / "episode.mcap"),
+                        "source_episode": "episode",
+                        "camera_view": "head-left",
+                        "frame_index": frame_index,
+                        "left_in_frame_joint_count": 21,
+                        "right_in_frame_joint_count": 0,
+                        "expected_hand_count": 1,
+                        "left_hand_issue_reasons": [],
+                        "right_hand_issue_reasons": [],
+                    }
+                    for run_name, frame_index in (("run-a", 3), ("run-b", 8))
+                ]
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"regenerate.*source_uri"):
+        load_projected_hand_label_report(report_path)
+
+
+def test_saved_label_report_matches_same_named_sources_by_canonical_provenance(
+    tmp_path: Path,
+) -> None:
+    first_source_path = tmp_path / "run-a" / "episode.mcap"
+    second_source_path = tmp_path / "run-b" / "episode.mcap"
+    report_path = tmp_path / "labels.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "frames": [
+                    {
+                        "source_path": str(source_path),
+                        "source_uri": source_uri,
+                        "source_episode": "episode",
+                        "camera_view": "head-left",
+                        "frame_index": 3,
+                        "left_in_frame_joint_count": 21,
+                        "right_in_frame_joint_count": 21 if expected_hand_count == 2 else 0,
+                        "expected_hand_count": expected_hand_count,
+                        "left_hand_issue_reasons": [],
+                        "right_hand_issue_reasons": [],
+                    }
+                    for source_path, source_uri, expected_hand_count in (
+                        (first_source_path, "run-a/episode.mcap", 1),
+                        (second_source_path, "run-b/episode.mcap", 2),
+                    )
+                ]
+            }
+        )
+    )
+
+    label_report = load_projected_hand_label_report(report_path)
+    selected_labels = labels_for_pipeline_episode(
+        tmp_path / "episode.canonical.mcap",
+        {"source_uri": "run-b/episode.mcap"},
+        label_report,
+    )
+
+    assert [label.expected_hand_count for label in selected_labels] == [2]
+
+
+@pytest.mark.parametrize(
+    ("episode_metadata", "error_match"),
+    [
+        ({}, "has no source_uri provenance"),
+        ({"source_uri": "run-c/episode.mcap"}, "run-c/episode.mcap"),
+    ],
+)
+def test_saved_label_report_rejects_missing_or_unrelated_canonical_provenance(
+    tmp_path: Path,
+    episode_metadata: dict[str, object],
+    error_match: str,
+) -> None:
+    source_path = tmp_path / "run-a" / "episode.mcap"
+    report_path = tmp_path / "labels.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "frames": [
+                    {
+                        "source_path": str(source_path),
+                        "source_uri": "run-a/episode.mcap",
+                        "source_episode": "episode",
+                        "camera_view": "head-left",
+                        "frame_index": 3,
+                        "left_in_frame_joint_count": 21,
+                        "right_in_frame_joint_count": 0,
+                        "expected_hand_count": 1,
+                        "left_hand_issue_reasons": [],
+                        "right_hand_issue_reasons": [],
+                    }
+                ]
+            }
+        )
+    )
+    label_report = load_projected_hand_label_report(report_path)
+
+    with pytest.raises(ValueError, match=error_match):
+        labels_for_pipeline_episode(
+            tmp_path / "episode.canonical.mcap",
+            episode_metadata,
+            label_report,
+        )
+
+
+def test_label_report_records_hflow_source_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_root = tmp_path / "hflow-data"
+    source_path = data_root / "run-a" / "episode.mcap"
+    source_path.parent.mkdir(parents=True)
+    source_path.touch()
+    monkeypatch.setenv("HFLOW_DATA_ROOT", str(data_root))
+    label = ProjectedHandFrameLabel(
+        source_path=source_path,
+        source_episode="episode",
+        camera_view=CameraView.HEAD_LEFT,
+        frame_index=3,
+        left_in_frame_joint_count=21,
+        right_in_frame_joint_count=0,
+        expected_hand_count=1,
+        left_hand_issue_reasons=(),
+        right_hand_issue_reasons=(),
+    )
+    report_path = tmp_path / "labels.json"
+
+    write_label_report(
+        {source_path: [label]},
+        camera_view=CameraView.HEAD_LEFT,
+        frame_stride=30,
+        limit_per_episode=None,
+        episode_count=None,
+        samples_per_episode=None,
+        samples_per_hand_count=None,
+        sample_seed=42,
+        output_path=report_path,
+    )
+
+    report = json.loads(report_path.read_text())
+    assert report["frames"][0]["source_uri"] == "run-a/episode.mcap"
 
 
 def test_pipeline_records_agreement_output_validity_and_frame_intervals() -> None:
@@ -938,10 +1090,16 @@ def test_stratified_selection_caps_each_class_and_is_reproducible() -> None:
     ]
 
     first_selection = select_stratified_labels(
-        {source_path: labels}, samples_per_hand_count=2, sample_seed=7
+        {source_path: labels},
+        source_uri_by_path={source_path: "episode.mcap"},
+        samples_per_hand_count=2,
+        sample_seed=7,
     )
     repeated_selection = select_stratified_labels(
-        {source_path: labels}, samples_per_hand_count=2, sample_seed=7
+        {source_path: labels},
+        source_uri_by_path={source_path: "episode.mcap"},
+        samples_per_hand_count=2,
+        sample_seed=7,
     )
 
     selected_labels = first_selection[source_path]
@@ -954,22 +1112,58 @@ def test_stratified_selection_caps_each_class_and_is_reproducible() -> None:
     assert first_selection == repeated_selection
 
 
+def test_stratified_sampling_ranks_same_named_sources_by_source_uri() -> None:
+    first_source_path = Path("/workspace/run-a/episode.mcap")
+    second_source_path = Path("/workspace/run-b/episode.mcap")
+    labels_by_source = {
+        source_path: [
+            ProjectedHandFrameLabel(
+                source_path=source_path,
+                source_episode="episode",
+                camera_view=CameraView.HEAD_LEFT,
+                frame_index=0,
+                left_in_frame_joint_count=0,
+                right_in_frame_joint_count=0,
+                expected_hand_count=0,
+                left_hand_issue_reasons=(),
+                right_hand_issue_reasons=(),
+            )
+        ]
+        for source_path in (first_source_path, second_source_path)
+    }
+
+    selection = select_stratified_labels(
+        labels_by_source,
+        source_uri_by_path={
+            first_source_path: "run-a/episode.mcap",
+            second_source_path: "run-b/episode.mcap",
+        },
+        samples_per_hand_count=1,
+        sample_seed=7,
+    )
+
+    assert set(selection) == {second_source_path}
+
+
 def test_natural_sampling_selects_reproducible_episodes_and_frames() -> None:
     source_paths = tuple(Path(f"episode-{episode_index}.mcap") for episode_index in range(5))
 
     first_episode_selection = select_episode_paths(
         source_paths,
+        source_uri_by_path={path: str(path) for path in source_paths},
         episode_count=3,
         sample_seed=7,
     )
     repeated_episode_selection = select_episode_paths(
         source_paths,
+        source_uri_by_path={path: str(path) for path in source_paths},
         episode_count=3,
         sample_seed=7,
     )
     selected_frame_indices = _selected_frame_indices(
         first_episode_selection[0],
         300,
+        source_uri=str(first_episode_selection[0]),
         frame_stride=30,
         limit_per_episode=None,
         samples_per_episode=4,
@@ -982,6 +1176,47 @@ def test_natural_sampling_selects_reproducible_episodes_and_frames() -> None:
     assert selected_frame_indices == sorted(selected_frame_indices)
     assert len(selected_frame_indices) == 4
     assert all(frame_index % 30 == 0 for frame_index in selected_frame_indices)
+
+
+def test_episode_sampling_ranks_same_named_sources_by_source_uri() -> None:
+    first_source_path = Path("run-a/episode.mcap")
+    second_source_path = Path("run-b/episode.mcap")
+
+    selection = select_episode_paths(
+        (second_source_path, first_source_path),
+        source_uri_by_path={
+            first_source_path: "run-a/episode.mcap",
+            second_source_path: "run-b/episode.mcap",
+        },
+        episode_count=1,
+        sample_seed=7,
+    )
+
+    assert selection == (first_source_path,)
+
+
+def test_frame_sampling_ranks_same_named_sources_by_source_uri() -> None:
+    first_selection = _selected_frame_indices(
+        Path("run-a/episode.mcap"),
+        300,
+        source_uri="run-a/episode.mcap",
+        frame_stride=30,
+        limit_per_episode=None,
+        samples_per_episode=4,
+        sample_seed=7,
+    )
+    second_selection = _selected_frame_indices(
+        Path("run-b/episode.mcap"),
+        300,
+        source_uri="run-b/episode.mcap",
+        frame_stride=30,
+        limit_per_episode=None,
+        samples_per_episode=4,
+        sample_seed=7,
+    )
+
+    assert first_selection == [0, 30, 90, 150]
+    assert second_selection == [0, 150, 180, 240]
 
 
 def test_compare_refuses_a_missing_summary_without_a_traceback(


### PR DESCRIPTION
## Summary

- record HFlow `source_uri` identity in new EgoSuite label reports
- match saved labels to canonical episode provenance instead of basenames
- preserve unambiguous legacy reports and reject ambiguous ones with regeneration guidance
- use source identity for deterministic episode, frame, and stratified sampling

## Why

Recordings in different directories can share a basename. Basename-keyed reports merged or rejected those labels and could apply them to an unrelated canonical episode. This keeps report matching aligned with `App.source_identity()` and canonical `source_uri` semantics.

Closes #310.

## Validation

- `uv run --locked --project examples/egosuite_evaluation ruff check --fix examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation ruff format examples/egosuite_evaluation` — 6 files unchanged
- `uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests` — 47 passed
- `uv run pytest -q` — 1391 passed, 6 skipped
- fresh pre-reopen full suite — 1391 passed, 6 skipped

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.