### PR TITLE
feat(lerobot): publish imports into bucket-backed data roots

### DIFF
--- a/docs/how-to/import-lerobot-v3.md
+++ b/docs/how-to/import-lerobot-v3.md
@@ -33,6 +33,24 @@ Re-running against the same output directory reuses downloaded source files.
 Run `uv run hflow doctor ./data/lerobot_pusht/landing/*.mcap` to print the
 canonical-format report.
 
+Object-store data roots work the same way when the optional bucket backend is
+installed (`uv sync --extra bucket`) and provider credentials are available:
+
+```bash
+uv run hflow import lerobot \
+  --repo lerobot/pusht \
+  --revision main \
+  --camera observation.image \
+  --episode-index 0 \
+  --output-dir gs://robot-data/production
+```
+
+Durable outputs land as `landing/*.mcap` and `prepared-manifest.json` under
+that prefix. Hugging Face downloads stay in the local mirror under
+`_lerobot_cache/` (`HFLOW_MIRROR_DIR`, or `$XDG_CACHE_HOME/hflow/mirrors`) and
+are never uploaded into the bucket. The success manifest is published only
+after every selected episode object has been written.
+
 For a gated or private repository, export a read token as `HF_TOKEN` (or
 `HUGGING_FACE_HUB_TOKEN`) before running the command. HFlow sends the token
 only to Hugging Face requests and never records it in an episode or manifest.
