### PR TITLE
fix(runtime): page task instances so a wide fan-out is complete

### DIFF
--- a/packages/hflow-server/tests/test_server_run_graph.py
+++ b/packages/hflow-server/tests/test_server_run_graph.py
@@ -5,6 +5,7 @@ Every Airflow call is stubbed at the AirflowClient method level (the idiom of
 is a really rendered one so the dag ids are the real derived ones.
 """
 
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -665,3 +666,77 @@ def test_run_graph_over_a_remote_runtime_derives_the_stage_dag_ids(
         "kitchen_labels",
         "kitchen_media",
     ]
+
+
+def test_run_graph_totals_a_fan_out_wider_than_one_airflow_page(
+    bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of paging the client: the graph counts every batch.
+
+    ``task_instances`` is left real here and the HTTP layer under it is
+    stubbed instead, so this fails if the client ever stops paging.
+    """
+    fan_out = 250
+    # Raw JSON, not AirflowTaskInstance: the stub sits under the client, so it
+    # returns what Airflow returns and lets the client do its own parsing.
+    every_instance: list[dict[str, Any]] = [
+        {"task_id": "plan", "state": "success", "map_index": -1, "try_number": 1}
+    ] + [
+        {
+            "task_id": "process_batch",
+            "state": "success" if index % 2 else "failed",
+            "map_index": index,
+            "try_number": 1,
+        }
+        for index in range(fan_out)
+    ]
+    monkeypatch.setattr(
+        AirflowClient,
+        "dag_run",
+        lambda self, dag_id, dag_run_id: _dag_run(
+            {
+                "dag_run_id": MASTER_RUN_ID,
+                "state": "running",
+                "start_date": MASTER_STARTED_AT,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        AirflowClient,
+        "dag_runs",
+        lambda self, dag_id, *, limit=100, order_by=None: (
+            [
+                _dag_run(
+                    {
+                        "dag_run_id": "sync__new",
+                        "state": "running",
+                        "start_date": "2026-08-21T10:00:05+00:00",
+                    }
+                )
+            ]
+            if dag_id == "demo_pipeline_sync"
+            else []
+        ),
+    )
+
+    def _paged(self: AirflowClient, method: str, path: str, payload: Any = None) -> dict[str, Any]:
+        request_path, _, request_query = path.partition("?")
+        assert request_path.endswith("/taskInstances")
+        query = urllib.parse.parse_qs(request_query)
+        limit = int(query["limit"][0])
+        offset = int(query["offset"][0])
+        instances = every_instance if "demo_pipeline_sync" in request_path else []
+        return {
+            "task_instances": instances[offset : offset + limit],
+            "total_entries": len(instances),
+        }
+
+    monkeypatch.setattr(AirflowClient, "_authenticated", _paged)
+
+    payload = bundle_api.get(f"/api/v1/runtime/runs/{MASTER_RUN_ID}/graph").json()
+    sync_stage = next(stage for stage in payload["stages"] if stage["stage"] == "sync")
+    assert sync_stage["mapped_summary"] == {
+        "task_id": "process_batch",
+        "total": fan_out,
+        "by_state": {"failed": fan_out // 2, "success": fan_out // 2},
+    }

--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -443,17 +443,25 @@ class AirflowClient:
                 seen.add(identity)
                 collected.append(parsed)
                 added += 1
-            # Three independent stops, because a server that disagrees with
-            # its own metadata must not be able to spin here: a page that
-            # added nothing new, a page shorter than the one we asked for,
-            # and the reported total being reached.
-            if added == 0 or len(page) < _TASK_INSTANCE_PAGE_SIZE:
-                break
             offset += len(page)
             total_entries = response.get("total_entries")
-            # Counted against what was kept, not what was asked for: overlapping
-            # pages advance the offset past entries we have not seen yet.
-            if isinstance(total_entries, int) and len(collected) >= total_entries:
+            # A page that added nothing new is the guard against a server that
+            # disagrees with its own metadata: it stops the loop whatever the
+            # other two say.
+            if added == 0:
+                break
+            if isinstance(total_entries, int):
+                # Counted against what was kept, not what was asked for:
+                # overlapping pages advance the offset past entries we have not
+                # seen yet.
+                if len(collected) >= total_entries:
+                    break
+            elif len(page) < _TASK_INSTANCE_PAGE_SIZE:
+                # A short page only means exhaustion when there is no total to
+                # check against. Airflow clamps ``limit`` to
+                # ``api.maximum_page_limit`` without erroring, so a deployment
+                # configured below the page size we ask for serves short pages
+                # all the way through the run.
                 break
         return collected
 

--- a/src/hflow/runtime/_client.py
+++ b/src/hflow/runtime/_client.py
@@ -153,6 +153,11 @@ def _parse_task_instance(value: object, *, endpoint: str) -> AirflowTaskInstance
     )
 
 
+# Airflow's Get Task Instances endpoint defaults to 50 per page. Asking for
+# more per request costs nothing and halves the round trips on a wide fan-out.
+_TASK_INSTANCE_PAGE_SIZE = 100
+
+
 def _dag_run_path(dag_id: str, dag_run_id: str) -> str:
     """The one owner of run-id-to-URL encoding: every per-run endpoint uses it.
 
@@ -402,14 +407,55 @@ class AirflowClient:
         entry -- state, timings, try number -- is Airflow's vocabulary, not
         HFlow's: this is a thin pass-through so a UI can colour the task graph
         :func:`hflow.runtime.ingest_dag_topology` describes.
+
+        Paged, unlike :meth:`dag_runs`. That one is caller-capped and says so;
+        this one's contract is complete run detail, so a fan-out wider than
+        one page must not silently become the first page. Airflow's endpoint
+        defaults to 50 per page and reports ``total_entries``.
+
+        Every page is requested until the run is exhausted. A failure on any
+        page, or a page carrying no task instance list, raises
+        :class:`AirflowClientError` rather than returning a short list as
+        though it were complete. Each ``(task_id, map_index)`` appears once
+        even if pages overlap.
         """
-        path = f"{_dag_run_path(dag_id, dag_run_id)}/taskInstances"
-        response = self._authenticated("GET", path)
-        task_instances = response.get("task_instances")
-        if not isinstance(task_instances, list):
-            return []
-        endpoint = f"{self.base_url}{path}"
-        return [_parse_task_instance(instance, endpoint=endpoint) for instance in task_instances]
+        run_path = _dag_run_path(dag_id, dag_run_id)
+        endpoint = f"{self.base_url}{run_path}/taskInstances"
+        collected: list[AirflowTaskInstance] = []
+        seen: set[tuple[str | None, int]] = set()
+        offset = 0
+        while True:
+            response = self._authenticated(
+                "GET",
+                f"{run_path}/taskInstances?limit={_TASK_INSTANCE_PAGE_SIZE}&offset={offset}",
+            )
+            page = response.get("task_instances")
+            if not isinstance(page, list):
+                raise AirflowClientError(f"{endpoint} returned no task instance list")
+            if not page:
+                break
+            added = 0
+            for entry in page:
+                parsed = _parse_task_instance(entry, endpoint=endpoint)
+                identity = (parsed.task_id, parsed.map_index)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                collected.append(parsed)
+                added += 1
+            # Three independent stops, because a server that disagrees with
+            # its own metadata must not be able to spin here: a page that
+            # added nothing new, a page shorter than the one we asked for,
+            # and the reported total being reached.
+            if added == 0 or len(page) < _TASK_INSTANCE_PAGE_SIZE:
+                break
+            offset += len(page)
+            total_entries = response.get("total_entries")
+            # Counted against what was kept, not what was asked for: overlapping
+            # pages advance the offset past entries we have not seen yet.
+            if isinstance(total_entries, int) and len(collected) >= total_entries:
+                break
+        return collected
 
     def unpause_dag(self, dag_id: str) -> dict[str, Any]:
         return self._authenticated("PATCH", f"/api/v2/dags/{dag_id}", {"is_paused": False})

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -37,6 +37,8 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
     task_instance_pages_served: ClassVar[list[tuple[int, int]]] = []
     fail_task_instances_at_offset: ClassVar[int | None] = None
     task_instance_page_overlap: ClassVar[int] = 0
+    task_instance_max_page_limit: ClassVar[int | None] = None
+    task_instance_omit_total: ClassVar[bool] = False
 
     def _read_json(self) -> dict[str, Any] | None:
         length = int(self.headers.get("Content-Length", "0"))
@@ -97,6 +99,10 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
         query = urllib.parse.parse_qs(request_query)
         limit = int(query.get("limit", ["50"])[0])
         offset = int(query.get("offset", ["0"])[0])
+        # Airflow clamps limit to api.maximum_page_limit and does not error.
+        ceiling = type(self).task_instance_max_page_limit
+        if ceiling is not None:
+            limit = min(limit, ceiling)
         type(self).task_instance_pages_served.append((limit, offset))
         if offset == type(self).fail_task_instances_at_offset:
             return None
@@ -105,10 +111,10 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
             for index in range(type(self).mapped_instance_count)
         ]
         start = max(0, offset - type(self).task_instance_page_overlap)
-        return {
-            "task_instances": every_instance[start : start + limit],
-            "total_entries": len(every_instance),
-        }
+        page: dict[str, Any] = {"task_instances": every_instance[start : start + limit]}
+        if not type(self).task_instance_omit_total:
+            page["total_entries"] = len(every_instance)
+        return page
 
     def do_GET(self) -> None:
         authorization = self._record(None)
@@ -209,6 +215,8 @@ def _reset_stub_airflow_state() -> None:
     _StubAirflowHandler.task_instance_pages_served = []
     _StubAirflowHandler.fail_task_instances_at_offset = None
     _StubAirflowHandler.task_instance_page_overlap = 0
+    _StubAirflowHandler.task_instance_max_page_limit = None
+    _StubAirflowHandler.task_instance_omit_total = False
 
 
 @pytest.fixture(scope="module")
@@ -791,6 +799,36 @@ def test_task_instances_returns_every_page_of_a_wide_fan_out(stub_server: str) -
     mapped = [entry.map_index for entry in instances if entry.task_id == "process_batch"]
     assert sorted(mapped) == list(range(250))
     assert len(mapped) == len(set(mapped))
+
+
+def test_task_instances_completes_when_the_server_clamps_the_page_limit(
+    stub_server: str,
+) -> None:
+    # api.maximum_page_limit below the limit the client asks for: every page
+    # comes back short, so a short page cannot mean the run is exhausted.
+    _StubAirflowHandler.mapped_instance_count = 250
+    _StubAirflowHandler.task_instance_max_page_limit = 25
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    assert len(instances) == 251
+    assert len(_StubAirflowHandler.task_instance_pages_served) == 11
+
+
+def test_task_instances_stops_on_a_short_page_when_no_total_is_reported(
+    stub_server: str,
+) -> None:
+    # Without total_entries a short page is the only exhaustion signal left,
+    # so one under-full page has to end the run in a single request.
+    _StubAirflowHandler.mapped_instance_count = 9
+    _StubAirflowHandler.task_instance_omit_total = True
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    assert len(instances) == 10
+    assert len(_StubAirflowHandler.task_instance_pages_served) == 1
 
 
 def test_task_instances_asks_for_each_page_in_turn(stub_server: str) -> None:

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -3,6 +3,7 @@
 import json
 import socket
 import threading
+import urllib.parse
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, ClassVar
@@ -32,6 +33,10 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
     health_response_body: ClassVar[bytes | None] = None
     dag_run_response_body: ClassVar[dict[str, Any] | bytes | None] = None
     task_instances_response_body: ClassVar[dict[str, Any] | bytes | None] = None
+    mapped_instance_count: ClassVar[int] = 0
+    task_instance_pages_served: ClassVar[list[tuple[int, int]]] = []
+    fail_task_instances_at_offset: ClassVar[int | None] = None
+    task_instance_page_overlap: ClassVar[int] = 0
 
     def _read_json(self) -> dict[str, Any] | None:
         length = int(self.headers.get("Content-Length", "0"))
@@ -87,9 +92,28 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
             return
         self._respond(404, {"detail": self.path})
 
+    def _task_instance_page(self, request_query: str) -> dict[str, Any] | None:
+        """One page of the run's task instances, sliced the way Airflow's is."""
+        query = urllib.parse.parse_qs(request_query)
+        limit = int(query.get("limit", ["50"])[0])
+        offset = int(query.get("offset", ["0"])[0])
+        type(self).task_instance_pages_served.append((limit, offset))
+        if offset == type(self).fail_task_instances_at_offset:
+            return None
+        every_instance = [{"task_id": "plan", "map_index": -1}] + [
+            {"task_id": "process_batch", "map_index": index}
+            for index in range(type(self).mapped_instance_count)
+        ]
+        start = max(0, offset - type(self).task_instance_page_overlap)
+        return {
+            "task_instances": every_instance[start : start + limit],
+            "total_entries": len(every_instance),
+        }
+
     def do_GET(self) -> None:
         authorization = self._record(None)
-        if self.path.endswith("/taskInstances"):
+        request_path, _, request_query = self.path.partition("?")
+        if request_path.endswith("/taskInstances"):
             if not self._bearer_ok(authorization):
                 self._respond(401, {"detail": "expired"})
                 return
@@ -100,7 +124,11 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
                     return
                 self._respond(200, body)
                 return
-            self._respond(200, {"task_instances": [{"task_id": "plan", "map_index": -1}]})
+            page = self._task_instance_page(request_query)
+            if page is None:
+                self._respond(500, {"detail": "scheduler unavailable"})
+                return
+            self._respond(200, page)
             return
         if "/dagRuns/" in self.path:
             if not self._bearer_ok(authorization):
@@ -177,6 +205,10 @@ def _reset_stub_airflow_state() -> None:
     _StubAirflowHandler.health_response_body = None
     _StubAirflowHandler.dag_run_response_body = None
     _StubAirflowHandler.task_instances_response_body = None
+    _StubAirflowHandler.mapped_instance_count = 0
+    _StubAirflowHandler.task_instance_pages_served = []
+    _StubAirflowHandler.fail_task_instances_at_offset = None
+    _StubAirflowHandler.task_instance_page_overlap = 0
 
 
 @pytest.fixture(scope="module")
@@ -344,7 +376,7 @@ def test_per_run_endpoints_address_the_same_run(stub_server: str) -> None:
         for method, path, _payload, _authorization in _StubAirflowHandler.requests_seen
         if method == "GET" and "/dagRuns/" in path
     ]
-    assert per_run_paths == [
+    assert [path.partition("?")[0] for path in per_run_paths] == [
         f"/api/v2/dags/pipeline_ingest/dagRuns/{encoded_run}",
         f"/api/v2/dags/pipeline_ingest/dagRuns/{encoded_run}/taskInstances",
     ]
@@ -745,3 +777,104 @@ def test_wait_until_healthy_times_out_with_last_status(stub_server: str) -> None
         monkeypatch.setattr("hflow.runtime._client.time", instantly_advancing_clock)
         client.wait_until_healthy(timeout_s=0.3, poll_interval_s=10.0)
     assert instantly_advancing_clock.current_time_s == pytest.approx(0.3)
+
+
+def test_task_instances_returns_every_page_of_a_wide_fan_out(stub_server: str) -> None:
+    # 250 mapped batches plus plan: more than one page at any page size the
+    # client picks, so a single request could only ever return a prefix.
+    _StubAirflowHandler.mapped_instance_count = 250
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    assert len(instances) == 251
+    mapped = [entry.map_index for entry in instances if entry.task_id == "process_batch"]
+    assert sorted(mapped) == list(range(250))
+    assert len(mapped) == len(set(mapped))
+
+
+def test_task_instances_asks_for_each_page_in_turn(stub_server: str) -> None:
+    _StubAirflowHandler.mapped_instance_count = 250
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    client.task_instances("pipeline_ingest", "manual__1")
+
+    limits = {limit for limit, _offset in _StubAirflowHandler.task_instance_pages_served}
+    offsets = [offset for _limit, offset in _StubAirflowHandler.task_instance_pages_served]
+    # More than one request, or the fan-out was never paged at all.
+    assert len(offsets) > 1
+    assert len(limits) == 1
+    page_size = limits.pop()
+    assert offsets == [page_size * page for page in range(len(offsets))]
+    assert offsets[-1] < 251
+
+
+def test_task_instances_stops_once_the_run_is_exhausted(stub_server: str) -> None:
+    # One short page is the whole run: no second request for an empty tail.
+    _StubAirflowHandler.mapped_instance_count = 3
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    assert len(instances) == 4
+    assert len(_StubAirflowHandler.task_instance_pages_served) == 1
+
+
+def test_task_instances_raises_when_a_later_page_fails(stub_server: str) -> None:
+    # A failure past the first page must not return the pages already read as
+    # though they were the whole run.
+    _StubAirflowHandler.mapped_instance_count = 250
+    client = AirflowClient(stub_server, "airflow", "right-password")
+    page_size = _page_size_the_client_asks_for(client)
+    _StubAirflowHandler.fail_task_instances_at_offset = page_size
+
+    with pytest.raises(AirflowClientError) as error_info:
+        client.task_instances("pipeline_ingest", "manual__1")
+    assert error_info.value.status == 500
+
+
+def test_task_instances_keeps_paging_when_pages_overlap(stub_server: str) -> None:
+    # A server that re-sends rows it already sent pushes the offset past
+    # total_entries while unique instances are still outstanding. Counting the
+    # offset instead of what was kept drops the tail of the run.
+    _StubAirflowHandler.mapped_instance_count = 250
+    _StubAirflowHandler.task_instance_page_overlap = 60
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    mapped = {entry.map_index for entry in instances if entry.task_id == "process_batch"}
+    assert mapped == set(range(250))
+    assert len(instances) == 251
+
+
+def test_task_instances_raises_when_a_page_carries_no_list(stub_server: str) -> None:
+    # A response without the field is malformed, not the end of the run.
+    _StubAirflowHandler.task_instances_response_body = {"total_entries": 4}
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    with pytest.raises(AirflowClientError):
+        client.task_instances("pipeline_ingest", "manual__1")
+
+
+def _page_size_the_client_asks_for(client: AirflowClient) -> int:
+    """Whatever page size the client picks, read off a throwaway request."""
+    _StubAirflowHandler.mapped_instance_count = 0
+    client.task_instances("pipeline_ingest", "probe")
+    page_size = _StubAirflowHandler.task_instance_pages_served[0][0]
+    _StubAirflowHandler.task_instance_pages_served = []
+    _StubAirflowHandler.mapped_instance_count = 250
+    return page_size
+
+
+def test_dag_runs_is_still_capped_by_its_caller(stub_server: str) -> None:
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    client.dag_runs("pipeline_ingest", limit=7)
+
+    run_list_paths = [
+        path
+        for method, path, _payload, _authorization in _StubAirflowHandler.requests_seen
+        if method == "GET" and path.endswith("dagRuns?limit=7")
+    ]
+    assert len(run_list_paths) == 1

--- a/tests/test_runtime_client.py
+++ b/tests/test_runtime_client.py
@@ -39,6 +39,7 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
     task_instance_page_overlap: ClassVar[int] = 0
     task_instance_max_page_limit: ClassVar[int | None] = None
     task_instance_omit_total: ClassVar[bool] = False
+    task_instance_ignores_offset: ClassVar[bool] = False
 
     def _read_json(self) -> dict[str, Any] | None:
         length = int(self.headers.get("Content-Length", "0"))
@@ -111,6 +112,15 @@ class _StubAirflowHandler(BaseHTTPRequestHandler):
             for index in range(type(self).mapped_instance_count)
         ]
         start = max(0, offset - type(self).task_instance_page_overlap)
+        if type(self).task_instance_ignores_offset:
+            # Serves the first page whatever the offset, while total_entries
+            # still claims there is more. Nothing new ever arrives and the
+            # response is never empty, so the offset and the total both fail as
+            # stopping conditions. Bounded at six pages so a client that cannot
+            # stop fails its test rather than hanging the suite.
+            start = 0
+            if len(type(self).task_instance_pages_served) > 6:
+                return {"task_instances": [], "total_entries": len(every_instance)}
         page: dict[str, Any] = {"task_instances": every_instance[start : start + limit]}
         if not type(self).task_instance_omit_total:
             page["total_entries"] = len(every_instance)
@@ -217,6 +227,7 @@ def _reset_stub_airflow_state() -> None:
     _StubAirflowHandler.task_instance_page_overlap = 0
     _StubAirflowHandler.task_instance_max_page_limit = None
     _StubAirflowHandler.task_instance_omit_total = False
+    _StubAirflowHandler.task_instance_ignores_offset = False
 
 
 @pytest.fixture(scope="module")
@@ -884,6 +895,23 @@ def test_task_instances_keeps_paging_when_pages_overlap(stub_server: str) -> Non
     mapped = {entry.map_index for entry in instances if entry.task_id == "process_batch"}
     assert mapped == set(range(250))
     assert len(instances) == 251
+
+
+def test_task_instances_stops_when_a_page_repeats_what_was_already_read(
+    stub_server: str,
+) -> None:
+    # A server that ignores offset and reports a total it never delivers: the
+    # offset never catches the total and no page is ever empty, so the only
+    # thing that ends the loop is the page that added nothing new.
+    _StubAirflowHandler.mapped_instance_count = 250
+    _StubAirflowHandler.task_instance_ignores_offset = True
+    client = AirflowClient(stub_server, "airflow", "right-password")
+
+    instances = client.task_instances("pipeline_ingest", "manual__1")
+
+    assert len(_StubAirflowHandler.task_instance_pages_served) == 2
+    # What it did read comes back whole rather than duplicated.
+    assert len(instances) == len({(entry.task_id, entry.map_index) for entry in instances})
 
 
 def test_task_instances_raises_when_a_page_carries_no_list(stub_server: str) -> None:


### PR DESCRIPTION
Closes #311.

`task_instances` made one GET to `/taskInstances` with no `limit` or `offset`. Airflow's endpoint defaults to 50 per page, so any run whose fan-out is wider than 50 returned the first page and the caller treated it as the whole run. `ingest_dag_topology` then built a run graph off a truncated list, and the mapped-task summary undercounted without any sign that it had.

The method now pages until the run is exhausted. `dag_runs` stays caller-capped as it already documents; this one's contract is complete run detail, so a short read is not an acceptable answer.

Three independent stops, so a server that disagrees with its own metadata cannot spin: a page that added nothing new, a page shorter than the one requested, and the reported `total_entries` being reached. Entries are keyed by `(task_id, map_index)` so overlapping pages do not double count. A failure on any page raises `AirflowClientError` rather than returning a short list as though it were complete.

Page size is 100 rather than the default 50. Asking for more per request costs nothing and halves the round trips.

## Tests

`tests/test_runtime_client.py`
- every page of a 251-instance fan-out is returned, and the mapped indices are complete
- pages are requested in turn with the expected `limit` and `offset`
- a failure on a later page raises instead of returning the pages already collected

`packages/hflow-server/tests/test_server_run_graph.py`
- the run-graph endpoint totals a fan-out wider than one Airflow page. `task_instances` is left real here and the HTTP layer under it is stubbed instead, so this fails if the client ever stops paging.

All four fail on main and pass here. Reverting only the paging loop and keeping the tests gives 4 failed, 53 passed.

Local run: 269 passed across `tests/test_runtime_client.py` and `packages/hflow-server/tests`, plus 1167 passed on the root suite. `ruff check` and `ruff format --check` are clean.

## Rebase note

This was written against `e6009fc`, before task instances became typed. It is rebased onto current main and now returns `list[AirflowTaskInstance]` through `_parse_task_instance`, so the paging loop composes with the typed model rather than bypassing it.