### PR TITLE
fix(server): preserve non-404 stage Airflow failures

### DIFF
--- a/packages/hflow-server/src/hflow_server/_graph.py
+++ b/packages/hflow-server/src/hflow_server/_graph.py
@@ -59,6 +59,7 @@ from hflow_server._contract import (
     RunGraphResponse,
     RunGraphStage,
     RunTaskInstance,
+    RuntimeSource,
     StageRunMatch,
 )
 from hflow_server._pipeline import PipelineLoaded, PipelineState, registered_steps_by_stage
@@ -440,16 +441,18 @@ def create_graph_router(pipeline_state: PipelineState, resolver: RuntimeResolver
     router = APIRouter(prefix="/api/v1")
 
     def stage_task_instances(
-        client: AirflowClient, dag_id: str, dag_run_id: str
+        client: AirflowClient, dag_id: str, dag_run_id: str, *, source: RuntimeSource
     ) -> list[AirflowTaskInstance]:
         try:
             return client.task_instances(dag_id, dag_run_id)
-        except AirflowClientError:
+        except AirflowClientError as error:
             # A stage sub-DAG that vanished (or a run Airflow expired) leaves
             # that lane without task detail; the master's own state -- the
             # page's point -- is already in hand, so this is a thinner
             # drawing, not a failed request.
-            return []
+            if error.status == 404:
+                return []
+            raise airflow_failure_refusal(error, source=source) from error
 
     @router.get("/pipeline/graph")
     def read_pipeline_graph() -> PipelineGraphResponse:
@@ -514,10 +517,13 @@ def create_graph_router(pipeline_state: PipelineState, resolver: RuntimeResolver
                 stage_runs = runtime.client.dag_runs(
                     stage_dag_id, limit=_STAGE_RUN_SEARCH_LIMIT, order_by="-id"
                 )
-            except AirflowClientError:
+            except AirflowClientError as error:
                 # An unregistered stage sub-DAG (a partial profile, or a
                 # bundle mid-render) is a stage that never ran here.
-                stage_runs = []
+                if error.status == 404:
+                    stage_runs = []
+                else:
+                    raise airflow_failure_refusal(error, source=runtime.source) from error
             matched = _matched_stage_run(stage_runs, master_window)
             if matched is None:
                 stages.append(_empty_stage_graph(stage_topology))
@@ -525,7 +531,9 @@ def create_graph_router(pipeline_state: PipelineState, resolver: RuntimeResolver
             stage_run_id = matched.run.dag_run_id
             stage_tasks = (
                 _sorted_task_instances(
-                    stage_task_instances(runtime.client, stage_dag_id, stage_run_id),
+                    stage_task_instances(
+                        runtime.client, stage_dag_id, stage_run_id, source=runtime.source
+                    ),
                     stage_topology.dag,
                 )
                 if stage_run_id is not None

--- a/packages/hflow-server/src/hflow_server/_runtime.py
+++ b/packages/hflow-server/src/hflow_server/_runtime.py
@@ -395,10 +395,14 @@ def create_runtime_router(settings: ServerSettings, resolver: RuntimeResolver) -
                     recent_runs = runtime.client.dag_runs(
                         stage_dag_id, limit=_RECENT_STAGE_RUN_LIMIT, order_by="-id"
                     )
-                except AirflowClientError:
-                    # A stage sub-DAG that has not registered (or errored) is
-                    # an empty strip, not a failed page.
-                    recent_runs = []
+                except AirflowClientError as error:
+                    # A stage sub-DAG that has not registered is an empty
+                    # strip; other upstream failures use the route's shared
+                    # browser-safe 502 response.
+                    if error.status == 404:
+                        recent_runs = []
+                    else:
+                        raise airflow_failure_refusal(error, source=runtime.source) from error
                 stages.append(
                     StageRecentRuns(
                         stage=stage_name,

--- a/packages/hflow-server/tests/test_server_run_graph.py
+++ b/packages/hflow-server/tests/test_server_run_graph.py
@@ -467,6 +467,84 @@ def test_run_graph_tolerates_unregistered_stage_sub_dags(
     assert all(stage["dag_run_id"] is None for stage in payload["stages"])
 
 
+def test_run_graph_tolerates_missing_task_detail_for_a_matched_stage_run(
+    bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stubbed_airflow(
+        monkeypatch,
+        master_run={
+            "dag_run_id": MASTER_RUN_ID,
+            "state": "success",
+            "start_date": MASTER_STARTED_AT,
+        },
+        stage_runs={
+            "demo_pipeline_sync": [
+                {
+                    "dag_run_id": "sync__expired_tasks",
+                    "state": "success",
+                    "start_date": "2026-08-21T10:00:05+00:00",
+                }
+            ]
+        },
+        task_instances={},
+    )
+
+    def task_instances_with_expired_stage_run(
+        self: AirflowClient, dag_id: str, dag_run_id: str
+    ) -> list[AirflowTaskInstance]:
+        if dag_id == "demo_pipeline_sync":
+            raise AirflowClientError(
+                f"GET /dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances failed with HTTP 404",
+                status=404,
+            )
+        return []
+
+    monkeypatch.setattr(AirflowClient, "task_instances", task_instances_with_expired_stage_run)
+    response = bundle_api.get(f"/api/v1/runtime/runs/{MASTER_RUN_ID}/graph")
+    assert response.status_code == 200
+    sync_stage = next(stage for stage in response.json()["stages"] if stage["stage"] == "sync")
+    assert sync_stage["dag_run_id"] == "sync__expired_tasks"
+    assert sync_stage["state"] == "success"
+    assert sync_stage["match"] == "heuristic"
+    assert sync_stage["tasks"] == []
+    assert sync_stage["mapped_summary"] is None
+
+
+def test_run_graph_stage_task_failure_without_status_maps_to_502(
+    bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stubbed_airflow(
+        monkeypatch,
+        master_run={
+            "dag_run_id": MASTER_RUN_ID,
+            "state": "running",
+            "start_date": MASTER_STARTED_AT,
+        },
+        stage_runs={
+            "demo_pipeline_sync": [
+                {
+                    "dag_run_id": "sync__running",
+                    "state": "running",
+                    "start_date": "2026-08-21T10:00:05+00:00",
+                }
+            ]
+        },
+        task_instances={},
+    )
+
+    def failing_stage_tasks(
+        self: AirflowClient, dag_id: str, dag_run_id: str
+    ) -> list[AirflowTaskInstance]:
+        if dag_id == "demo_pipeline_sync":
+            raise AirflowClientError("stage task-instance request lost its connection")
+        return []
+
+    monkeypatch.setattr(AirflowClient, "task_instances", failing_stage_tasks)
+    response = bundle_api.get(f"/api/v1/runtime/runs/{MASTER_RUN_ID}/graph")
+    assert response.status_code == 502
+    assert "stage task-instance request lost its connection" in response.json()["detail"]
+
+
 def test_run_graph_unknown_run_is_a_404(
     bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -516,6 +594,48 @@ def test_run_graph_remote_failure_does_not_leak_the_base_url(
     response = _client_over(data_root, unbuilt_assets_dir).get("/api/v1/runtime/runs/x/graph")
     assert response.status_code == 502
     assert "airflow.internal.corp" not in response.text
+
+
+def test_run_graph_remote_stage_listing_failure_is_a_sanitized_502(
+    runtime_free_cwd: Path,
+    tmp_path: Path,
+    unbuilt_assets_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HFLOW_AIRFLOW_URL", "https://airflow.internal.corp:8443")
+    monkeypatch.setenv("HFLOW_AIRFLOW_DAG_ID", "kitchen_ingest")
+    monkeypatch.setenv("HFLOW_AIRFLOW_TOKEN", "minted-token")
+    monkeypatch.setattr(
+        AirflowClient,
+        "dag_run",
+        lambda self, dag_id, dag_run_id: _dag_run(
+            {
+                "dag_run_id": dag_run_id,
+                "state": "running",
+                "start_date": MASTER_STARTED_AT,
+            }
+        ),
+    )
+    monkeypatch.setattr(AirflowClient, "task_instances", lambda self, dag_id, dag_run_id: [])
+
+    def failing_stage_runs(
+        self: AirflowClient, dag_id: str, *, limit: int = 100, order_by: str | None = None
+    ) -> list[AirflowDagRun]:
+        raise AirflowClientError(
+            "GET https://airflow.internal.corp:8443/api/v2/dags/"
+            f"{dag_id}/dagRuns failed with HTTP 503: minted-token Traceback: upstream failed",
+            status=503,
+        )
+
+    monkeypatch.setattr(AirflowClient, "dag_runs", failing_stage_runs)
+    data_root = tmp_path / "bare-root"
+    data_root.mkdir()
+    response = _client_over(data_root, unbuilt_assets_dir).get("/api/v1/runtime/runs/r1/graph")
+    assert response.status_code == 502
+    assert "status 503" in response.json()["detail"]
+    assert "airflow.internal.corp" not in response.text
+    assert "minted-token" not in response.text
+    assert "Traceback" not in response.text
 
 
 def test_run_graph_over_a_remote_runtime_derives_the_stage_dag_ids(

--- a/packages/hflow-server/tests/test_server_runtime.py
+++ b/packages/hflow-server/tests/test_server_runtime.py
@@ -283,6 +283,24 @@ def test_runs_tolerates_an_unregistered_stage_dag(
     assert all(stage["recent"] == [] for stage in payload["stages"])
 
 
+def test_runs_maps_stage_rate_limit_to_502(
+    bundle_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_dag_runs(
+        self: AirflowClient, dag_id: str, *, limit: int = 100, order_by: str | None = None
+    ) -> list[AirflowDagRun]:
+        if dag_id == "demo_pipeline_ingest":
+            return []
+        raise AirflowClientError(
+            f"GET /dags/{dag_id}/dagRuns failed with HTTP 429: rate limited", status=429
+        )
+
+    monkeypatch.setattr(AirflowClient, "dag_runs", fake_dag_runs)
+    response = bundle_api.get("/api/v1/runtime/runs")
+    assert response.status_code == 502
+    assert "rate limited" in response.json()["detail"]
+
+
 def test_runs_without_a_runtime_is_a_clear_409(
     runtime_free_cwd: Path, tmp_path: Path, unbuilt_assets_dir: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Preserve the existing HTTP 404 degradation for unregistered stage DAGs and expired stage task details.
- Return the existing browser-safe 502 response for all other stage `AirflowClientError` failures, including errors without an HTTP status.
- Add route-level regression coverage for all three previously suppressed call sites and for remote failure sanitization.

Fixes #312

## Why

Stage run surfaces previously converted authentication, rate-limit, upstream 5xx, and status-less Airflow failures into empty lanes or recent-run strips. Restricting degradation to 404 keeps the optional-stage behavior while surfacing real upstream failures through the same sanitized 502 path already used for master DAG failures.

## Validation

- `uv run ruff check --fix` — passed.
- `uv run ruff format` — passed; 208 files unchanged.
- `uv run ty check` — passed.
- `uv run pytest -q packages/hflow-server/tests/test_server_runtime.py packages/hflow-server/tests/test_server_run_graph.py` — 35 passed.
- `uv run pytest -q` — 1440 passed, 6 skipped after installing the documented ffmpeg/ffprobe prerequisite.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.