### PR TITLE
fix(egosuite): validate label report envelope

### DIFF
--- a/examples/egosuite_evaluation/evaluate.py
+++ b/examples/egosuite_evaluation/evaluate.py
@@ -65,6 +65,7 @@ from examples.egosuite_evaluation.judgment import (  # noqa: E402
 )
 
 SCHEMA_VERSION = 1
+PROJECTED_HAND_LABEL_TYPE = "projected-hand-joints"
 EXPECTED_HAND_JOINT_COUNT = 21
 DEFAULT_RUNS_DIRECTORY = Path("data/egosuite-evaluation/runs")
 DEFAULT_LABELS_DIRECTORY = Path("data/egosuite-evaluation/labels")
@@ -151,6 +152,22 @@ def load_projected_hand_label_report(
         ) from error
     if not isinstance(report_payload, dict):
         raise ValueError(f"projected-hand label report {report_path} must contain a JSON object")
+    schema_version = report_payload.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"projected-hand label report {report_path} field 'schema_version' has value "
+            f"{schema_version!r}; supported value is {SCHEMA_VERSION}"
+        )
+    label_type = report_payload.get("label_type")
+    if not isinstance(label_type, str) or label_type != PROJECTED_HAND_LABEL_TYPE:
+        raise ValueError(
+            f"projected-hand label report {report_path} field 'label_type' has value "
+            f"{label_type!r}; supported value is {PROJECTED_HAND_LABEL_TYPE!r}"
+        )
     raw_frame_records = report_payload.get("frames")
     if not isinstance(raw_frame_records, list):
         raise ValueError(f"projected-hand label report {report_path} must contain a 'frames' array")
