### PR TITLE
Check the no-B-frame constraint in doctor and the encoder

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -158,18 +158,20 @@ to MP4 cannot represent the reorder tail: the trailing B frames are silently und
 the muxed file (measured in [#250](https://github.com/Hebbian-Robotics/hflow/issues/250): 303
 samples in, 301 decoded). The transform refuses pass-through video that carries B-frames, and
 the MP4 remux behind `Episode.video` refuses any B-frame payload outright, with an error naming
-the observed reorder depth and the frames at risk. `hflow doctor` still does not classify
-picture coding types (below), so a clean report does not prove this constraint; the refusals do.
+the observed reorder depth and the frames at risk. `hflow doctor` reports any B picture it
+classifies in a video message as the `video-b-picture` error finding (below), so a clean
+report now covers this constraint alongside the refusals.
 
 `hflow doctor <file.mcap> [more.mcap ...]` checks every file given and prints
 one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
 stamps, chunk purity (against the file's own group map, or a video-versus-state
 approximation when it has none), per-topic time order, per-group chunk time
-order, and the H.264 access-unit properties listed below. It does not
-currently classify H.264 picture coding types to detect
-B-frames, so a clean report is not proof of the unchecked no-B-frame
-constraint. The doctor also does not reject non-VCL NAL units before the first
+order, and the H.264 access-unit properties listed below. It classifies
+H.264 picture coding types to detect
+B-frames as the `video-b-picture` error finding. A payload whose slice headers cannot be
+parsed still cannot be classified and is reported as
+`video-invalid-slice-header`. The doctor also does not reject non-VCL NAL units before the first
 AUD, so a clean report does not prove the canonical AUD-first constraint. An
 unreadable or unparseable path is reported in place, in the same per-file shape
 (`[error] unreadable: ...`), and the run continues with the remaining files.
@@ -196,6 +198,7 @@ automation. An `error` breaks the canonical convention (or the MCAP spec); a
 | `topic-time-order` | error | A channel's `log_time` decreases between messages. |
 | `video-format` | error | A supported video message does not declare `format="h264"`. |
 | `video-invalid-slice-header` | error | The H.264 payload's picture count cannot be determined from its slice headers. |
+| `video-b-picture` | error | A video message's slice headers classify at least one picture as a B picture; canonical video requires no B-frames. |
 | `video-multiple-access-units` | error | A video message contains more than one picture or access unit. |
 | `video-not-aud-delimited` | error | No AUD is present, or VCL data precedes the first AUD. |
 | `video-keyframe-missing-parameter-sets` | error | A keyframe does not carry both SPS and PPS. |

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -167,14 +167,14 @@ one report each in argument order; its aggregate result follows the
 [exit code rules](#exit-codes). It validates the container, summary, indexes,
 stamps, chunk purity (against the file's own group map, or a video-versus-state
 approximation when it has none), per-topic time order, per-group chunk time
-order, and the H.264 access-unit properties listed below. It classifies
-H.264 picture coding types to detect
-B-frames as the `video-b-picture` error finding. A payload whose slice headers cannot be
-parsed still cannot be classified and is reported as
-`video-invalid-slice-header`. The doctor also does not reject non-VCL NAL units before the first
-AUD, so a clean report does not prove the canonical AUD-first constraint. An
-unreadable or unparseable path is reported in place, in the same per-file shape
-(`[error] unreadable: ...`), and the run continues with the remaining files.
+order, and the H.264 access-unit properties listed below. It classifies H.264
+picture coding types to detect B-frames as the `video-b-picture` error finding.
+A payload whose slice headers cannot be parsed still cannot be classified, and
+is reported as `video-invalid-slice-header` instead. The doctor does not reject
+non-VCL NAL units before the first AUD, so a clean report does not prove the
+canonical AUD-first constraint. An unreadable or unparseable path is reported
+in place, in the same per-file shape (`[error] unreadable: ...`), and the run
+continues with the remaining files.
 
 ### Doctor finding codes
 

--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -109,7 +109,21 @@ def _check_video_payload(
         )
         return
     try:
-        picture_count = video_module.count_h264_pictures(payload)
+        try:
+            coding_scan = video_module.scan_picture_coding_types(payload)
+        except ValueError:
+            # The scan fails closed on any unparseable slice header, but
+            # count_h264_pictures only needs first_mb_in_slice and can still
+            # succeed. Delegating to it keeps the doctor hot path to one walk
+            # while its own ValueError, caught below, keeps the finding text
+            # byte-identical for both count failure kinds. Its count also
+            # reproduces the pre-classification behavior exactly when the
+            # first_mb_in_slice field parses and slice_type does not.
+            picture_count = video_module.count_h264_pictures(payload)
+            b_picture_count = None
+        else:
+            picture_count = coding_scan.picture_count
+            b_picture_count = coding_scan.b_picture_count
     except ValueError as error:
         collector.add(
             DiagnosticLevel.ERROR,
@@ -117,6 +131,16 @@ def _check_video_payload(
             f"{topic} message {message_index}: {error}",
         )
         return
+    if b_picture_count is None:
+        # The scan could not classify; no B-frame claim is possible.
+        pass
+    elif b_picture_count > 0:
+        collector.add(
+            DiagnosticLevel.ERROR,
+            "video-b-picture",
+            f"{topic} message {message_index}: {b_picture_count} B picture(s), "
+            "canonical video requires no B-frames; a remux would drop the reorder tail",
+        )
     if picture_count > 1:
         collector.add(
             DiagnosticLevel.ERROR,

--- a/src/hflow/video.py
+++ b/src/hflow/video.py
@@ -150,6 +150,7 @@ def encode_images_to_h264(
       input order (no B-frames means decode order == presentation order).
     - ``result[i].is_keyframe`` is True exactly when ``i % gop_frames == 0``.
     - Every keyframe access unit has ``has_parameter_sets == True``.
+    - No access unit contains a B picture (checked from the slice headers).
     """
     concatenated_image_bytes = b"".join(images)
     x264_params = (
@@ -685,6 +686,17 @@ def _enforce_encode_guarantees(
             raise VideoEncodeError(
                 f"keyframe access unit {unit_index} is missing SPS/PPS despite repeat-headers=1"
             )
+    coding_scan = scan_picture_coding_types(b"".join(unit.data for unit in access_units))
+    if coding_scan.b_picture_count > 0:
+        # The joined scan proves the stream carries a B picture; the per-unit
+        # rescan on this error path names the first offending access unit.
+        for unit_index, access_unit in enumerate(access_units):
+            unit_scan = scan_picture_coding_types(access_unit.data)
+            if unit_scan.b_picture_count > 0:
+                raise VideoEncodeError(
+                    f"access unit {unit_index}: {unit_scan.b_picture_count} B picture(s), "
+                    "canonical video requires no B-frames"
+                )
 
 
 def _stderr_tail(stderr: bytes) -> str:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -107,6 +107,92 @@ def test_nonconforming_ros2_video_is_reported(tmp_path: Path) -> None:
     assert "video-not-aud-delimited" in codes
 
 
+def _write_video_message_mcap(path: Path, payload: bytes) -> None:
+    """One ``foxglove.CompressedVideo`` message carrying ``payload`` on /cam."""
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        channel_id = writer.register_channel(
+            topic="/cam", message_encoding="protobuf", schema_id=schema_id
+        )
+        message = CompressedVideo()
+        message.timestamp.FromNanoseconds(10**9)
+        message.frame_id = "cam"
+        message.data = payload
+        message.format = "h264"
+        writer.add_message(
+            channel_id, log_time=10**9, data=message.SerializeToString(), publish_time=10**9
+        )
+        writer.finish()
+
+
+def test_doctor_reports_a_b_picture_from_slice_headers(tmp_path: Path) -> None:
+    # Slice header RBSP 0xa8: first_mb_in_slice = 0 (ue "1"), slice_type = 1
+    # (ue "010", B in H.264 Table 7-6), stop bit, zero padding. The payload is
+    # AUD-first with exactly one picture, so the B classification is the only
+    # non-conformance besides the first-message keyframe rule.
+    path = tmp_path / "b_picture.mcap"
+    _write_video_message_mcap(path, b"\x00\x00\x00\x01\x09\x10\x00\x00\x00\x01\x41\xa8")
+
+    report = diagnose(path)
+
+    assert not report.conforming
+    b_finding = next(finding for finding in report.findings if finding.code == "video-b-picture")
+    assert "1 B picture" in b_finding.message
+    assert "no B-frames" in b_finding.message
+    assert "video-invalid-slice-header" not in {finding.code for finding in report.findings}
+
+
+def test_doctor_keeps_both_pinned_count_messages_when_the_scan_refuses(
+    tmp_path: Path,
+) -> None:
+    # The scan fails closed on both payloads; the doctor delegates the count
+    # on that error path, so the emitted text is count_h264_pictures' own.
+    malformed_first_byte_to_pinned_message = {
+        b"\x00": "slice header has no complete first_mb_in_slice value",
+        b"\x04": "slice header truncates its first_mb_in_slice value",
+    }
+    for message_index, (malformed_rbsp, pinned_message) in enumerate(
+        malformed_first_byte_to_pinned_message.items()
+    ):
+        path = tmp_path / f"malformed_{message_index}.mcap"
+        _write_video_message_mcap(
+            path, b"\x00\x00\x00\x01\x09\x10\x00\x00\x00\x01\x65" + malformed_rbsp
+        )
+
+        report = diagnose(path)
+
+        finding = next(
+            finding for finding in report.findings if finding.code == "video-invalid-slice-header"
+        )
+        assert finding.message.endswith(pinned_message)
+        assert not any(finding.code == "video-b-picture" for finding in report.findings)
+
+
+def test_doctor_reports_invalid_slice_header_over_b_picture_when_a_header_is_malformed(
+    tmp_path: Path,
+) -> None:
+    # A B slice follows a malformed first slice. The scan refuses before any
+    # picture is classified, so the count message wins and no B code appears.
+    path = tmp_path / "b_after_malformed.mcap"
+    _write_video_message_mcap(
+        path, b"\x00\x00\x00\x01\x09\x10\x00\x00\x00\x01\x65\x00\x00\x00\x00\x01\x41\xa8"
+    )
+
+    report = diagnose(path)
+
+    finding = next(
+        finding for finding in report.findings if finding.code == "video-invalid-slice-header"
+    )
+    assert finding.message.endswith("slice header has no complete first_mb_in_slice value")
+    assert not any(finding.code == "video-b-picture" for finding in report.findings)
+
+
 def test_not_an_mcap_file(tmp_path: Path) -> None:
     bogus = tmp_path / "bogus.mcap"
     bogus.write_bytes(b"definitely not mcap")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -11,6 +11,7 @@ from hflow.video import (
     AccessUnit,
     PictureCodingScan,
     VideoEncodeError,
+    _enforce_encode_guarantees,
     _first_mb_failure_message,
     _remove_emulation_prevention_bytes,
     _unescape_ebsp_head,
@@ -233,6 +234,68 @@ def test_remux_refuses_a_b_frame_stream_naming_the_tail(
     # The refusal fires before ffmpeg runs, so no partial MP4 is left behind.
     assert not output_path.exists()
     assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_encode_guarantees_accept_a_conforming_stream(
+    encoded_units: list[AccessUnit],
+) -> None:
+    _enforce_encode_guarantees(
+        encoded_units, expected_frame_count=len(encoded_units), gop_frames=GOP_FRAMES
+    )
+
+
+def test_encode_guarantees_raise_on_a_b_picture_naming_the_unit() -> None:
+    # A keyframe lead (passing the cadence check), then a B picture
+    # (slice_type 1), then a P picture. The guarantee must name access unit 1.
+    aud = b"\x00\x00\x00\x01\x09\x10"
+    non_idr_nal = b"\x00\x00\x00\x01\x41"
+    units = [
+        AccessUnit(
+            data=aud + b"\x00\x00\x00\x01\x65" + _slice_header_rbsp(0, 2),
+            is_keyframe=True,
+            has_parameter_sets=True,
+        ),
+        AccessUnit(
+            data=aud + non_idr_nal + _slice_header_rbsp(0, 1),
+            is_keyframe=False,
+            has_parameter_sets=False,
+        ),
+        AccessUnit(
+            data=aud + non_idr_nal + _slice_header_rbsp(0, 0),
+            is_keyframe=False,
+            has_parameter_sets=False,
+        ),
+    ]
+
+    with pytest.raises(VideoEncodeError, match=r"access unit 1") as error:
+        _enforce_encode_guarantees(units, expected_frame_count=len(units), gop_frames=3)
+
+    assert "B picture" in str(error.value)
+
+
+def test_encode_guarantees_find_a_b_picture_in_a_later_unit() -> None:
+    # A B picture in the final unit must still be named, proving the joined
+    # scan covers the whole stream rather than stopping early.
+    aud = b"\x00\x00\x00\x01\x09\x10"
+    non_idr_nal = b"\x00\x00\x00\x01\x41"
+    units = [
+        AccessUnit(
+            data=aud + b"\x00\x00\x00\x01\x65" + _slice_header_rbsp(0, 2),
+            is_keyframe=True,
+            has_parameter_sets=True,
+        ),
+        AccessUnit(
+            data=aud + non_idr_nal + _slice_header_rbsp(0, 1),
+            is_keyframe=False,
+            has_parameter_sets=False,
+        ),
+    ]
+
+    with pytest.raises(VideoEncodeError, match=r"access unit 1"):
+        _enforce_encode_guarantees(units, expected_frame_count=len(units), gop_frames=2)
+
+    with pytest.raises(VideoEncodeError, match=r"access unit 1"):
+        _enforce_encode_guarantees(units, expected_frame_count=len(units), gop_frames=2)
 
 
 def test_split_rejects_garbage_without_aud() -> None:


### PR DESCRIPTION
Closes #368.

- Doctor now classifies picture coding types. _check_video_payload takes the count from scan_picture_coding_types(...).picture_count and reports a video-b-picture error finding when b_picture_count > 0, one NAL walk on the hot path, no double walk.
- On an unparseable slice header the doctor delegates to count_h264_pictures on the error path and lets its own ValueError emit the finding, so video-invalid-slice-header stays byte-identical for both pinned kinds and the existing guard tests pass untouched.
- Precedence: a malformed slice header wins over any B claim. The B finding is additive and never fires on an unclassifiable payload.
- _enforce_encode_guarantees scans the joined stream and raises VideoEncodeError naming the first access unit that carries a B picture. The per-unit rescan runs only on the error path.
- Mutation proof: deleting the doctor B check fails test_doctor_reports_a_b_picture_from_slice_headers, deleting the encoder B check fails both encoder tests with DID NOT RAISE VideoEncodeError.
- Timing, interleaved A/B, median of warm iterations, conforming bframes=0 streams: 300 messages 2.64 ms before and 2.96 ms after (+12.1%), 3000 messages 24.67 ms before and 26.63 ms after (+7.9%). The delta is the same count-vs-scan gap you measured on #358, now buying the doctor the B classification.
- docs/FORMAT.md closes both gap notes and adds the video-b-picture row. 1415 passed / 6 skipped, ruff, format, and ty clean.