### PR TITLE
feat(catalog-ui): explore bucket-backed catalogs

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -151,11 +151,14 @@ marker and never creates or changes objects in the bucket. It syncs append-only
 Parquet table files into the local mirror under `HFLOW_MIRROR_DIR` (or
 `$XDG_CACHE_HOME/hflow/mirrors`) before DuckDB opens, then re-syncs on its poll
 interval so the first and later completed appends become visible in the open UI
-without a restart. DuckDB reads the mirror only and continues to listen on
-loopback. A valid empty bucket catalog -- marker present, no Parquet rows yet --
-starts the UI and waits for its first completed append the same way a local
-empty catalog does. Local catalogs may still be created on startup when the
-directory does not exist yet; remote catalogs must already exist.
+without a restart. The default poll interval is 0.5 seconds; each tick lists the
+catalog table prefixes and downloads only the files the mirror still lacks,
+which is fine for an interactive laptop session. DuckDB reads the mirror only
+and continues to listen on loopback. A valid empty bucket catalog -- marker
+present, no Parquet rows yet -- starts the UI and waits for its first completed
+append the same way a local empty catalog does. Local catalogs may still be
+created on startup when the directory does not exist yet; remote catalogs must
+already exist.
 
 DuckDB UI listens on loopback. When HFlow is running on another machine, run
 the second command there and forward the port from your laptop:

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -138,6 +138,25 @@ hflow catalog ui --catalog data/egocentric/catalog
 hflow catalog ui --catalog data/egocentric/catalog --no-browser
 ```
 
+Object-store catalogs work the same way when the optional bucket backend is
+installed (`uv sync --extra bucket`) and provider credentials are available:
+
+```bash
+hflow catalog ui --catalog s3://robot-data/production/catalog --no-browser
+hflow catalog ui --catalog gs://robot-data/production/catalog --no-browser
+```
+
+For bucket catalogs, `catalog ui` validates the existing `format_version`
+marker and never creates or changes objects in the bucket. It syncs append-only
+Parquet table files into the local mirror under `HFLOW_MIRROR_DIR` (or
+`$XDG_CACHE_HOME/hflow/mirrors`) before DuckDB opens, then re-syncs on its poll
+interval so the first and later completed appends become visible in the open UI
+without a restart. DuckDB reads the mirror only and continues to listen on
+loopback. A valid empty bucket catalog -- marker present, no Parquet rows yet --
+starts the UI and waits for its first completed append the same way a local
+empty catalog does. Local catalogs may still be created on startup when the
+directory does not exist yet; remote catalogs must already exist.
+
 DuckDB UI listens on loopback. When HFlow is running on another machine, run
 the second command there and forward the port from your laptop:
 
@@ -151,8 +170,8 @@ assets. DuckDB UI is an unrestricted local SQL explorer, so keep the port on
 loopback and use a tunnel instead of exposing it publicly.
 
 This command is separate from [`hflow serve`](./SERVE.md). `catalog ui` is
-DuckDB's browser over the local catalog. `serve` is HFlow's optional workspace
-REST API and does not ship a browser client.
+DuckDB's browser over the catalog (local or synced from a bucket). `serve` is
+HFlow's optional workspace REST API and does not ship a browser client.
 
 ### Query from Python or the CLI
 
@@ -601,9 +620,11 @@ itself. A catalog root contains the `format_version` marker.
 - The wide view binds its measurement columns to the keys present when the
   connection was opened. `hflow catalog ui` refreshes this surface after an
   initially empty catalog's first append, and `curate()` reopens per call.
-  If a later run introduces brand-new measurement keys into a long-lived UI
-  or `open_catalog_connection()` session, restart that session to add those
-  columns. New rows for existing keys appear without a restart.
+  Bucket-backed UI sessions re-sync newly appended Parquet files on each poll
+  so new rows for existing keys appear without a restart. If a later run
+  introduces brand-new measurement keys into a long-lived UI or
+  `open_catalog_connection()` session, restart that session to add those
+  columns.
 
 ## See also
 

--- a/src/hflow/catalog_ui.py
+++ b/src/hflow/catalog_ui.py
@@ -1,4 +1,4 @@
-"""DuckDB's browser UI over a local HFlow catalog."""
+"""DuckDB's browser UI over a local or bucket-backed HFlow catalog."""
 
 from __future__ import annotations
 
@@ -13,7 +13,18 @@ from threading import Event
 import duckdb
 
 from hflow.catalog import Catalog
-from hflow.curation import _refresh_local_catalog_connection, open_catalog_connection
+from hflow.curation import (
+    _completed_append_exists,
+    _refresh_local_catalog_connection,
+    _sync_catalog_mirror,
+    open_catalog_connection,
+)
+from hflow.storage import (
+    BucketStorageRoot,
+    LocalStorageRoot,
+    StorageRoot,
+    parse_storage_root,
+)
 
 DEFAULT_CATALOG_UI_PORT = 4213
 DEFAULT_CATALOG_POLL_INTERVAL_SECONDS = 0.5
@@ -25,9 +36,9 @@ class CatalogUiStartupError(RuntimeError):
 
 @dataclass(frozen=True)
 class CatalogUiSettings:
-    """Configuration for one local DuckDB catalog browser."""
+    """Configuration for one DuckDB catalog browser."""
 
-    catalog_root: Path
+    catalog_root: Path | str | StorageRoot
     port: int = DEFAULT_CATALOG_UI_PORT
     open_browser: bool = True
     catalog_poll_interval_seconds: float = DEFAULT_CATALOG_POLL_INTERVAL_SECONDS
@@ -53,6 +64,11 @@ class CatalogUiSettings:
                 "catalog_poll_interval_seconds must be positive and finite, got "
                 f"{self.catalog_poll_interval_seconds}"
             )
+
+
+def _catalog_display_label(catalog_root: Path | str | StorageRoot) -> str:
+    """The catalog location to show the operator, never the mirror directory."""
+    return str(parse_storage_root(catalog_root))
 
 
 def _raise_if_loopback_port_is_unavailable(port: int) -> None:
@@ -118,26 +134,34 @@ def _catalog_connection_contains_episodes(
     return episode_count_row is not None and int(episode_count_row[0]) > 0
 
 
-def _first_completed_append_exists(catalog_root: Path) -> bool:
-    # Catalog.append_episode writes the episodes file last. Its presence is
-    # therefore the commit marker for all table files in that append.
-    return any((catalog_root / "episodes").glob("*.parquet"))
+def _first_completed_append_exists(catalog_root: Path | str | StorageRoot) -> bool:
+    return _completed_append_exists(catalog_root)
+
+
+def _prepare_catalog_for_ui(location: StorageRoot) -> None:
+    """Ensure a local catalog exists; bucket catalogs must already be present."""
+    if isinstance(location, LocalStorageRoot):
+        Catalog(location.path)
 
 
 def serve_catalog_ui(settings: CatalogUiSettings, *, shutdown_event: Event | None = None) -> None:
-    """Serve DuckDB UI now, including when the local catalog is still empty.
+    """Serve DuckDB UI now, including when the catalog is still empty.
 
     Empty catalog relations begin as in-memory tables because DuckDB refuses a
     Parquet glob with no matches. The first completed append replaces those
     tables with the normal Parquet-backed HFlow views on the same connection,
     so the already-open UI becomes queryable without restarting this command.
+
+    Bucket catalogs are read-only: the remote ``format_version`` marker must
+    already exist and this command never creates or changes object-store keys.
     """
     effective_shutdown_event = shutdown_event or Event()
+    catalog_root = settings.catalog_root
+    location = parse_storage_root(catalog_root)
+    bucket_catalog = isinstance(location, BucketStorageRoot)
 
-    # Creating a local Catalog is safe before the runtime starts. It writes the
-    # format marker and empty table directories that the ingest will use later.
-    Catalog(settings.catalog_root)
-    catalog_connection = open_catalog_connection(settings.catalog_root)
+    _prepare_catalog_for_ui(location)
+    catalog_connection = open_catalog_connection(catalog_root)
     server_started = False
     try:
         _start_duckdb_ui_server(catalog_connection, settings.port)
@@ -145,7 +169,7 @@ def serve_catalog_ui(settings: CatalogUiSettings, *, shutdown_event: Event | Non
 
         browser_url = f"http://127.0.0.1:{settings.port}"
         print(f"DuckDB UI: {browser_url}", flush=True)
-        print(f"Catalog: {settings.catalog_root.resolve()}", flush=True)
+        print(f"Catalog: {_catalog_display_label(catalog_root)}", flush=True)
         print("Press Ctrl+C to stop DuckDB UI.", flush=True)
         if settings.open_browser:
             try:
@@ -163,8 +187,8 @@ def serve_catalog_ui(settings: CatalogUiSettings, *, shutdown_event: Event | Non
                 flush=True,
             )
             while not effective_shutdown_event.wait(settings.catalog_poll_interval_seconds):
-                if _first_completed_append_exists(settings.catalog_root):
-                    _refresh_local_catalog_connection(catalog_connection, settings.catalog_root)
+                if _first_completed_append_exists(catalog_root):
+                    _refresh_local_catalog_connection(catalog_connection, catalog_root)
                     print(
                         "First completed append detected. Catalog views are now "
                         "available in the open UI.",
@@ -173,7 +197,8 @@ def serve_catalog_ui(settings: CatalogUiSettings, *, shutdown_event: Event | Non
                     break
 
         while not effective_shutdown_event.wait(settings.catalog_poll_interval_seconds):
-            pass
+            if bucket_catalog:
+                _sync_catalog_mirror(catalog_root)
     except KeyboardInterrupt:
         pass
     finally:

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -1349,6 +1349,19 @@ def _command_catalog_ui(arguments: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 2
+    bucket_catalog = is_bucket_url(catalog_location)
+    bucket_storage_error: type[BaseException] | None = None
+    if bucket_catalog:
+        # Import while the optional extra is already known to be required for
+        # this path, so a later handler cannot mask an unrelated failure with
+        # ModuleNotFoundError from this import.
+        try:
+            from obstore.exceptions import BaseError as BucketStorageError
+        except ModuleNotFoundError:
+            bucket_storage_error = None
+        else:
+            bucket_storage_error = BucketStorageError
+
     try:
         settings = CatalogUiSettings(
             catalog_root=catalog_location,
@@ -1360,20 +1373,15 @@ def _command_catalog_ui(arguments: argparse.Namespace) -> int:
         CatalogUiStartupError,
         OSError,
         ValueError,
-        FileNotFoundError,
         ModuleNotFoundError,
     ) as error:
         print(f"catalog ui: {error}", file=sys.stderr)
         return 2
     except Exception as error:
-        if not is_bucket_url(catalog_location):
-            raise
-        from obstore.exceptions import BaseError as BucketStorageError
-
-        if not isinstance(error, BucketStorageError):
-            raise
-        print(f"catalog ui: {error}", file=sys.stderr)
-        return 2
+        if bucket_storage_error is not None and isinstance(error, bucket_storage_error):
+            print(f"catalog ui: {error}", file=sys.stderr)
+            return 2
+        raise
     return 0
 
 

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -189,20 +189,21 @@ def _build_parser() -> argparse.ArgumentParser:
     catalog_subparsers = catalog_parser.add_subparsers(dest="catalog_command", required=True)
     catalog_ui_parser = catalog_subparsers.add_parser(
         "ui",
-        help="open DuckDB UI over the local catalog",
+        help="open DuckDB UI over a local or bucket-backed catalog",
         description=(
-            "Start DuckDB's browser UI over a local HFlow catalog. The UI starts "
+            "Start DuckDB's browser UI over an HFlow catalog. The UI starts "
             "even when the catalog is empty, then refreshes its views after the "
-            "first completed append."
+            "first completed append. Local catalogs may be created on startup; "
+            "bucket catalogs must already exist and are read-only."
         ),
     )
     catalog_ui_parser.add_argument(
         "--catalog",
         default=_default_catalog_location(),
         help=(
-            "local catalog directory "
-            f"(default: $HFLOW_DATA_ROOT, else {PROJECT_CONFIG_FILE_NAME}'s data_root, "
-            f"else {DEFAULT_DATA_ROOT} -- plus /catalog)"
+            "catalog root: local directory or object-store prefix "
+            f"(s3://, gs://, az://; default: $HFLOW_DATA_ROOT, else "
+            f"{PROJECT_CONFIG_FILE_NAME}'s data_root, else {DEFAULT_DATA_ROOT} -- plus /catalog)"
         ),
     )
     catalog_ui_parser.add_argument(
@@ -1339,30 +1340,36 @@ def _command_catalog_ui(arguments: argparse.Namespace) -> int:
         serve_catalog_ui,
     )
 
-    if is_bucket_url(arguments.catalog):
-        print(
-            "catalog ui: DuckDB UI currently requires a local catalog directory",
-            file=sys.stderr,
-        )
-        return 2
-
-    local_catalog_root = Path(arguments.catalog)
-    if local_catalog_root.exists() and not local_catalog_root.is_dir():
-        print(
-            f"catalog ui: {os.strerror(errno.ENOTDIR)}: {local_catalog_root}",
-            file=sys.stderr,
-        )
-        return 2
+    catalog_location = arguments.catalog
+    if not is_bucket_url(catalog_location):
+        local_catalog_root = Path(catalog_location)
+        if local_catalog_root.exists() and not local_catalog_root.is_dir():
+            print(
+                f"catalog ui: {os.strerror(errno.ENOTDIR)}: {local_catalog_root}",
+                file=sys.stderr,
+            )
+            return 2
     try:
         settings = CatalogUiSettings(
-            catalog_root=local_catalog_root,
+            catalog_root=catalog_location,
             port=arguments.port,
             open_browser=not arguments.no_browser,
         )
         serve_catalog_ui(settings)
-    except (CatalogUiStartupError, OSError, ValueError) as error:
+    except (
+        CatalogUiStartupError,
+        OSError,
+        ValueError,
+        FileNotFoundError,
+        ModuleNotFoundError,
+    ) as error:
         print(f"catalog ui: {error}", file=sys.stderr)
         return 2
+    except Exception as error:
+        if is_bucket_url(catalog_location):
+            print(f"catalog ui: {error}", file=sys.stderr)
+            return 2
+        raise
     return 0
 
 

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -1366,10 +1366,14 @@ def _command_catalog_ui(arguments: argparse.Namespace) -> int:
         print(f"catalog ui: {error}", file=sys.stderr)
         return 2
     except Exception as error:
-        if is_bucket_url(catalog_location):
-            print(f"catalog ui: {error}", file=sys.stderr)
-            return 2
-        raise
+        if not is_bucket_url(catalog_location):
+            raise
+        from obstore.exceptions import BaseError as BucketStorageError
+
+        if not isinstance(error, BucketStorageError):
+            raise
+        print(f"catalog ui: {error}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -458,8 +458,33 @@ def _register_catalog_relations(
         )
 
 
+def _sync_catalog_mirror(catalog_root: "Path | str | StorageRoot") -> None:
+    """Download any catalog table files a bucket mirror lacks.
+
+    Local catalogs are already on disk; bucket catalogs need a fresh sync
+    before polling can see newly appended Parquet files.
+    """
+    location = parse_storage_root(catalog_root)
+    if isinstance(location, BucketStorageRoot):
+        location.sync_into_mirror(tuple(_TABLE_DIRECTORIES.values()))
+
+
+def _completed_append_exists(catalog_root: "Path | str | StorageRoot") -> bool:
+    """Whether a completed catalog append is present.
+
+    ``Catalog.append_episode`` writes the episodes file last, so any
+    ``episodes/*.parquet`` object proves the whole append finished.
+    """
+    location = parse_storage_root(catalog_root)
+    if isinstance(location, BucketStorageRoot):
+        _sync_catalog_mirror(location)
+        episodes_dir = location.mirror / "episodes"
+        return episodes_dir.is_dir() and any(episodes_dir.glob("*.parquet"))
+    return any(location.path.joinpath("episodes").glob("*.parquet"))
+
+
 def _refresh_local_catalog_connection(
-    connection: duckdb.DuckDBPyConnection, catalog_root: Path
+    connection: duckdb.DuckDBPyConnection, catalog_root: "Path | str | StorageRoot"
 ) -> None:
     """Replace an empty catalog surface after its first append completes.
 
@@ -471,14 +496,14 @@ def _refresh_local_catalog_connection(
     transaction lets a long-running local explorer see that first run without
     replacing its DuckDB connection.
 
-    This is intentionally local and unconstrained. Bucket connections have a
-    synced mirror with a separate refresh lifecycle, while constrained
-    connections have locked their configuration and materialized their data.
+    For bucket catalogs the query root is the synced mirror directory; this
+    re-syncs before re-registering views so the first remote append is
+    visible. Constrained connections have locked their configuration and
+    materialized their data and must not call this.
     """
     location = parse_storage_root(catalog_root)
-    if not isinstance(location, LocalStorageRoot):
-        raise ValueError("catalog connection refresh requires a local catalog")
     _verify_catalog_format(location)
+    query_root = _local_query_root(location)
 
     derived_view_names = (
         "episodes",
@@ -509,7 +534,7 @@ def _refresh_local_catalog_connection(
 
         _register_catalog_relations(
             connection,
-            location.path,
+            query_root,
             constrained=False,
             writable_directories=(),
         )

--- a/tests/test_catalog_ui.py
+++ b/tests/test_catalog_ui.py
@@ -5,12 +5,51 @@ from enum import IntEnum
 from pathlib import Path
 from socket import AF_INET, SOCK_STREAM, socket
 from threading import Event, Thread
+from typing import TYPE_CHECKING
 
 import duckdb
 import pytest
 
 import hflow
 import hflow.catalog_ui as catalog_ui
+from hflow.catalog import Catalog
+from hflow.format import CATALOG_FORMAT_VERSION
+from hflow.storage import StorageRoot
+from hflow.transform import EpisodeStamps
+
+if TYPE_CHECKING:
+    from hflow.storage import BucketStorageRoot
+
+_BUCKET_STAMPS = EpisodeStamps(
+    schema_version="1",
+    pipeline_version="bucket-ui-test",
+    ffmpeg_version="ffmpeg version test",
+    robot_software_version="sim-0.1.0",
+)
+
+
+def _write_remote_catalog_marker(catalog_root: "BucketStorageRoot") -> None:
+    catalog_root.write_bytes_if_absent(
+        "format_version",
+        (CATALOG_FORMAT_VERSION + "\n").encode(),
+    )
+
+
+def _append_remote_episode(
+    tmp_path: Path,
+    catalog_root: "BucketStorageRoot",
+    *,
+    task: str,
+    canonical_bytes: bytes = b"canonical episode",
+) -> None:
+    canonical_episode = tmp_path / f"{task}.canonical.mcap"
+    canonical_episode.write_bytes(canonical_bytes)
+    Catalog(catalog_root).append_episode(
+        canonical_path=canonical_episode,
+        stamps=_BUCKET_STAMPS,
+        episode_metadata={"task": task},
+        check_rows=[],
+    )
 
 
 def test_catalog_ui_starts_empty_then_exposes_the_first_completed_append(
@@ -296,3 +335,260 @@ def test_catalog_ui_refuses_a_port_owned_by_another_process() -> None:
             match=rf"port {occupied_port} is already in use",
         ):
             catalog_ui._raise_if_loopback_port_is_unavailable(occupied_port)
+
+
+def _run_bucket_catalog_ui_in_thread(
+    catalog_root: Path | str | StorageRoot,
+    *,
+    shutdown_event: Event,
+    background_failures: list[BaseException],
+    monkeypatch: pytest.MonkeyPatch,
+    server_started_event: Event | None = None,
+    empty_catalog_ready_event: Event | None = None,
+    catalog_refreshed_event: Event | None = None,
+    catalog_connections: list[duckdb.DuckDBPyConnection] | None = None,
+    display_labels: list[str] | None = None,
+) -> Thread:
+    def record_server_start(catalog_connection: duckdb.DuckDBPyConnection, port: int) -> None:
+        if catalog_connections is not None:
+            catalog_connections.append(catalog_connection)
+        if server_started_event is not None:
+            server_started_event.set()
+
+    refresh_local_catalog_connection = catalog_ui._refresh_local_catalog_connection
+    catalog_connection_contains_episodes = catalog_ui._catalog_connection_contains_episodes
+
+    def record_initial_catalog_read(
+        catalog_connection: duckdb.DuckDBPyConnection,
+    ) -> bool:
+        contains_episodes = catalog_connection_contains_episodes(catalog_connection)
+        if empty_catalog_ready_event is not None:
+            empty_catalog_ready_event.set()
+        return contains_episodes
+
+    def record_catalog_refresh(
+        catalog_connection: duckdb.DuckDBPyConnection,
+        refreshed_catalog_root: Path | str,
+    ) -> None:
+        refresh_local_catalog_connection(catalog_connection, refreshed_catalog_root)
+        if catalog_refreshed_event is not None:
+            catalog_refreshed_event.set()
+
+    monkeypatch.setattr(catalog_ui, "_start_duckdb_ui_server", record_server_start)
+    monkeypatch.setattr(
+        catalog_ui,
+        "_catalog_connection_contains_episodes",
+        record_initial_catalog_read,
+    )
+    monkeypatch.setattr(
+        catalog_ui,
+        "_refresh_local_catalog_connection",
+        record_catalog_refresh,
+    )
+
+    real_display_label = catalog_ui._catalog_display_label
+
+    def record_display_label(root: Path | str | StorageRoot) -> str:
+        label = real_display_label(root)
+        if display_labels is not None:
+            display_labels.append(label)
+        return label
+
+    monkeypatch.setattr(catalog_ui, "_catalog_display_label", record_display_label)
+
+    def run_catalog_ui() -> None:
+        try:
+            catalog_ui.serve_catalog_ui(
+                catalog_ui.CatalogUiSettings(
+                    catalog_root=catalog_root,
+                    open_browser=False,
+                    catalog_poll_interval_seconds=0.01,
+                ),
+                shutdown_event=shutdown_event,
+            )
+        except BaseException as error:
+            background_failures.append(error)
+
+    catalog_ui_thread = Thread(target=run_catalog_ui)
+    catalog_ui_thread.start()
+    return catalog_ui_thread
+
+
+def test_catalog_ui_starts_against_a_populated_bucket_catalog(
+    tmp_path: Path,
+    bucket_over_tmp: tuple["BucketStorageRoot", Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root, _remote_dir = bucket_over_tmp
+    catalog_root = data_root.child("catalog")
+    _append_remote_episode(tmp_path, catalog_root, task="first")
+    shutdown_event = Event()
+    server_started_event = Event()
+    background_failures: list[BaseException] = []
+    catalog_connections: list[duckdb.DuckDBPyConnection] = []
+    display_labels: list[str] = []
+    catalog_ready_event = Event()
+
+    catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
+        catalog_root,
+        shutdown_event=shutdown_event,
+        background_failures=background_failures,
+        monkeypatch=monkeypatch,
+        server_started_event=server_started_event,
+        empty_catalog_ready_event=catalog_ready_event,
+        catalog_connections=catalog_connections,
+        display_labels=display_labels,
+    )
+    try:
+        assert server_started_event.wait(timeout=2)
+        assert catalog_ready_event.wait(timeout=2)
+        (catalog_connection,) = catalog_connections
+        assert catalog_connection.execute(
+            "SELECT count(*), min(task) FROM episodes"
+        ).fetchone() == (1, "first")
+        assert display_labels == [str(catalog_root)]
+    finally:
+        shutdown_event.set()
+        catalog_ui_thread.join(timeout=2)
+
+    assert not catalog_ui_thread.is_alive()
+    assert background_failures == []
+
+
+def test_catalog_ui_waits_for_the_first_remote_append(
+    tmp_path: Path,
+    bucket_over_tmp: tuple["BucketStorageRoot", Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root, _remote_dir = bucket_over_tmp
+    catalog_root = data_root.child("catalog")
+    _write_remote_catalog_marker(catalog_root)
+    shutdown_event = Event()
+    server_started_event = Event()
+    empty_catalog_ready_event = Event()
+    catalog_refreshed_event = Event()
+    background_failures: list[BaseException] = []
+    catalog_connections: list[duckdb.DuckDBPyConnection] = []
+
+    catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
+        catalog_root,
+        shutdown_event=shutdown_event,
+        background_failures=background_failures,
+        monkeypatch=monkeypatch,
+        server_started_event=server_started_event,
+        empty_catalog_ready_event=empty_catalog_ready_event,
+        catalog_refreshed_event=catalog_refreshed_event,
+        catalog_connections=catalog_connections,
+    )
+    try:
+        assert server_started_event.wait(timeout=2)
+        assert empty_catalog_ready_event.wait(timeout=2)
+        (catalog_connection,) = catalog_connections
+        assert catalog_connection.execute("SELECT count(*) FROM episodes").fetchone() == (0,)
+
+        _append_remote_episode(tmp_path, catalog_root, task="remote-first")
+
+        assert catalog_refreshed_event.wait(timeout=2)
+        assert catalog_connection.execute(
+            "SELECT count(*), min(task) FROM episodes"
+        ).fetchone() == (1, "remote-first")
+    finally:
+        shutdown_event.set()
+        catalog_ui_thread.join(timeout=2)
+
+    assert not catalog_ui_thread.is_alive()
+    assert background_failures == []
+
+
+def test_catalog_ui_sees_a_later_remote_append_without_restart(
+    tmp_path: Path,
+    bucket_over_tmp: tuple["BucketStorageRoot", Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root, _remote_dir = bucket_over_tmp
+    catalog_root = data_root.child("catalog")
+    _append_remote_episode(tmp_path, catalog_root, task="first")
+    shutdown_event = Event()
+    server_started_event = Event()
+    background_failures: list[BaseException] = []
+    catalog_connections: list[duckdb.DuckDBPyConnection] = []
+    catalog_ready_event = Event()
+
+    catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
+        catalog_root,
+        shutdown_event=shutdown_event,
+        background_failures=background_failures,
+        monkeypatch=monkeypatch,
+        server_started_event=server_started_event,
+        empty_catalog_ready_event=catalog_ready_event,
+        catalog_connections=catalog_connections,
+    )
+    try:
+        assert server_started_event.wait(timeout=2)
+        assert catalog_ready_event.wait(timeout=2)
+        (catalog_connection,) = catalog_connections
+        assert catalog_connection.execute("SELECT count(*) FROM episodes").fetchone() == (1,)
+
+        _append_remote_episode(
+            tmp_path,
+            catalog_root,
+            task="second",
+            canonical_bytes=b"another canonical episode",
+        )
+
+        import time
+
+        start = time.monotonic()
+        while time.monotonic() - start < 2:
+            row_count = catalog_connection.execute("SELECT count(*) FROM episodes").fetchone()
+            if row_count == (2,):
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("expected the second remote append to become visible")
+    finally:
+        shutdown_event.set()
+        catalog_ui_thread.join(timeout=2)
+
+    assert not catalog_ui_thread.is_alive()
+    assert background_failures == []
+
+
+def test_catalog_ui_does_not_write_bucket_objects_while_browsing(
+    tmp_path: Path,
+    bucket_over_tmp: tuple["BucketStorageRoot", Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_root, _remote_dir = bucket_over_tmp
+    catalog_root = data_root.child("catalog")
+    _append_remote_episode(tmp_path, catalog_root, task="stable")
+    remote_keys_before = catalog_root.list_names()
+    catalog_constructor_calls = 0
+    real_catalog = Catalog
+
+    def record_catalog_constructor(root: Path | str) -> Catalog:
+        nonlocal catalog_constructor_calls
+        catalog_constructor_calls += 1
+        return real_catalog(root)
+
+    monkeypatch.setattr(catalog_ui, "Catalog", record_catalog_constructor)
+    shutdown_event = Event()
+    server_started_event = Event()
+    background_failures: list[BaseException] = []
+
+    catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
+        catalog_root,
+        shutdown_event=shutdown_event,
+        background_failures=background_failures,
+        monkeypatch=monkeypatch,
+        server_started_event=server_started_event,
+    )
+    try:
+        assert server_started_event.wait(timeout=2)
+    finally:
+        shutdown_event.set()
+        catalog_ui_thread.join(timeout=2)
+
+    assert catalog_constructor_calls == 0
+    assert catalog_root.list_names() == remote_keys_before
+    assert background_failures == []

--- a/tests/test_catalog_ui.py
+++ b/tests/test_catalog_ui.py
@@ -52,6 +52,20 @@ def _append_remote_episode(
     )
 
 
+def _writer_catalog_root(tmp_path: Path, remote_dir: Path) -> "BucketStorageRoot":
+    """A catalog writer with its own mirror over the same bucket as the UI.
+
+    Production ingest is a separate process with a separate mirror. Sharing the
+    UI's mirror would let appends prime DuckDB without exercising sync.
+    """
+    from hflow.storage import BucketStorageRoot
+
+    return BucketStorageRoot(
+        f"file://{remote_dir}",
+        mirror=tmp_path / "writer-mirror",
+    ).child("catalog")
+
+
 def test_catalog_ui_starts_empty_then_exposes_the_first_completed_append(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -460,9 +474,10 @@ def test_catalog_ui_waits_for_the_first_remote_append(
     bucket_over_tmp: tuple["BucketStorageRoot", Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    data_root, _remote_dir = bucket_over_tmp
-    catalog_root = data_root.child("catalog")
-    _write_remote_catalog_marker(catalog_root)
+    data_root, remote_dir = bucket_over_tmp
+    ui_catalog_root = data_root.child("catalog")
+    writer_catalog_root = _writer_catalog_root(tmp_path, remote_dir)
+    _write_remote_catalog_marker(writer_catalog_root)
     shutdown_event = Event()
     server_started_event = Event()
     empty_catalog_ready_event = Event()
@@ -471,7 +486,7 @@ def test_catalog_ui_waits_for_the_first_remote_append(
     catalog_connections: list[duckdb.DuckDBPyConnection] = []
 
     catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
-        catalog_root,
+        ui_catalog_root,
         shutdown_event=shutdown_event,
         background_failures=background_failures,
         monkeypatch=monkeypatch,
@@ -486,7 +501,7 @@ def test_catalog_ui_waits_for_the_first_remote_append(
         (catalog_connection,) = catalog_connections
         assert catalog_connection.execute("SELECT count(*) FROM episodes").fetchone() == (0,)
 
-        _append_remote_episode(tmp_path, catalog_root, task="remote-first")
+        _append_remote_episode(tmp_path, writer_catalog_root, task="remote-first")
 
         assert catalog_refreshed_event.wait(timeout=2)
         assert catalog_connection.execute(
@@ -505,9 +520,10 @@ def test_catalog_ui_sees_a_later_remote_append_without_restart(
     bucket_over_tmp: tuple["BucketStorageRoot", Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    data_root, _remote_dir = bucket_over_tmp
-    catalog_root = data_root.child("catalog")
-    _append_remote_episode(tmp_path, catalog_root, task="first")
+    data_root, remote_dir = bucket_over_tmp
+    ui_catalog_root = data_root.child("catalog")
+    writer_catalog_root = _writer_catalog_root(tmp_path, remote_dir)
+    _append_remote_episode(tmp_path, writer_catalog_root, task="first")
     shutdown_event = Event()
     server_started_event = Event()
     background_failures: list[BaseException] = []
@@ -515,7 +531,7 @@ def test_catalog_ui_sees_a_later_remote_append_without_restart(
     catalog_ready_event = Event()
 
     catalog_ui_thread = _run_bucket_catalog_ui_in_thread(
-        catalog_root,
+        ui_catalog_root,
         shutdown_event=shutdown_event,
         background_failures=background_failures,
         monkeypatch=monkeypatch,
@@ -531,7 +547,7 @@ def test_catalog_ui_sees_a_later_remote_append_without_restart(
 
         _append_remote_episode(
             tmp_path,
-            catalog_root,
+            writer_catalog_root,
             task="second",
             canonical_bytes=b"another canonical episode",
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,3 +173,73 @@ def test_the_module_form_reports_a_conforming_file(tmp_path: Path) -> None:
     assert module.returncode == 0
     assert module.returncode == script.returncode
     assert module.stdout == script.stdout
+
+
+@pytest.mark.parametrize("scheme", ["s3", "gs", "az"])
+def test_catalog_ui_cli_accepts_bucket_catalog_urls(
+    scheme: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hflow.catalog_ui import CatalogUiSettings
+    from hflow.cli import _command_catalog_ui
+
+    served_catalog_roots: list[str] = []
+
+    def record_serve(settings: CatalogUiSettings) -> None:
+        served_catalog_roots.append(str(settings.catalog_root))
+
+    monkeypatch.setattr("hflow.catalog_ui.serve_catalog_ui", record_serve)
+    parser = _build_parser()
+    catalog_url = f"{scheme}://robot-data/production/catalog"
+    arguments = parser.parse_args(["catalog", "ui", "--no-browser", "--catalog", catalog_url])
+
+    assert _command_catalog_ui(arguments) == 0
+    assert served_catalog_roots == [catalog_url]
+
+
+def test_catalog_ui_cli_reports_a_missing_remote_catalog_marker(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    def raise_missing_marker(_settings: object) -> None:
+        raise FileNotFoundError(
+            "gs://robot-data/production/catalog is not a catalog root "
+            "(no format_version marker); expected the location a Catalog was "
+            "created with, e.g. <data_root>/catalog"
+        )
+
+    monkeypatch.setattr("hflow.catalog_ui.serve_catalog_ui", raise_missing_marker)
+
+    exit_code = main(
+        [
+            "catalog",
+            "ui",
+            "--no-browser",
+            "--catalog",
+            "gs://robot-data/production/catalog",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.err.startswith("catalog ui:")
+    assert "format_version" in captured.err
+
+
+def test_catalog_ui_cli_reports_a_missing_bucket_extra(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    def raise_missing_obstore() -> object:
+        raise ModuleNotFoundError(
+            "bucket storage roots need the optional obstore backend -- install the "
+            'extra: pip install "hflow[bucket]" (uv: uv add "hflow[bucket]")'
+        )
+
+    monkeypatch.setattr("hflow.storage._load_obstore", raise_missing_obstore)
+
+    exit_code = main(
+        ["catalog", "ui", "--no-browser", "--catalog", "s3://robot-data/production/catalog"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.err.startswith("catalog ui:")
+    assert "hflow[bucket]" in captured.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,3 +243,34 @@ def test_catalog_ui_cli_reports_a_missing_bucket_extra(
     assert exit_code == 2
     assert captured.err.startswith("catalog ui:")
     assert "hflow[bucket]" in captured.err
+
+
+def test_catalog_ui_cli_reports_a_bucket_credentials_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    from obstore.exceptions import UnauthenticatedError
+
+    def raise_credentials_error(_settings: object) -> None:
+        raise UnauthenticatedError("provider credentials are unavailable")
+
+    monkeypatch.setattr("hflow.catalog_ui.serve_catalog_ui", raise_credentials_error)
+
+    exit_code = main(
+        ["catalog", "ui", "--no-browser", "--catalog", "s3://robot-data/production/catalog"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.err == "catalog ui: provider credentials are unavailable\n"
+
+
+def test_catalog_ui_cli_does_not_hide_programming_errors_for_bucket_catalogs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_programming_error(_settings: object) -> None:
+        raise RuntimeError("unexpected implementation bug")
+
+    monkeypatch.setattr("hflow.catalog_ui.serve_catalog_ui", raise_programming_error)
+
+    with pytest.raises(RuntimeError, match="unexpected implementation bug"):
+        main(["catalog", "ui", "--no-browser", "--catalog", "gs://robot-data/catalog"])


### PR DESCRIPTION
## Summary

- Allow `hflow catalog ui --catalog` to open existing S3, GCS, and Azure catalogs.
- Validate the remote catalog marker without creating or changing bucket objects.
- Sync append-only Parquet files into the existing local mirror before DuckDB opens.
- Poll for first and later completed appends without restarting the UI.
- Keep DuckDB on loopback and restrict catalog reads to the local mirror.
- Add behavioral tests and document bucket usage, mirroring, and SSH forwarding.

Closes #305.

## Why

`hflow catalog ui` previously rejected every bucket URL even though HFlow's catalog connection already supported bucket-backed catalogs through its local mirror.

This change reuses the existing catalog marker, append, and mirror semantics instead of adding direct object-store access to DuckDB or introducing a new catalog format. Local catalog behavior remains unchanged, while bucket browsing stays read-only.

## Validation

- `uv run ruff check`
  - Passed
- `uv run ruff format --check`
  - Passed; 206 files already formatted
- `uv run ty check`
  - Passed
- `uv run pytest tests/test_catalog_ui.py tests/test_cli.py tests/test_storage.py -q`
  - 92 passed, 1 skipped
- `uv run pytest -q`
  - 1402 passed, 6 skipped
- Pre-commit hooks
  - `ruff check` passed
  - `ruff format` passed

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.