### PR TITLE
test(lerobot): use realistic valid shas in cache-namespacing test

### DIFF
--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -393,7 +393,18 @@ def test_camera_selection_validates_keys(tmp_path: Path, monkeypatch: pytest.Mon
 def test_import_namespaces_source_cache_by_resolved_revision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    resolved_shas = {"branch-a": "sha-a", "branch-b": "sha-b", "tag-a": "sha-a"}
+    # Realistic valid shas the production validator at
+    # src/hflow/importers/lerobot.py would accept: 40-character hexadecimal,
+    # visibly distinct at the start so a reader can tell them apart at a
+    # glance. ``branch-a`` and ``tag-a`` resolve to the same sha on purpose:
+    # they are the two-revisions-one-cache leg of the contract.
+    sha_a = "a1b2c3d4e5f60718293a4b5c6d7e8f9001020304"
+    sha_b = "f0e1d2c3b4a5968778695a4b3c2d1e0f00112233"
+    resolved_shas = {
+        "branch-a": sha_a,
+        "branch-b": sha_b,
+        "tag-a": sha_a,
+    }
     cache_observations: list[tuple[str, Path, str]] = []
 
     monkeypatch.setattr(
@@ -431,13 +442,13 @@ def test_import_namespaces_source_cache_by_resolved_revision(
         )
 
     assert cache_observations == [
-        ("sha-a", tmp_path / "_lerobot_cache" / "sha-a", "sha-a"),
-        ("sha-b", tmp_path / "_lerobot_cache" / "sha-b", "sha-b"),
-        ("sha-a", tmp_path / "_lerobot_cache" / "sha-a", "sha-a"),
+        (sha_a, tmp_path / "_lerobot_cache" / sha_a, sha_a),
+        (sha_b, tmp_path / "_lerobot_cache" / sha_b, sha_b),
+        (sha_a, tmp_path / "_lerobot_cache" / sha_a, sha_a),
     ]
     assert sorted(path.name for path in (tmp_path / "_lerobot_cache").iterdir()) == [
-        "sha-a",
-        "sha-b",
+        sha_a,
+        sha_b,
     ]
 
 


### PR DESCRIPTION
## What was wrong

`test_import_namespaces_source_cache_by_resolved_revision` proves the cache is namespaced by the *resolved* Hugging Face sha. It stubbed `_hf_repo_info` to return the values `sha-a` and `sha-b` — neither of which would survive the production validator at `src/hflow/importers/lerobot.py:239-240` (`r"[0-9a-f]{7,64}"`). The test passed only because the stub bypassed the validator, so a future bug in the validator or in the cache-path construction that consumes the resolved sha could not manifest in this test.

A test that uses values its own code path would reject cannot fail for the right reason.

## What changed

- `tests/test_lerobot_converter.py`: replaced the non-hex `sha-a` / `sha-b` literals with two 40-character hexadecimal shas and bound them to local variables `sha_a` and `sha_b`. The fixture dict and both assertions now reference the variables, so the test no longer contradicts the production validator.
- No production code changes. `_hf_repo_info`'s validator, the cache-path construction, and the rest of the test file are untouched.
- The test's contract is unchanged: two revisions that resolve to the same sha share one cache directory, a different sha gets its own. `branch-a` and `tag-a` still resolve to the same sha on purpose — that is the two-revisions-one-cache leg of the contract.

The two shas were chosen so a reader can tell them apart at a glance (one starts with `a1b2`, the other with `f0e1`), not just at the last character.

## How the fix was validated

- `uv run ruff check --fix` — passed
- `uv run ruff format` — passed (no formatting changes)
- `uv run ty check` — passed
- `uv run pytest -q tests/test_lerobot_converter.py` — **35 passed**
- `uv run pytest -q` — **1421 passed, 12 skipped** (the two pre-existing `test_checks.py` failures around `camera_motion` and Lucas-Kanade optical flow are unrelated to this change — they reproduce on plain `origin/main` without this branch's commit and concern a different module; out of scope for this PR).

## Proof the relevant test passes

```
$ uv run pytest -q tests/test_lerobot_converter.py::test_import_namespaces_source_cache_by_resolved_revision
.                                                                        [100%]
1 passed in 0.12s
```

## Out of scope

The two `test_checks.py` failures observed on the full suite are pre-existing and unrelated to this change. They will be addressed in a separate PR.


closes #371 