@@ -92,8 +110,9 @@ episodes = hflow.import_lerobot_dataset(
 )
 ```
 
-The return value is the list of canonical MCAP paths written under
-`output_dir / "landing"`.
+The return value is the list of published episode URIs under
+`landing/` -- absolute path strings for a local data root, or `s3://` /
+`gs://` / `az://` object URIs for a bucket root.
 
 This command imports source data into HFlow. It does not upload data, train a
 policy, or export a curated HFlow manifest back to LeRobot Dataset v3.

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -297,9 +297,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     lerobot_import_parser.add_argument(
         "--output-dir",
-        type=Path,
         required=True,
-        help="local destination; episodes are written under its landing/ directory",
+        help=(
+            "destination data root: local directory or object-store prefix "
+            "(s3://, gs://, az://); episodes publish under landing/"
+        ),
     )
     lerobot_import_parser.add_argument(
         "--camera",
@@ -853,18 +855,37 @@ def _command_import_lerobot(arguments: argparse.Namespace) -> int:
     from hflow.importers.lerobot import DEFAULT_CAMERA_KEY, import_lerobot_dataset
 
     camera_keys = arguments.camera_keys or [DEFAULT_CAMERA_KEY]
+    output_location = arguments.output_dir
+    bucket_destination = is_bucket_url(output_location)
+    bucket_storage_error: type[BaseException] | None = None
+    if bucket_destination:
+        # Import while the optional extra is already known to be required for
+        # this path, so a later handler cannot mask an unrelated failure with
+        # ModuleNotFoundError from this import.
+        try:
+            from obstore.exceptions import BaseError as BucketStorageError
+        except ModuleNotFoundError:
+            bucket_storage_error = None
+        else:
+            bucket_storage_error = BucketStorageError
+
     try:
-        output_paths = import_lerobot_dataset(
+        output_uris = import_lerobot_dataset(
             dataset_repo=arguments.repo,
             revision=arguments.revision,
-            output_dir=arguments.output_dir,
+            output_dir=output_location,
             episode_index=arguments.episode_index,
             camera_keys=camera_keys,
         )
-    except (ValueError, RuntimeError, OSError) as error:
+    except (ValueError, RuntimeError, OSError, ModuleNotFoundError) as error:
         print(f"import lerobot: {error}", file=sys.stderr)
         return 2
-    print(f"import lerobot: converted {len(output_paths)} episode(s)")
+    except Exception as error:
+        if bucket_storage_error is not None and isinstance(error, bucket_storage_error):
+            print(f"import lerobot: {error}", file=sys.stderr)
+            return 2
+        raise
+    print(f"import lerobot: converted {len(output_uris)} episode(s)")
     return 0
 
 

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -32,6 +32,7 @@ from urllib.parse import urlsplit
 from mcap.writer import Writer as McapWriter
 
 from hflow.ffmpeg import ffmpeg_path, ffmpeg_version, ffprobe_path
+from hflow.storage import LocalStorageRoot, StorageRoot, parse_storage_root
 from hflow.transform import TransformConfig, write_canonical_episode
 
 logger = logging.getLogger(__name__)
@@ -575,10 +576,10 @@ def _derive_numeric_schema(feature_name: str, feature_specification: dict) -> _N
 def import_lerobot_dataset(
     dataset_repo: str = DEFAULT_REPO,
     revision: str = DEFAULT_REVISION,
-    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    output_dir: Path | str | StorageRoot = DEFAULT_OUTPUT_DIR,
     episode_index: int | None = None,
     camera_keys: str | Sequence[str] = (DEFAULT_CAMERA_KEY,),
-) -> list[Path]:
+) -> list[str]:
     """Import selected LeRobot Dataset v3 episodes as canonical MCAP.
 
     ``dataset_repo`` is a Hugging Face dataset repository. ``revision`` may
@@ -588,11 +589,28 @@ def import_lerobot_dataset(
     camera features; a comma-separated string is accepted for compatibility.
     When ``episode_index`` is omitted, every episode is imported.
 
+    ``output_dir`` is any HFlow data root: a local directory or an object-store
+    prefix (``s3://``, ``gs://``, ``az://``). Hugging Face downloads and MCAP
+    construction use local staging under the root's workspace. Durable outputs
+    are published as ``landing/*.mcap`` plus ``prepared-manifest.json`` after
+    every selected episode succeeds. The source cache (``_lerobot_cache``) stays
+    in the workspace -- the local directory itself, or the bucket mirror under
+    ``HFLOW_MIRROR_DIR`` -- and is never uploaded into a bucket root.
+
     Dataset v3 video features and one-dimensional, fixed-width float32 state
     and action vectors are supported. Unsupported feature layouts fail before
-    any episode is published. The returned paths identify the canonical MCAP
-    episodes written under ``output_dir / "landing"``.
+    any episode is published. The returned values are the published episode
+    URIs (absolute path strings for local roots; ``s3://`` / ``gs://`` /
+    ``az://`` object URIs for buckets).
     """
+    storage = parse_storage_root(output_dir)
+    if (
+        isinstance(storage, LocalStorageRoot)
+        and storage.path.exists()
+        and not storage.path.is_dir()
+    ):
+        raise NotADirectoryError(f"output_dir is not a directory: {storage.path}")
+
     normalized_dataset_repo = dataset_repo.strip()
     normalized_revision = revision.strip()
     if not normalized_dataset_repo:
@@ -603,8 +621,6 @@ def import_lerobot_dataset(
         isinstance(episode_index, bool) or not isinstance(episode_index, int) or episode_index < 0
     ):
         raise ValueError("episode_index must be zero or greater")
-    if output_dir.exists() and not output_dir.is_dir():
-        raise NotADirectoryError(f"output_dir is not a directory: {output_dir}")
 
     camera_key_arguments = (camera_keys,) if isinstance(camera_keys, str) else camera_keys
     resolved_camera_keys = tuple(
@@ -619,7 +635,7 @@ def import_lerobot_dataset(
         raise ValueError("camera_keys must not contain duplicates")
 
     repository_information = _hf_repo_info(normalized_dataset_repo, normalized_revision)
-    cache_directory = output_dir / "_lerobot_cache" / repository_information["sha"]
+    cache_directory = storage.workspace / "_lerobot_cache" / repository_information["sha"]
     source_archive = _ensure_source_archive(
         DatasetSource(
             repo_id=normalized_dataset_repo,
@@ -658,23 +674,22 @@ def import_lerobot_dataset(
     selected_episode_indexes = (
         [episode_index] if episode_index is not None else list(range(len(episode_rows)))
     )
-    canonical_episode_paths: list[Path] = []
+    published_episode_uris: list[str] = []
 
     dataset_source = source_archive["dataset"]
     for selected_episode_index in selected_episode_indexes:
-        canonical_episode_path = _convert_single_episode(
-            source_archive=source_archive,
-            dataset_source=dataset_source,
-            output_dir=output_dir,
-            episode_index=selected_episode_index,
-            camera_keys=resolved_camera_keys,
-            numeric_schemas=numeric_schemas,
-            frames_per_second=int(source_archive["fps"]),
+        published_episode_uris.append(
+            _convert_single_episode(
+                source_archive=source_archive,
+                dataset_source=dataset_source,
+                storage=storage,
+                episode_index=selected_episode_index,
+                camera_keys=resolved_camera_keys,
+                numeric_schemas=numeric_schemas,
+                frames_per_second=int(source_archive["fps"]),
+            )
         )
-        canonical_episode_paths.append(canonical_episode_path)
 
-    manifest_path = output_dir / "prepared-manifest.json"
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_contents = json.dumps(
         {
             "schema_version": 2,
@@ -684,42 +699,33 @@ def import_lerobot_dataset(
                 "license": dataset_source.license,
             },
             "camera_keys": list(resolved_camera_keys),
-            "episodes_converted": len(canonical_episode_paths),
+            "episodes_converted": len(published_episode_uris),
             "converter_version": CONVERTER_VERSION,
         },
         indent=2,
     )
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        prefix=f".{manifest_path.name}.",
-        suffix=".partial",
-        dir=manifest_path.parent,
-        delete=False,
-    ) as temporary_manifest:
-        temporary_manifest_path = Path(temporary_manifest.name)
-        try:
-            temporary_manifest.write(manifest_contents)
-            temporary_manifest.flush()
-            os.fsync(temporary_manifest.fileno())
-            temporary_manifest_path.replace(manifest_path)
-        except BaseException:
-            temporary_manifest_path.unlink(missing_ok=True)
-            raise
-    logger.info("wrote LeRobot import manifest %s", manifest_path)
-    return canonical_episode_paths
+    # Manifest-last: only publish after every selected episode object succeeded.
+    with tempfile.TemporaryDirectory(prefix="lerobot-import-manifest-") as temporary_directory:
+        temporary_manifest_path = Path(temporary_directory) / "prepared-manifest.json"
+        temporary_manifest_path.write_text(manifest_contents + "\n", encoding="utf-8")
+        published_manifest_uri = storage.publish(temporary_manifest_path, "prepared-manifest.json")
+    logger.info("wrote LeRobot import manifest %s", published_manifest_uri)
+    return published_episode_uris
 
 
 def _convert_single_episode(
     source_archive: _SourceArchive,
     dataset_source: DatasetSource,
-    output_dir: Path,
+    storage: StorageRoot,
     episode_index: int,
     camera_keys: tuple[str, ...],
     numeric_schemas: dict[str, _NumericSchema],
     frames_per_second: int,
-) -> Path:
-    """Convert a single episode to canonical MCAP. Returns output path."""
+) -> str:
+    """Convert a single episode to canonical MCAP and publish it.
+
+    Returns the published episode URI under ``landing/``.
+    """
     import duckdb
 
     episode_row = source_archive["episodes"][episode_index]
@@ -886,10 +892,9 @@ def _convert_single_episode(
 
         video_data_by_camera[camera_key] = (access_units, presentation_timestamps)
 
-    # Write MCAP
+    # Write MCAP into local staging, then publish the complete file.
     output_file_name = f"lerobot_episode_{episode_index + 1:04d}.mcap"
-    output_path = output_dir / "landing" / output_file_name
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    landing_relative_key = f"landing/{output_file_name}"
 
     from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
     from mcap_protobuf.schema import build_file_descriptor_set
@@ -904,7 +909,8 @@ def _convert_single_episode(
 
     source_uri = f"hf://datasets/{dataset_source.repo_id}@{dataset_source.revision}"
     with tempfile.TemporaryDirectory(prefix="lerobot-source-episode-") as temporary_directory:
-        source_episode_path = Path(temporary_directory) / output_path.name
+        temporary_root = Path(temporary_directory)
+        source_episode_path = temporary_root / output_file_name
         with source_episode_path.open("wb") as source_stream:
             mcap_writer = McapWriter(source_stream)
             mcap_writer.start(profile="", library="hflow LeRobot source adapter")
@@ -990,19 +996,22 @@ def _convert_single_episode(
             )
             mcap_writer.finish()
 
+        canonical_episode_path = temporary_root / f"canonical-{output_file_name}"
         write_canonical_episode(
             source_episode_path,
-            output_path,
+            canonical_episode_path,
             TransformConfig(gop_seconds=1.0),
             source_uri=source_uri,
         )
+        published_uri = storage.publish(canonical_episode_path, landing_relative_key)
+        episode_size_bytes = canonical_episode_path.stat().st_size
 
     logger.info(
         "wrote canonical LeRobot episode %s (%.2f MB)",
-        output_path,
-        output_path.stat().st_size / 1_000_000,
+        published_uri,
+        episode_size_bytes / 1_000_000,
     )
-    return output_path
+    return published_uri
 
 
 __all__ = ["import_lerobot_dataset"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,3 +274,83 @@ def test_catalog_ui_cli_does_not_hide_programming_errors_for_bucket_catalogs(
 
     with pytest.raises(RuntimeError, match="unexpected implementation bug"):
         main(["catalog", "ui", "--no-browser", "--catalog", "gs://robot-data/catalog"])
+
+
+def test_import_lerobot_cli_reports_a_missing_bucket_extra(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    def raise_missing_obstore(**_kwargs: object) -> list[str]:
+        raise ModuleNotFoundError(
+            "bucket storage roots need the optional obstore backend -- install the "
+            'extra: pip install "hflow[bucket]" (uv: uv add "hflow[bucket]")'
+        )
+
+    monkeypatch.setattr("hflow.importers.lerobot.import_lerobot_dataset", raise_missing_obstore)
+
+    exit_code = main(
+        [
+            "import",
+            "lerobot",
+            "--repo",
+            "lerobot/pusht",
+            "--output-dir",
+            "s3://robot-data/production",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.err.startswith("import lerobot:")
+    assert "hflow[bucket]" in captured.err
+
+
+def test_import_lerobot_cli_reports_a_bucket_credentials_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    from obstore.exceptions import UnauthenticatedError
+
+    def raise_credentials_error(**_kwargs: object) -> list[str]:
+        raise UnauthenticatedError("provider credentials are unavailable")
+
+    monkeypatch.setattr("hflow.importers.lerobot.import_lerobot_dataset", raise_credentials_error)
+
+    exit_code = main(
+        [
+            "import",
+            "lerobot",
+            "--repo",
+            "lerobot/pusht",
+            "--output-dir",
+            "s3://robot-data/production",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.err == "import lerobot: provider credentials are unavailable\n"
+
+
+def test_import_lerobot_cli_accepts_bucket_output_dir_strings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: list[str] = []
+
+    def record_import(**kwargs: object) -> list[str]:
+        received.append(str(kwargs["output_dir"]))
+        return ["s3://robot-data/production/landing/lerobot_episode_0001.mcap"]
+
+    monkeypatch.setattr("hflow.importers.lerobot.import_lerobot_dataset", record_import)
+
+    exit_code = main(
+        [
+            "import",
+            "lerobot",
+            "--repo",
+            "lerobot/pusht",
+            "--output-dir",
+            "s3://robot-data/production",
+        ]
+    )
+
+    assert exit_code == 0
+    assert received == ["s3://robot-data/production"]

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -17,6 +17,7 @@ import pytest
 
 import hflow.importers.lerobot as prep
 from hflow.cli import main as cli_main
+from hflow.storage import LocalStorageRoot, StorageRoot
 
 _DERIVE = prep._derive_numeric_schema
 _ENCODE = prep._encode_cdr_float32_array
@@ -329,7 +330,7 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
         prep._convert_single_episode(
             source_archive=source_archive,
             dataset_source=dataset_source,
-            output_dir=tmp_path / "output",
+            storage=LocalStorageRoot(tmp_path / "output"),
             episode_index=episode_index,
             camera_keys=(camera_key,),
             numeric_schemas=numeric_schemas,
@@ -911,3 +912,180 @@ def test_info_json_accepts_normal_positive_fps(
     dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
     source_archive = prep._ensure_source_archive(dataset_source, tmp_path / "cache")
     assert source_archive["fps"] == 30
+
+
+def _stub_single_episode_source_archive(
+    dataset_source: prep.DatasetSource, cache_dir: Path
+) -> dict:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return {
+        "info": {"robot_type": "pusht"},
+        "fps": 30,
+        "data_path": "data/{chunk_index}/{file_index}.parquet",
+        "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
+        "episodes": [
+            {
+                "episode_index": 0,
+                "task": "push",
+                "length": 1,
+                "data_chunk": "000",
+                "data_file": "000",
+                "data_from": 0,
+                "data_to": 1,
+            }
+        ],
+        "video_keys": [prep.DEFAULT_CAMERA_KEY],
+        "numeric_features": {
+            "action": {"dtype": "float32", "shape": [1]},
+            "observation.state": {"dtype": "float32", "shape": [1]},
+        },
+        "cache_dir": cache_dir,
+        "dataset": dataset_source,
+    }
+
+
+def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[str]:
+    """Exercise StorageRoot.publish without running the video converter."""
+
+    published_keys: list[str] = []
+
+    def fake_convert(
+        *,
+        source_archive: object,
+        dataset_source: object,
+        storage: StorageRoot,
+        episode_index: int,
+        camera_keys: object,
+        numeric_schemas: object,
+        frames_per_second: object,
+    ) -> str:
+        del source_archive, dataset_source, camera_keys, numeric_schemas, frames_per_second
+        relative_key = f"landing/lerobot_episode_{episode_index + 1:04d}.mcap"
+        staged = tmp_path / f"staged-{episode_index}.mcap"
+        staged.write_bytes(f"episode-{episode_index}".encode())
+        published_keys.append(relative_key)
+        return storage.publish(staged, relative_key)
+
+    monkeypatch.setattr(prep, "_convert_single_episode", fake_convert)
+    return published_keys
+
+
+def test_import_returns_local_uris_and_keeps_cache_beside_landing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_ensure_source_archive", _stub_single_episode_source_archive)
+    _install_publish_through_convert(monkeypatch, tmp_path)
+
+    episode_uris = prep.import_lerobot_dataset(
+        dataset_repo="fake/repo",
+        revision="main",
+        output_dir=output_dir,
+        episode_index=0,
+    )
+
+    assert episode_uris == [str((output_dir / "landing" / "lerobot_episode_0001.mcap").resolve())]
+    assert Path(episode_uris[0]).is_file()
+    assert (output_dir / "prepared-manifest.json").is_file()
+    assert (output_dir / "_lerobot_cache" / "abc").is_dir()
+
+
+def test_import_publishes_into_a_bucket_data_root_without_uploading_cache(
+    tmp_path: Path,
+    bucket_over_tmp: tuple[object, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hflow.storage import BucketStorageRoot
+
+    data_root, remote_dir = bucket_over_tmp
+    assert isinstance(data_root, BucketStorageRoot)
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_ensure_source_archive", _stub_single_episode_source_archive)
+    _install_publish_through_convert(monkeypatch, tmp_path)
+
+    episode_uris = prep.import_lerobot_dataset(
+        dataset_repo="fake/repo",
+        revision="main",
+        output_dir=data_root,
+        episode_index=0,
+    )
+
+    assert episode_uris == [f"{data_root.url}/landing/lerobot_episode_0001.mcap"]
+    assert all(isinstance(uri, str) for uri in episode_uris)
+    assert not isinstance(episode_uris[0], Path)
+    assert (remote_dir / "landing" / "lerobot_episode_0001.mcap").is_file()
+    assert (remote_dir / "prepared-manifest.json").is_file()
+    assert data_root.list_names() == [
+        "landing/lerobot_episode_0001.mcap",
+        "prepared-manifest.json",
+    ]
+    assert not any(name.startswith("_lerobot_cache") for name in data_root.list_names())
+    assert (data_root.mirror / "_lerobot_cache" / "abc").is_dir()
+
+
+def test_import_skips_bucket_manifest_when_an_episode_publish_fails(
+    tmp_path: Path,
+    bucket_over_tmp: tuple[object, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hflow.storage import BucketStorageRoot
+
+    data_root, remote_dir = bucket_over_tmp
+    assert isinstance(data_root, BucketStorageRoot)
+
+    def ensure_two_episodes(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+        archive = _stub_single_episode_source_archive(dataset_source, cache_dir)
+        archive["episodes"] = [
+            archive["episodes"][0],
+            {
+                **archive["episodes"][0],
+                "episode_index": 1,
+                "task": "second",
+            },
+        ]
+        return archive
+
+    convert_calls = 0
+
+    def fail_on_second_episode(
+        *,
+        source_archive: object,
+        dataset_source: object,
+        storage: StorageRoot,
+        episode_index: int,
+        camera_keys: object,
+        numeric_schemas: object,
+        frames_per_second: object,
+    ) -> str:
+        nonlocal convert_calls
+        del source_archive, dataset_source, camera_keys, numeric_schemas, frames_per_second
+        convert_calls += 1
+        if episode_index == 1:
+            raise RuntimeError("forced publish failure")
+        relative_key = f"landing/lerobot_episode_{episode_index + 1:04d}.mcap"
+        staged = tmp_path / f"staged-{episode_index}.mcap"
+        staged.write_bytes(b"first")
+        return storage.publish(staged, relative_key)
+
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_ensure_source_archive", ensure_two_episodes)
+    monkeypatch.setattr(prep, "_convert_single_episode", fail_on_second_episode)
+
+    with pytest.raises(RuntimeError, match="forced publish failure"):
+        prep.import_lerobot_dataset(
+            dataset_repo="fake/repo",
+            revision="main",
+            output_dir=data_root,
+        )
+
+    assert convert_calls == 2
+    assert (remote_dir / "landing" / "lerobot_episode_0001.mcap").is_file()
+    assert not (remote_dir / "prepared-manifest.json").exists()
+    assert "prepared-manifest.json" not in data_root.list_names()

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -326,8 +326,9 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
         lambda source_path, output_path, *_args, **_kwargs: shutil.copy(source_path, output_path),
     )
 
+    published_uris: list[str] = []
     for episode_index in (0, 1, 0):
-        prep._convert_single_episode(
+        uri = prep._convert_single_episode(
             source_archive=source_archive,
             dataset_source=dataset_source,
             storage=LocalStorageRoot(tmp_path / "output"),
@@ -336,6 +337,10 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
             numeric_schemas=numeric_schemas,
             frames_per_second=30,
         )
+        published_uris.append(uri)
+
+    assert published_uris[0].endswith("landing/lerobot_episode_0001.mcap")
+    assert published_uris[1].endswith("landing/lerobot_episode_0002.mcap")
 
     video_urls = [
         "https://huggingface.co/datasets/fake/repo/resolve/abc/videos/"


### PR DESCRIPTION
## Summary

- Accept local paths and `s3://` / `gs://` / `az://` data roots for `hflow import lerobot`
- Stage Hugging Face downloads and MCAP builds locally; publish only `landing/*.mcap`
- Publish `prepared-manifest.json` only after every selected episode succeeds
- Keep `_lerobot_cache` in the local workspace/mirror (never upload it)
- Return real episode URIs; concise CLI errors for missing bucket deps/auth

Closes #304.

## Why

Bucket-backed workspaces had to import LeRobot locally and upload by hand. This reuses the existing `StorageRoot` publish boundary so import can land directly in a durable data root without changing the canonical MCAP layout.

## Validation

- `uv run ruff check` — passed
- `uv run ruff format --check` — passed
- `uv run ty check` — passed
- `uv run pytest tests/test_lerobot_converter.py tests/test_storage.py -q` — passed
- `uv run pytest -q` — 1442 passed, 6 skipped

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.