### PR TITLE
test(lerobot): cover the required 'index' column refusal in the curated export

### DIFF
--- a/tests/test_lerobot_export.py
+++ b/tests/test_lerobot_export.py
@@ -404,6 +404,21 @@ def test_export_duplicate_episode_fails(fake_corpus: dict, tmp_path: Path) -> No
     assert not dest.exists()
 
 
+def test_export_missing_index_column_fails(fake_corpus: dict, tmp_path: Path) -> None:
+    """A source data parquet without an 'index' column is refused by message."""
+    import pyarrow.parquet as pq
+
+    src = Path(fake_corpus["cache_dir"]) / "data" / "chunk-000" / "file-000.parquet"
+    table = pq.read_table(src).drop_columns(["index"])
+    pq.write_table(table, src)
+
+    manifest = _fake_manifest(tmp_path, [{"metadata_json": _provenance_meta(0)}])
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match=r"has no 'index' column"):
+        export.export(dest, manifest=manifest, camera_keys=CAMS)
+    assert not dest.exists()
+
+
 def test_export_sql_selection(fake_corpus: dict, tmp_path: Path) -> None:
     """SQL selection path: same outcome via a duckdb query string."""
     _make_data_local(fake_corpus)


### PR DESCRIPTION
Fixes #370

The guard at `examples/lerobot/export.py:349-354` was the one refusal in the export module with no test (it came from my #273 renumbering cleanup, where the `frame_index` fallback collided with the per-episode renumber). This PR adds the missing test.

**What changed**

- New `test_export_missing_index_column_fails` in `tests/test_lerobot_export.py`: builds the normal `fake_corpus`, drops the `index` column from the source data parquet (pyarrow), drives the real `export.export(...)` via a manifest, and asserts the refusal **by message** (`has no 'index' column`) rather than by exception type — several other guards in the module also raise `ValueError`.
- The happy-path fixture keeps its `index` column; nothing in `examples/lerobot/export.py` changes (test-only per the issue).

**RED/GREEN evidence**

- Guard neutered (`if False and "index" not in cols:`): the new test FAILS — the export falls through to a duckdb `BinderException` at export.py:357 instead of the refusal. (1 failed)
- Guard restored: 17/17 in `tests/test_lerobot_export.py` pass.

**Validation run**

- `uv run --no-sync pytest -q tests/test_lerobot_export.py` → 17 passed
- `uv run --no-sync ruff check tests/test_lerobot_export.py` → clean
- `uv run --no-sync ruff format --check tests/test_lerobot_export.py` → clean
- `uv run --no-sync ty check` → clean
- `uv run --no-sync pytest -q` (repo root) → 1410 passed, 6 skipped, 1 failed: `test_canonical_episode_extracts_exact_source_frame_indices` — reproduced identically on a clean origin/main worktree (same WSL ffmpeg env failure, unrelated to this change).