@@ -889,7 +906,7 @@ def write_label_report(
     all_labels = [label for labels in labels_by_source.values() for label in labels]
     report = {
         "schema_version": SCHEMA_VERSION,
-        "label_type": "projected-hand-joints",
+        "label_type": PROJECTED_HAND_LABEL_TYPE,
         "camera_view": camera_view.value,
         "frame_stride": frame_stride,
         "limit_per_episode": limit_per_episode,

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -35,6 +35,7 @@ from examples.egosuite_evaluation.evaluate import (
     select_episode_paths,
     select_stratified_labels,
     summarize_evaluation_results,
+    write_label_report,
 )
 from examples.egosuite_evaluation.geometry import (
     CameraPoseInWorld,
@@ -268,25 +269,30 @@ def test_pipeline_registers_projected_hand_visibility_as_an_hflow_check() -> Non
 def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_path: Path) -> None:
     source_path = tmp_path / "episode-123.mcap"
     report_path = tmp_path / "labels.json"
-    report_path.write_text(
-        json.dumps(
-            {
-                "frames": [
-                    {
-                        "source_path": str(source_path),
-                        "source_episode": "episode-123",
-                        "camera_view": "head-left",
-                        "frame_index": frame_index,
-                        "left_in_frame_joint_count": 21,
-                        "right_in_frame_joint_count": 21 if frame_index == 8 else 0,
-                        "expected_hand_count": 2 if frame_index == 8 else 1,
-                        "left_hand_issue_reasons": [],
-                        "right_hand_issue_reasons": ["occlusion"] if frame_index == 8 else [],
-                    }
-                    for frame_index in (8, 3)
-                ]
-            }
+    labels = [
+        ProjectedHandFrameLabel(
+            source_path=source_path,
+            source_episode="episode-123",
+            camera_view=CameraView.HEAD_LEFT,
+            frame_index=frame_index,
+            left_in_frame_joint_count=21,
+            right_in_frame_joint_count=21 if frame_index == 8 else 0,
+            expected_hand_count=2 if frame_index == 8 else 1,
+            left_hand_issue_reasons=(),
+            right_hand_issue_reasons=("occlusion",) if frame_index == 8 else (),
         )
+        for frame_index in (8, 3)
+    ]
+    write_label_report(
+        {source_path: labels},
+        camera_view=CameraView.HEAD_LEFT,
+        frame_stride=30,
+        limit_per_episode=None,
+        episode_count=None,
+        samples_per_episode=None,
+        samples_per_hand_count=None,
+        sample_seed=42,
+        output_path=report_path,
     )
 
     labels_by_source_episode = load_projected_hand_label_report(report_path)
@@ -297,6 +303,80 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
     assert [label.frame_index for label in selected_labels] == [3, 8]
     assert [label.expected_hand_count for label in selected_labels] == [1, 2]
     assert selected_labels[1].right_hand_issue_reasons == ("occlusion",)
+
+
+@pytest.mark.parametrize(
+    ("envelope", "field_name", "found_value", "supported_value"),
+    [
+        pytest.param(
+            {"label_type": "projected-hand-joints"},
+            "schema_version",
+            "None",
+            "1",
+            id="missing-schema-version",
+        ),
+        pytest.param(
+            {"schema_version": "1", "label_type": "projected-hand-joints"},
+            "schema_version",
+            "'1'",
+            "1",
+            id="non-integer-schema-version",
+        ),
+        pytest.param(
+            {"schema_version": 0, "label_type": "projected-hand-joints"},
+            "schema_version",
+            "0",
+            "1",
+            id="older-schema-version",
+        ),
+        pytest.param(
+            {"schema_version": 2, "label_type": "projected-hand-joints"},
+            "schema_version",
+            "2",
+            "1",
+            id="future-schema-version",
+        ),
+        pytest.param(
+            {"schema_version": 1},
+            "label_type",
+            "None",
+            "'projected-hand-joints'",
+            id="missing-label-type",
+        ),
+        pytest.param(
+            {"schema_version": 1, "label_type": 1},
+            "label_type",
+            "1",
+            "'projected-hand-joints'",
+            id="non-string-label-type",
+        ),
+        pytest.param(
+            {"schema_version": 1, "label_type": "bounding-boxes"},
+            "label_type",
+            "'bounding-boxes'",
+            "'projected-hand-joints'",
+            id="unsupported-label-type",
+        ),
+    ],
+)
+def test_saved_label_report_rejects_unsupported_envelope_before_frames(
+    tmp_path: Path,
+    envelope: dict[str, object],
+    field_name: str,
+    found_value: str,
+    supported_value: str,
+) -> None:
+    report_path = tmp_path / "labels.json"
+    report_path.write_text(json.dumps({**envelope, "frames": [None]}))
+
+    with pytest.raises(ValueError) as error:
+        load_projected_hand_label_report(report_path)
+
+    message = str(error.value)
+    assert str(report_path) in message
+    assert repr(field_name) in message
+    assert f"value {found_value}" in message
+    assert f"supported value is {supported_value}" in message
 
 
 def test_pipeline_records_agreement_output_validity_and_frame_intervals() -> None:

--- a/examples/egosuite_evaluation/tests/test_evaluation.py
+++ b/examples/egosuite_evaluation/tests/test_evaluation.py
@@ -334,6 +334,15 @@ def test_saved_label_report_selects_exact_frames_for_a_canonical_episode(tmp_pat
             "1",
             id="older-schema-version",
         ),
+        # bool subclasses int, so True passes an isinstance(_, int) check and
+        # compares equal to 1. Only the explicit bool guard rejects it.
+        pytest.param(
+            {"schema_version": True, "label_type": "projected-hand-joints"},
+            "schema_version",
+            "True",
+            "1",
+            id="bool-schema-version",
+        ),
         pytest.param(
             {"schema_version": 2, "label_type": "projected-hand-joints"},
             "schema_version",


### PR DESCRIPTION
## Summary

- validate the saved projected-hand label report schema version and label type before reading frame records
- use one projected-hand label type constant for the writer and reader contract
- exercise the writer-to-reader happy path and every requested missing, type, older/future, and unsupported envelope boundary

Fixes #307

## Validation

- uv run --locked --project examples/egosuite_evaluation ruff check --fix examples/egosuite_evaluation
- uv run --locked --project examples/egosuite_evaluation ruff format examples/egosuite_evaluation
- uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . examples/egosuite_evaluation
- uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests (46 passed)
- uv run ruff check
- uv run ruff format --check
- uv run ty check
- uv run pytest -q (1,404 passed, 11 skipped)

## AI assistance disclosure

I used OpenAI Codex to help inspect, implement, and validate this change. I reviewed the final diff and the validation results.