### PR TITLE
feat: add hosted Build AI check execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Airflow. To use your own recording:
 uv run python examples/quickstart.py path/to/episode.mcap
 ```
 
+For the recommended first run on real egocentric footage, follow
+[Evaluate your first egocentric episode](./docs/tutorials/evaluate-an-egocentric-episode.md).
+It runs HFlow's local deterministic quality baseline and two hosted semantic
+checks together, without requiring an account, API key, or model server.
+
 Use `uv run hflow --help` to see the CLI. When you are ready to schedule the
 same pipeline, continue with the [runtime guide](https://github.com/Hebbian-Robotics/hflow/blob/main/docs/RUNTIME.md). Developers
 and contributors should start with [CONTRIBUTING.md](https://github.com/Hebbian-Robotics/hflow/blob/main/CONTRIBUTING.md). Browse

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -249,8 +249,8 @@ explicitly (`ep.frames(fps=...)`), calls its own client (hosted or self-run vLLM
 its endpoint, credentials, model, prompt, and aggregation policy. The opt-in
 `hflow.build_ai_vlm_checks.register_hand_visibility` and
 `register_active_manipulation` integrations bundle one published methodology
-on top of the optional OpenAI-compatible client; they still require the caller
-to supply endpoint and model configuration per check. Two helpers survive
+with a per-check execution choice: either a caller-configured OpenAI-compatible
+model or HFlow's fixed hosted check API. Two helpers survive
 because they encode non-obvious value: the **contact sheet** (N timestamped frames composited
 into one image; works even on single-image models, cheap on vision tokens) and frame extraction
 itself. Missing/occluded hand positions -- one of the issue classes Dyna's article names -- is

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -97,8 +97,9 @@ sampling policy, and interpretation of the response.
 The [OpenAI vision guide](./how-to/call-openai-vision.md) demonstrates the
 generic pattern with an ordinary client. The opt-in
 [Build AI checks](./how-to/run-build-ai-evaluation.md) provide a named,
-published hand-visibility and active-manipulation methodology while leaving
-endpoint and model selection with each registration. The
+published hand-visibility and active-manipulation methodology with an explicit
+per-check choice between a caller-owned OpenAI-compatible model and HFlow's
+fixed hosted execution. The
 [native-video provider protocol](./PROVIDERS.md) is an extension point for
 servers whose request format contains reusable protocol knowledge.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,10 @@ and tradeoffs.
 
 ## Start here
 
-- **Run a pipeline locally:** follow the
+- **Evaluate real egocentric video:** follow the recommended
+  [first-episode tutorial](./tutorials/evaluate-an-egocentric-episode.md) to run
+  local deterministic checks and hosted model checks together.
+- **Run entirely offline:** follow the
   [five-minute quickstart](../examples/README.md#five-minute-quickstart).
 - **Understand the project first:** read the [architecture](./ARCHITECTURE.md),
   especially [what is implemented](./ARCHITECTURE.md#implementation-status).
@@ -37,6 +40,9 @@ the whole workflow before adapting it.
 - [Five-minute local quickstart](../examples/README.md#five-minute-quickstart):
   synthesize a small episode and run transform, checks, and reporting without
   Docker.
+- [Evaluate your first egocentric episode](./tutorials/evaluate-an-egocentric-episode.md):
+  download a real MCAP and combine HFlow's deterministic baseline with hosted
+  hand-visibility and active-manipulation checks.
 - [Egocentric factory corpus](../examples/egocentric/README.md): prepare real
   head-mounted video, inject known defects, run locally or in Airflow, inspect
   the results, and cut a curated manifest.

--- a/docs/how-to/enable-built-in-checks.md
+++ b/docs/how-to/enable-built-in-checks.md
@@ -27,6 +27,12 @@ HFlow owns explicit versions for these automatic registrations. Once you
 register or wrap a check yourself, the version in your pipeline is the one
 that controls compatibility.
 
+Checks that send data to a network service are deliberately not automatic.
+The recommended
+[real-episode tutorial](../tutorials/evaluate-an-egocentric-episode.md) shows
+how to keep this deterministic baseline and explicitly add HFlow's hosted
+hand-visibility and active-manipulation checks.
+
 To change the set, pass it:
 
 ```python

--- a/docs/how-to/run-build-ai-evaluation.md
+++ b/docs/how-to/run-build-ai-evaluation.md
@@ -18,10 +18,60 @@ The example has two execution paths built around the same judgment contract:
   and the local results viewer; the adapter adds the pinned datasets and
   Build AI-specific summary and comparison table.
 
+For a first HFlow run that combines these hosted model checks with the default
+deterministic quality checks, start with
+[Evaluate your first egocentric episode](../tutorials/evaluate-an-egocentric-episode.md).
+
 ## Run the methodology on an HFlow episode
 
-Configure any OpenAI-compatible vision endpoint and the environment variable
-that contains its credential:
+The example uses HFlow's fixed hosted implementation for both checks by
+default. It needs no model configuration, account, or API key.
+
+To try the checks without supplying your own recording, download a small
+egocentric MCAP from Lightwheel's
+[`EgoDemo`](https://huggingface.co/datasets/LightwheelAI/EgoDemo) dataset. The
+Hugging Face CLI preserves the dataset's deeply nested source path, so copy the
+download to a short path used by the rest of this guide:
+
+```bash
+mkdir -p data/build-ai-evaluation
+downloaded_sample_mcap_path="$(
+    hf download LightwheelAI/EgoDemo \
+        'EgoStand/mcap/Thimble Removal/a8d29fea-3cf9-47f7-ad4b-4b1d0ecb7a71.mcap' \
+        --repo-type dataset \
+        --quiet
+)"
+cp "$downloaded_sample_mcap_path" data/build-ai-evaluation/sample.mcap
+```
+
+If Hugging Face requests access, accept the dataset's terms and run
+`hf auth login` before downloading. You can then run the pipeline against the
+sample:
+
+```bash
+uv run --project examples/build_ai_evaluation \
+    python -m examples.build_ai_evaluation.pipeline \
+    data/build-ai-evaluation/sample.mcap
+```
+
+Replace that path with any MCAP containing meaningful egocentric footage to
+evaluate your own recording.
+
+To use an unauthenticated local OpenAI-compatible vision server instead, select
+that execution route and identify its model:
+
+```bash
+export BUILD_AI_EXECUTION="openai-compatible"
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+export OPENAI_MODEL="Qwen/Qwen3-VL-8B-Instruct"
+
+uv run --project examples/build_ai_evaluation \
+    python -m examples.build_ai_evaluation.pipeline \
+    data/build-ai-evaluation/sample.mcap
+```
+
+For an authenticated provider such as OpenRouter, change `OPENAI_BASE_URL` and
+`OPENAI_MODEL`, then name the environment variable holding its credential:
 
 ```bash
 export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
@@ -29,67 +79,74 @@ export OPENAI_MODEL="qwen/qwen3-vl-32b-instruct"
 export BUILD_AI_API_KEY_ENV="OPENROUTER_API_KEY"
 ```
 
-Run against a small synthesized episode:
-
-```bash
-uv run --project examples/build_ai_evaluation \
-    python -m examples.build_ai_evaluation.pipeline
-```
-
-Or pass an existing MCAP recording:
-
-```bash
-uv run --project examples/build_ai_evaluation \
-    python -m examples.build_ai_evaluation.pipeline path/to/episode.mcap
-```
-
 The pipeline samples one frame at zero seconds from the episode's only camera
 and runs both judgments as `@app.check` steps. For a multi-camera episode, set
 `BUILD_AI_CAMERA` to the camera topic. Change the sample time with
 `BUILD_AI_FRAME_TIME_SECONDS`. The resulting HFlow measurements use the
 `build_ai/hand_count/` and `build_ai/active_manipulation/` namespaces and
-include the parsed prediction, raw response, requested and routed models, and
-numeric token usage.
+always include the parsed prediction and raw response. OpenAI-compatible
+execution also records the requested model plus any routed model and numeric
+token usage the provider returns; hosted execution records its immutable hosted
+check reference as the requested model.
 
 Each check also writes one `hflow.Observation` at the exact sampled-frame
 timestamp. Its typed fields retain the task, prediction, raw response,
-validity, requested/routed models, and usage in the catalog's `observations`
-table. The measurements remain as convenient episode summaries; the
+validity, execution identity, and any available model usage in the catalog's
+`observations` table. The measurements remain as convenient episode summaries; the
 observation is the per-frame record that scales to evaluations sampling more
 than one frame.
 
-Swap prompt files with `BUILD_AI_HAND_VISIBILITY_PROMPT` and
-`BUILD_AI_ACTIVE_MANIPULATION_PROMPT`. Other request controls are
-`BUILD_AI_RESPONSE_FORMAT`, `BUILD_AI_TEMPERATURE`, `BUILD_AI_MAX_TOKENS`, and
-`BUILD_AI_MAX_RETRIES`. The registered HFlow check version hashes every
+When using OpenAI-compatible execution, swap prompt files with
+`BUILD_AI_HAND_VISIBILITY_PROMPT` and
+`BUILD_AI_ACTIVE_MANIPULATION_PROMPT`. Other request controls for that route
+are `BUILD_AI_RESPONSE_FORMAT`, `BUILD_AI_TEMPERATURE`, `BUILD_AI_MAX_TOKENS`,
+and `BUILD_AI_MAX_RETRIES`. The registered HFlow check version hashes every
 result-affecting model, prompt, schema, request, camera, and sampling setting so
 different configurations do not claim comparable step versions.
 
-For an unauthenticated self-hosted endpoint, omit `BUILD_AI_API_KEY_ENV`. Each
-check can use a different service through the
+Each check can select its execution independently with
+`BUILD_AI_HAND_VISIBILITY_EXECUTION` and
+`BUILD_AI_ACTIVE_MANIPULATION_EXECUTION`; each defaults to `BUILD_AI_EXECUTION`
+and then to `hflow-hosted`. For example, one check can remain hosted while the
+other uses your model:
+
+```bash
+export BUILD_AI_HAND_VISIBILITY_EXECUTION="hflow-hosted"
+export BUILD_AI_ACTIVE_MANIPULATION_EXECUTION="openai-compatible"
+```
+
+OpenAI-compatible checks can use different services through the
 `BUILD_AI_HAND_VISIBILITY_BASE_URL` / `BUILD_AI_HAND_VISIBILITY_MODEL` /
 `BUILD_AI_HAND_VISIBILITY_API_KEY_ENV` and corresponding
 `BUILD_AI_ACTIVE_MANIPULATION_*` overrides.
 
-The same checks are available directly in any pipeline:
+`HFlowHostedExecution` owns only the hosted base URL, check version, and request
+timeout; its server owns every model setting.
+
+The same checks are available directly in any pipeline. Execution is selected
+per check, so the two checks may use different models:
 
 ```python
 hflow.build_ai_vlm_checks.register_hand_visibility(
     app,
-    endpoint="http://localhost:8000/v1",
-    model="Qwen/Qwen3-VL-8B-Instruct",
+    execution=hflow.build_ai_vlm_checks.HFlowHostedExecution(),
 )
 hflow.build_ai_vlm_checks.register_active_manipulation(
     app,
-    endpoint="https://hosted.example/v1",
-    model="hosted-model",
-    api_key_environment_variable="HOSTED_MODEL_API_KEY",
+    execution=hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+        endpoint="https://hosted.example/v1",
+        model="hosted-model",
+        api_key_environment_variable="HOSTED_MODEL_API_KEY",
+    ),
 )
 ```
 
-The API key is optional for local unauthenticated servers. Registration is
+The API key is optional for local unauthenticated servers. The hosted service
+accepts no model, prompt, or generation settings and needs no API key. A custom
+prompt is supported only with `OpenAICompatibleExecution`. Registration is
 opt-in rather than part of `DEFAULT_CHECKS`, because both checks perform model
-calls and users may intentionally choose different models for them.
+calls and users may intentionally choose different execution strategies for
+them.
 
 ## What this reproduces
 

--- a/docs/tutorials/evaluate-an-egocentric-episode.md
+++ b/docs/tutorials/evaluate-an-egocentric-episode.md
@@ -1,0 +1,113 @@
+# Evaluate your first egocentric episode
+
+This tutorial runs one real recording through HFlow's recommended starting
+point for egocentric video: the default deterministic quality checks plus two
+hosted model checks. It demonstrates the useful split in one command:
+
+- HFlow measures recording integrity locally and deterministically.
+- HFlow's hosted checks add semantic evidence without requiring an account,
+  API key, or model server.
+- Both kinds of evidence are versioned and recorded through the same pipeline.
+
+The hosted checks are registered explicitly rather than included in
+`hflow.checks.DEFAULT_CHECKS`. Constructing a normal `hflow.App` must remain
+offline and must not send recording data over the network unexpectedly. This
+tutorial makes that boundary visible in both the command and the source.
+
+## 1. Install the repository environment
+
+From the repository root:
+
+```bash
+uv sync --locked
+uv tool install -U huggingface_hub
+```
+
+## 2. Download a real sample recording
+
+The sample is a short first-person "Thimble Removal" episode from Lightwheel's
+[`EgoDemo`](https://huggingface.co/datasets/LightwheelAI/EgoDemo) dataset. The
+Hugging Face CLI returns its cache path; copy it to the short path used below:
+
+```bash
+mkdir -p data/episode-evaluation
+downloaded_sample_mcap_path="$(
+    hf download LightwheelAI/EgoDemo \
+        'EgoStand/mcap/Thimble Removal/a8d29fea-3cf9-47f7-ad4b-4b1d0ecb7a71.mcap' \
+        --repo-type dataset \
+        --quiet
+)"
+cp "$downloaded_sample_mcap_path" data/episode-evaluation/sample.mcap
+```
+
+If Hugging Face requests access, accept the dataset's terms and run
+`hf auth login`, then repeat the download.
+
+## 3. Run the evaluation
+
+The sample has two camera streams, so select its left head camera explicitly:
+
+```bash
+uv run python examples/evaluate_episode.py \
+    data/episode-evaluation/sample.mcap \
+    --camera /sensor/camera/head_left/video
+```
+
+No model endpoint or API key is required. HFlow processes the episode locally;
+the two model checks send only the selected JPEG frame to `api.hflow.dev`.
+
+The first sample frame visibly contains two wearer hands manipulating material.
+The hosted results should therefore include:
+
+```text
+build_ai/hand_count/prediction = 2
+build_ai/active_manipulation/prediction = yes
+```
+
+The report also includes HFlow's automatic deterministic baseline:
+
+| Check | Evidence it records |
+|---|---|
+| `episode_duration` | Recording duration and message coverage |
+| `timestamp_regularity` | Timing intervals, gaps, and cross-stream alignment |
+| `camera_frame_stats` | Frame count, blackout, freeze, and exposure measurements |
+| `keyframe_interval` | Video seekability evidence |
+| `content_digest` | Exact recording identity for duplicate detection |
+| `media_digest` | Visual-media identity across differently wrapped recordings |
+| `build_ai_hand_visibility` | Number of wearer hands visible in the selected frame |
+| `build_ai_active_manipulation` | Whether the wearer is visibly manipulating an object |
+
+The canonical MCAP, contact sheets, run evidence, and Parquet catalog are
+written beneath `data/episode-evaluation/`.
+
+## 4. Evaluate your recording
+
+Replace the sample path with your MCAP. Omit `--camera` when it contains only
+one camera, or pass the desired camera topic when it contains several:
+
+```bash
+uv run python examples/evaluate_episode.py path/to/episode.mcap \
+    --camera /your/egocentric/camera
+```
+
+Use `--frame-time-seconds` to choose another instant. The selected time and
+camera are part of each model check's version, so results from different
+sampling configurations do not silently claim to be comparable.
+
+The hosted checks implement Build AI's published hand-visibility and
+active-manipulation prompts. For custom prompts, models, or OpenAI-compatible
+endpoints, continue with the
+[Build AI evaluation guide](../how-to/run-build-ai-evaluation.md). To configure
+or add deterministic checks, see the
+[built-in checks guide](../how-to/enable-built-in-checks.md).
+
+## Bring us your workflow
+
+This starter pipeline is intentionally general. Real deployments usually need
+checks and processing tailored to the recording rig, task, failure modes, and
+training format—and a plan for running them across the full corpus.
+
+If you want help designing that pipeline or evaluating what HFlow can automate
+for your team, [tell Hebbian Robotics about your workflow](https://forms.gle/EZpQpGGF3eJomx498).
+For implementation questions and open-source feedback, join the
+[HFlow Discord](https://discord.gg/vacepQvjmg).

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,38 @@ argument to process your own recording.
 
 Code: [`quickstart.py`](./quickstart.py)
 
+## Recommended real-episode evaluation
+
+**Use it for:** seeing HFlow's default deterministic checks and hosted semantic
+checks work together on real egocentric footage.
+
+**Prerequisites:** the normal development environment, the `hf` CLI, and
+network access. The hosted checks require no account, API key, or model server.
+
+```bash
+mkdir -p data/episode-evaluation
+downloaded_sample_mcap_path="$(
+    hf download LightwheelAI/EgoDemo \
+        'EgoStand/mcap/Thimble Removal/a8d29fea-3cf9-47f7-ad4b-4b1d0ecb7a71.mcap' \
+        --repo-type dataset \
+        --quiet
+)"
+cp "$downloaded_sample_mcap_path" data/episode-evaluation/sample.mcap
+
+uv run python examples/evaluate_episode.py \
+    data/episode-evaluation/sample.mcap \
+    --camera /sensor/camera/head_left/video
+```
+
+The report includes the six automatic recording-integrity checks plus hosted
+hand visibility and active manipulation. The sample's first left-camera frame
+is a clear positive case, so the model evidence should report two visible hands
+and active manipulation. Outputs land under `data/episode-evaluation/`.
+
+Guide: [Evaluate your first egocentric episode](../docs/tutorials/evaluate-an-egocentric-episode.md)
+
+Code: [`evaluate_episode.py`](./evaluate_episode.py)
+
 ## OpenAI vision check
 
 **Use it for:** sampling an episode, making a contact sheet, and calling an
@@ -66,23 +98,44 @@ Code: [`openai_vision/pipeline.py`](./openai_vision/pipeline.py)
 active-manipulation methodology as HFlow checks, then replaying their
 Egocentric-10K or Egocentric-100K inputs to compare models and prompts.
 
-**Prerequisites:** an OpenAI-compatible vision endpoint. The pinned evaluation
-replay additionally needs the `hf` CLI and sufficient disk for the selected
-Parquet files. Each frame makes two API calls and can incur charges.
+**Prerequisites:** network access and the `hf` CLI for the sample recording.
+The default pipeline route uses HFlow's hosted checks without an account or API
+key. The pinned evaluation replay additionally needs sufficient disk for the
+selected Parquet files. Each frame makes two external check calls; a configured
+model provider may charge for them.
 
 ```bash
-export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
-export OPENAI_MODEL="qwen/qwen3-vl-32b-instruct"
-export BUILD_AI_API_KEY_ENV="OPENROUTER_API_KEY"
+mkdir -p data/build-ai-evaluation
+downloaded_sample_mcap_path="$(
+    hf download LightwheelAI/EgoDemo \
+        'EgoStand/mcap/Thimble Removal/a8d29fea-3cf9-47f7-ad4b-4b1d0ecb7a71.mcap' \
+        --repo-type dataset \
+        --quiet
+)"
+cp "$downloaded_sample_mcap_path" data/build-ai-evaluation/sample.mcap
+
 uv run --project examples/build_ai_evaluation \
-    python -m examples.build_ai_evaluation.pipeline
+    python -m examples.build_ai_evaluation.pipeline \
+    data/build-ai-evaluation/sample.mcap
 ```
 
-The HFlow pipeline synthesizes a sample episode when no MCAP path is supplied,
-evaluates its first frame through two `@app.check` steps, and records the raw
-answers, parsed predictions, routed model, and token usage as
-`hflow.CheckResult` measurements. Pass an MCAP path to run the checks on an
-existing episode.
+The HFlow pipeline evaluates the existing episode's first frame through two
+`@app.check` steps and records the raw answers, parsed predictions, execution
+identity, and any available model usage as `hflow.CheckResult`
+measurements. An episode path is required because generated test-pattern
+footage cannot meaningfully demonstrate either judgment.
+
+To use a local OpenAI-compatible model server instead of HFlow's hosted checks:
+
+```bash
+export BUILD_AI_EXECUTION="openai-compatible"
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+export OPENAI_MODEL="Qwen/Qwen3-VL-8B-Instruct"
+
+uv run --project examples/build_ai_evaluation \
+    python -m examples.build_ai_evaluation.pipeline \
+    data/build-ai-evaluation/sample.mcap
+```
 
 The companion adapter streams the published Parquet images into Inspect AI
 without transcoding them, using the same prompts, schemas, and parsers:

--- a/examples/build_ai_evaluation/pipeline.py
+++ b/examples/build_ai_evaluation/pipeline.py
@@ -1,25 +1,28 @@
 """Run Build AI's published single-frame checks on HFlow episodes.
 
-Each check may target a different OpenAI-compatible endpoint and model. Omit
-its API-key environment-variable setting for an unauthenticated local server.
+The example uses HFlow's fixed hosted checks by default, without an API key.
+Set ``BUILD_AI_EXECUTION=openai-compatible`` to use a local or third-party
+OpenAI-compatible vision endpoint instead.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+from collections.abc import Mapping
 from pathlib import Path
 
 import hflow
 
 DEFAULT_HFLOW_DATA_ROOT = Path("data/build-ai-evaluation/hflow")
-DEFAULT_SAMPLE_EPISODE_PATH = DEFAULT_HFLOW_DATA_ROOT / "single-camera-sample.mcap"
 DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "http://localhost:8000/v1"
 DEFAULT_MODEL_NAME = "model-not-configured"
+DEFAULT_EXECUTION_NAME = "hflow-hosted"
+OPENAI_COMPATIBLE_EXECUTION_NAME = "openai-compatible"
 
 
-def _optional_float_environment_variable(name: str) -> float | None:
-    raw_value = os.environ.get(name)
+def _optional_float_environment_variable(name: str, environment: Mapping[str, str]) -> float | None:
+    raw_value = environment.get(name)
     return float(raw_value) if raw_value is not None else None
 
 
@@ -28,17 +31,48 @@ def _optional_prompt(environment_variable_name: str, default_prompt: str) -> str
     return Path(prompt_path).read_text() if prompt_path is not None else default_prompt
 
 
-shared_endpoint = os.environ.get("OPENAI_BASE_URL", DEFAULT_OPENAI_COMPATIBLE_BASE_URL)
-shared_model = os.environ.get("OPENAI_MODEL", DEFAULT_MODEL_NAME)
-shared_api_key_environment_variable = os.environ.get("BUILD_AI_API_KEY_ENV")
-response_format = hflow.build_ai_vlm_checks.ResponseFormat(
-    os.environ.get(
-        "BUILD_AI_RESPONSE_FORMAT", hflow.build_ai_vlm_checks.ResponseFormat.JSON_SCHEMA.value
+def _execution_from_environment(
+    check_environment_variable_prefix: str,
+    environment: Mapping[str, str],
+) -> hflow.build_ai_vlm_checks.BuildAIExecution:
+    check_execution_environment_variable = f"{check_environment_variable_prefix}_EXECUTION"
+    execution_name = environment.get(
+        check_execution_environment_variable,
+        environment.get("BUILD_AI_EXECUTION", DEFAULT_EXECUTION_NAME),
     )
-)
-temperature = _optional_float_environment_variable("BUILD_AI_TEMPERATURE")
-max_tokens = int(os.environ.get("BUILD_AI_MAX_TOKENS", "32"))
-max_retries = int(os.environ.get("BUILD_AI_MAX_RETRIES", "5"))
+    if execution_name == DEFAULT_EXECUTION_NAME:
+        return hflow.build_ai_vlm_checks.HFlowHostedExecution()
+    if execution_name == OPENAI_COMPATIBLE_EXECUTION_NAME:
+        return hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint=environment.get(
+                f"{check_environment_variable_prefix}_BASE_URL",
+                environment.get("OPENAI_BASE_URL", DEFAULT_OPENAI_COMPATIBLE_BASE_URL),
+            ),
+            model=environment.get(
+                f"{check_environment_variable_prefix}_MODEL",
+                environment.get("OPENAI_MODEL", DEFAULT_MODEL_NAME),
+            ),
+            api_key_environment_variable=environment.get(
+                f"{check_environment_variable_prefix}_API_KEY_ENV",
+                environment.get("BUILD_AI_API_KEY_ENV"),
+            ),
+            response_format=hflow.build_ai_vlm_checks.ResponseFormat(
+                environment.get(
+                    "BUILD_AI_RESPONSE_FORMAT",
+                    hflow.build_ai_vlm_checks.ResponseFormat.JSON_SCHEMA.value,
+                )
+            ),
+            temperature=_optional_float_environment_variable("BUILD_AI_TEMPERATURE", environment),
+            max_tokens=int(environment.get("BUILD_AI_MAX_TOKENS", "32")),
+            max_retries=int(environment.get("BUILD_AI_MAX_RETRIES", "5")),
+        )
+    raise ValueError(
+        f"{check_execution_environment_variable} (or BUILD_AI_EXECUTION) must be "
+        f"{DEFAULT_EXECUTION_NAME!r} or {OPENAI_COMPATIBLE_EXECUTION_NAME!r}, "
+        f"got {execution_name!r}"
+    )
+
+
 camera = os.environ.get("BUILD_AI_CAMERA")
 frame_time_seconds = float(os.environ.get("BUILD_AI_FRAME_TIME_SECONDS", "0"))
 
@@ -48,18 +82,10 @@ app = hflow.App(
     default_checks=(),
 )
 
+hand_visibility_execution = _execution_from_environment("BUILD_AI_HAND_VISIBILITY", os.environ)
 hflow.build_ai_vlm_checks.register_hand_visibility(
     app,
-    endpoint=os.environ.get("BUILD_AI_HAND_VISIBILITY_BASE_URL", shared_endpoint),
-    model=os.environ.get("BUILD_AI_HAND_VISIBILITY_MODEL", shared_model),
-    api_key_environment_variable=os.environ.get(
-        "BUILD_AI_HAND_VISIBILITY_API_KEY_ENV",
-        shared_api_key_environment_variable,
-    ),
-    response_format=response_format,
-    temperature=temperature,
-    max_tokens=max_tokens,
-    max_retries=max_retries,
+    execution=hand_visibility_execution,
     camera=camera,
     frame_time_seconds=frame_time_seconds,
     prompt=_optional_prompt(
@@ -68,18 +94,12 @@ hflow.build_ai_vlm_checks.register_hand_visibility(
     ),
 )
 
+active_manipulation_execution = _execution_from_environment(
+    "BUILD_AI_ACTIVE_MANIPULATION", os.environ
+)
 hflow.build_ai_vlm_checks.register_active_manipulation(
     app,
-    endpoint=os.environ.get("BUILD_AI_ACTIVE_MANIPULATION_BASE_URL", shared_endpoint),
-    model=os.environ.get("BUILD_AI_ACTIVE_MANIPULATION_MODEL", shared_model),
-    api_key_environment_variable=os.environ.get(
-        "BUILD_AI_ACTIVE_MANIPULATION_API_KEY_ENV",
-        shared_api_key_environment_variable,
-    ),
-    response_format=response_format,
-    temperature=temperature,
-    max_tokens=max_tokens,
-    max_retries=max_retries,
+    execution=active_manipulation_execution,
     camera=camera,
     frame_time_seconds=frame_time_seconds,
     prompt=_optional_prompt(
@@ -93,29 +113,15 @@ def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "episode",
-        nargs="?",
         type=Path,
-        help="MCAP episode to evaluate; omitted: synthesize a small sample",
+        help="MCAP episode containing meaningful egocentric footage to evaluate",
     )
     return parser
 
 
 def main() -> None:
     arguments = _argument_parser().parse_args()
-    episode_path = arguments.episode or DEFAULT_SAMPLE_EPISODE_PATH
-    if arguments.episode is None and not episode_path.is_file():
-        print(f"synthesizing a sample episode at {episode_path} ...")
-        hflow.testing.synthesize_episode(
-            episode_path,
-            hflow.testing.SyntheticEpisodeSpec(
-                duration_s=2.0,
-                cameras=("wrist_cam",),
-                black_segment=None,
-                joint_jump_at_s=None,
-                timestamp_offset_segment=None,
-            ),
-        )
-    report = app.test(episode_path)
+    report = app.test(arguments.episode)
     if report.has_errors:
         raise SystemExit(1)
 

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -35,7 +35,13 @@ from examples.build_ai_evaluation.evaluate import (
     main,
     summarize_results,
 )
-from examples.build_ai_evaluation.pipeline import app
+from examples.build_ai_evaluation.pipeline import (
+    _argument_parser as pipeline_argument_parser,
+)
+from examples.build_ai_evaluation.pipeline import (
+    _execution_from_environment,
+    app,
+)
 from hflow.build_ai_vlm_checks import (
     ACTIVE_MANIPULATION_RESPONSE_SCHEMA,
     HAND_COUNT_RESPONSE_SCHEMA,
@@ -244,6 +250,34 @@ def test_build_ai_pipeline_registers_both_judgments_as_hflow_checks() -> None:
         "build_ai_hand_visibility",
     }
     assert all(check.requires == frozenset({"vision-model"}) for check in checks_by_name.values())
+
+
+def test_build_ai_pipeline_defaults_to_hosted_and_can_select_openai_compatible_execution() -> None:
+    hosted_execution = _execution_from_environment("BUILD_AI_HAND_VISIBILITY", {})
+    openai_compatible_execution = _execution_from_environment(
+        "BUILD_AI_HAND_VISIBILITY",
+        {
+            "BUILD_AI_EXECUTION": "hflow-hosted",
+            "BUILD_AI_HAND_VISIBILITY_EXECUTION": "openai-compatible",
+            "BUILD_AI_HAND_VISIBILITY_BASE_URL": "http://localhost:8000/v1",
+            "BUILD_AI_HAND_VISIBILITY_MODEL": "local-vision-model",
+        },
+    )
+
+    assert hosted_execution == hflow.build_ai_vlm_checks.HFlowHostedExecution()
+    assert openai_compatible_execution == hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+        endpoint="http://localhost:8000/v1",
+        model="local-vision-model",
+    )
+
+
+def test_build_ai_pipeline_requires_an_episode_with_meaningful_footage() -> None:
+    with pytest.raises(SystemExit):
+        pipeline_argument_parser().parse_args([])
+
+    arguments = pipeline_argument_parser().parse_args(["recording.mcap"])
+
+    assert arguments.episode == Path("recording.mcap")
 
 
 def test_summary_reports_prevalence_agreement_and_failures_without_counting_failures_negative() -> (

--- a/examples/evaluate_episode.py
+++ b/examples/evaluate_episode.py
@@ -1,0 +1,79 @@
+"""Evaluate a real egocentric episode with local and hosted HFlow checks.
+
+The normal ``hflow.App`` baseline stays enabled. Two explicitly registered
+hosted checks add Build AI's hand-visibility and active-manipulation judgments.
+
+Run from the repository root::
+
+    uv run python examples/evaluate_episode.py episode.mcap [--camera TOPIC]
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import hflow
+
+DEFAULT_DATA_ROOT = Path("data/episode-evaluation")
+
+
+def build_application(
+    *,
+    data_root: Path,
+    camera: str | None,
+    frame_time_seconds: float,
+) -> hflow.App:
+    application = hflow.App("episode-evaluation", data_root=data_root)
+    hosted_execution = hflow.build_ai_vlm_checks.HFlowHostedExecution()
+    hflow.build_ai_vlm_checks.register_hand_visibility(
+        application,
+        execution=hosted_execution,
+        camera=camera,
+        frame_time_seconds=frame_time_seconds,
+    )
+    hflow.build_ai_vlm_checks.register_active_manipulation(
+        application,
+        execution=hosted_execution,
+        camera=camera,
+        frame_time_seconds=frame_time_seconds,
+    )
+    return application
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("episode", type=Path, help="MCAP episode with egocentric video")
+    parser.add_argument(
+        "--camera",
+        help="camera topic to evaluate; required when the episode has multiple cameras",
+    )
+    parser.add_argument(
+        "--frame-time-seconds",
+        type=float,
+        default=0.0,
+        help="seconds from the start of the camera stream to evaluate (default: 0)",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=DEFAULT_DATA_ROOT,
+        help=f"HFlow output root (default: {DEFAULT_DATA_ROOT})",
+    )
+    return parser
+
+
+def main() -> None:
+    arguments = argument_parser().parse_args()
+    application = build_application(
+        data_root=arguments.data_root,
+        camera=arguments.camera,
+        frame_time_seconds=arguments.frame_time_seconds,
+    )
+    report = application.test(arguments.episode)
+    if report.has_errors:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ requires-python = ">=3.11"
 dependencies = [
     "duckdb>=1.5.5",
     "foxglove-schemas-protobuf>=0.4.0",
+    "httpx2>=2.12.0",
     "mcap>=1.4.0",
     "mcap-protobuf-support>=0.5.4",
     "mcap-ros2-support>=0.5.7",
@@ -62,9 +63,6 @@ hflow = "hflow.cli:main"
 [dependency-groups]
 dev = [
     "hflow-server", # the workspace API package, present in dev so the suite tests it
-    # Starlette's TestClient transport for the hflow-server suite. httpx2, not
-    # httpx: starlette 1.6 deprecates the httpx transport in its favour.
-    "httpx2>=2.12.0",
     "obstore>=0.11.1", # the bucket extra, present in dev so the suite tests it
     # the motion extra, present in dev so the suite tests it rather than
     # skipping the one check that cannot be verified any other way

--- a/src/hflow/__init__.py
+++ b/src/hflow/__init__.py
@@ -4,9 +4,8 @@ Ingest, quality-check, enrich, and curate robot episode data. See README.md
 for orientation and docs/ARCHITECTURE.md for the design and its references.
 """
 
-from importlib.metadata import PackageNotFoundError, version
-
 from hflow import build_ai_vlm_checks, checks, ffmpeg, providers, testing
+from hflow._version import __version__
 from hflow.app import (
     App,
     CheckOutcome,
@@ -105,11 +104,6 @@ from hflow.storage import (
 )
 from hflow.transform import EpisodeStamps, TransformConfig, write_canonical_episode
 from hflow.workspace import Workspace, WorkspaceIdentity
-
-try:
-    __version__ = version("hflow")
-except PackageNotFoundError:  # running from a source tree without an install
-    __version__ = "0.0.0"
 
 __all__ = [
     "DATASET_SNAPSHOT_FORMAT_NAME",

--- a/src/hflow/_version.py
+++ b/src/hflow/_version.py
@@ -1,0 +1,8 @@
+"""Installed HFlow package version."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("hflow")
+except PackageNotFoundError:  # Running directly from an unpackaged source tree.
+    __version__ = "0.0.0"

--- a/src/hflow/build_ai_vlm_checks.py
+++ b/src/hflow/build_ai_vlm_checks.py
@@ -2,8 +2,8 @@
 
 The prompts, schemas, response parsing, and HFlow evidence adapter live here
 so an episode pipeline and a corpus evaluation can share one methodology.
-Model execution stays user-configured through any OpenAI-compatible endpoint;
-each registered check owns its endpoint and model independently.
+Execution is selected per registered check: callers can provide an
+OpenAI-compatible model configuration or use HFlow's fixed hosted check API.
 
 Original methodology and released evaluation inputs:
 https://huggingface.co/datasets/builddotai/Egocentric-10K-Evaluation
@@ -25,6 +25,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, assert_never
 from urllib.parse import urlsplit
 
+import httpx2
+
+from hflow._version import __version__
 from hflow.episode import Episode
 from hflow.fingerprints import step_version_from_contract
 from hflow.steps import CheckFunction, CheckResult, MeasurementValue, Observation, StepVersion
@@ -65,6 +68,13 @@ Rules:
 
 BUILD_AI_HAND_VISIBILITY_CHECK_NAME = "build_ai_hand_visibility"
 BUILD_AI_ACTIVE_MANIPULATION_CHECK_NAME = "build_ai_active_manipulation"
+DEFAULT_HFLOW_HOSTED_BASE_URL = "https://api.hflow.dev"
+
+_HFLOW_HOSTED_TRANSPORT_VERSION = 1
+_DEFAULT_HFLOW_HOSTED_CHECK_VERSION = 1
+_MAX_HFLOW_HOSTED_IMAGE_BYTES = 10 * 1024 * 1024
+_MAX_HFLOW_HOSTED_RESPONSE_BYTES = 64 * 1024
+_HFLOW_HOSTED_USER_AGENT = f"hflow/{__version__} (+https://hflow.dev)"
 
 
 class EvaluationTask(StrEnum):
@@ -121,30 +131,23 @@ ACTIVE_MANIPULATION_RESPONSE_SCHEMA: dict[str, object] = {
 
 
 @dataclass(frozen=True)
-class _RegisteredModelCheckConfiguration:
+class OpenAICompatibleExecution:
+    """Run a Build AI check through one caller-selected model endpoint."""
+
     endpoint: str
     model: str
-    task_definition: TaskDefinition
-    api_key_environment_variable: str | None
-    response_format: ResponseFormat
-    temperature: float | None
-    max_tokens: int
-    max_retries: int
-    camera: str | None
-    frame_time_seconds: float
+    api_key_environment_variable: str | None = None
+    response_format: ResponseFormat = ResponseFormat.JSON_SCHEMA
+    temperature: float | None = None
+    max_tokens: int = 32
+    max_retries: int = 5
 
     def __post_init__(self) -> None:
-        if self.endpoint != self.endpoint.strip():
-            raise ValueError("endpoint must not have leading or trailing whitespace")
-        parsed_endpoint = urlsplit(self.endpoint)
-        if parsed_endpoint.scheme not in {"http", "https"} or not parsed_endpoint.netloc:
-            raise ValueError(f"endpoint must be an absolute http(s) URL, got {self.endpoint!r}")
+        _require_absolute_http_url(self.endpoint, name="endpoint")
         if not self.model.strip():
             raise ValueError("model must not be empty")
         if self.model != self.model.strip():
             raise ValueError("model must not have leading or trailing whitespace")
-        if not self.task_definition.prompt.strip():
-            raise ValueError("prompt must not be empty")
         if not isinstance(self.response_format, ResponseFormat):
             raise ValueError("response_format must be an hflow.build_ai_vlm_checks.ResponseFormat")
         if (
@@ -164,12 +167,74 @@ class _RegisteredModelCheckConfiguration:
             raise ValueError("max_retries must not be negative")
         if self.temperature is not None and not math.isfinite(self.temperature):
             raise ValueError("temperature must be finite")
+
+
+@dataclass(frozen=True)
+class HFlowHostedExecution:
+    """Run a fixed, versioned Build AI check through HFlow's hosted API."""
+
+    base_url: str = DEFAULT_HFLOW_HOSTED_BASE_URL
+    check_version: int = _DEFAULT_HFLOW_HOSTED_CHECK_VERSION
+    request_timeout_seconds: float = 60.0
+
+    def __post_init__(self) -> None:
+        _require_absolute_http_url(self.base_url, name="base_url")
+        parsed_base_url = urlsplit(self.base_url)
+        if parsed_base_url.query or parsed_base_url.fragment:
+            raise ValueError("base_url must not contain a query string or fragment")
+        if not isinstance(self.check_version, int) or isinstance(self.check_version, bool):
+            raise ValueError("check_version must be an integer")
+        if self.check_version <= 0:
+            raise ValueError("check_version must be greater than zero")
+        if (
+            isinstance(self.request_timeout_seconds, bool)
+            or not isinstance(self.request_timeout_seconds, int | float)
+            or not math.isfinite(self.request_timeout_seconds)
+            or self.request_timeout_seconds <= 0
+        ):
+            raise ValueError("request_timeout_seconds must be finite and greater than zero")
+
+
+BuildAIExecution = OpenAICompatibleExecution | HFlowHostedExecution
+
+
+@dataclass(frozen=True)
+class _RegisteredBuildAICheckConfiguration:
+    execution: BuildAIExecution
+    task_definition: TaskDefinition
+    published_prompt: str
+    camera: str | None
+    frame_time_seconds: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.execution, OpenAICompatibleExecution | HFlowHostedExecution):
+            raise ValueError(
+                "execution must be an OpenAICompatibleExecution or HFlowHostedExecution"
+            )
+        if not self.task_definition.prompt.strip():
+            raise ValueError("prompt must not be empty")
+        if (
+            isinstance(self.execution, HFlowHostedExecution)
+            and self.task_definition.prompt != self.published_prompt
+        ):
+            raise ValueError(
+                "HFlowHostedExecution uses the hosted check's fixed prompt and does not support "
+                "prompt overrides"
+            )
         if isinstance(self.frame_time_seconds, bool) or not math.isfinite(self.frame_time_seconds):
             raise ValueError("frame_time_seconds must be finite and non-negative")
         if self.frame_time_seconds < 0:
             raise ValueError("frame_time_seconds must be finite and non-negative")
         if self.camera == "":
             raise ValueError("camera must be None or a non-empty topic name")
+
+
+def _require_absolute_http_url(value: str, *, name: str) -> None:
+    if value != value.strip():
+        raise ValueError(f"{name} must not have leading or trailing whitespace")
+    parsed_url = urlsplit(value)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise ValueError(f"{name} must be an absolute http(s) URL, got {value!r}")
 
 
 def _strip_markdown_code_fence(response_text: str) -> str:
@@ -442,41 +507,200 @@ def evaluate_image_with_model(
     )
 
 
-def _check_version(configuration: _RegisteredModelCheckConfiguration) -> StepVersion:
-    return step_version_from_contract(
-        "build-ai-single-frame-v1",
-        {
-            "task": configuration.task_definition.task.value,
-            "prompt": configuration.task_definition.prompt,
-            "response_schema": configuration.task_definition.response_schema,
-            "endpoint": configuration.endpoint,
-            "model": configuration.model,
-            "response_format": configuration.response_format.value,
-            "temperature": configuration.temperature,
-            "max_tokens": configuration.max_tokens,
-            "camera": configuration.camera,
-            "frame_time_seconds": configuration.frame_time_seconds,
-        },
+def _check_name_for_task(task: EvaluationTask) -> str:
+    match task:
+        case EvaluationTask.HAND_COUNT:
+            return BUILD_AI_HAND_VISIBILITY_CHECK_NAME
+        case EvaluationTask.ACTIVE_MANIPULATION:
+            return BUILD_AI_ACTIVE_MANIPULATION_CHECK_NAME
+        case EvaluationTask.BOTH:
+            raise AssertionError("BOTH is a CLI selection, not an executable task")
+
+
+def _hosted_check_endpoint(execution: HFlowHostedExecution, task: EvaluationTask) -> str:
+    check_name = _check_name_for_task(task)
+    return (
+        f"{execution.base_url.rstrip('/')}/v{_HFLOW_HOSTED_TRANSPORT_VERSION}/checks/"
+        f"{check_name}/versions/{execution.check_version}/evaluate"
     )
 
 
-def _register_model_check(
+def _hosted_execution_label(execution: HFlowHostedExecution, task: EvaluationTask) -> str:
+    return f"hflow-hosted/{_check_name_for_task(task)}@{execution.check_version}"
+
+
+def _hosted_observation_upload(image_bytes: bytes) -> tuple[str, bytes, str]:
+    image_mime_type = _mime_type_for_image(image_bytes)
+    image_extension_by_mime_type = {
+        "image/jpeg": "jpg",
+        "image/png": "png",
+        "image/webp": "webp",
+    }
+    filename = f"observation.{image_extension_by_mime_type[image_mime_type]}"
+    return filename, image_bytes, image_mime_type
+
+
+def _read_bounded_hosted_response(response: httpx2.Response) -> bytes:
+    response_body = bytearray()
+    for response_chunk in response.iter_bytes():
+        if len(response_body) + len(response_chunk) > _MAX_HFLOW_HOSTED_RESPONSE_BYTES:
+            raise RuntimeError("HFlow hosted check response exceeds the 64 KiB limit")
+        response_body.extend(response_chunk)
+    return bytes(response_body)
+
+
+def _parse_hosted_prediction(task: EvaluationTask, value: object) -> int | str:
+    match task:
+        case EvaluationTask.HAND_COUNT:
+            if isinstance(value, bool) or not isinstance(value, int) or value not in {0, 1, 2}:
+                raise RuntimeError(
+                    "HFlow hosted hand-visibility check returned a parsed prediction "
+                    "outside 0, 1, or 2"
+                )
+            return value
+        case EvaluationTask.ACTIVE_MANIPULATION:
+            if not isinstance(value, str) or value not in {"yes", "no"}:
+                raise RuntimeError(
+                    "HFlow hosted active-manipulation check returned a parsed prediction other "
+                    'than "yes" or "no"'
+                )
+            return value
+        case EvaluationTask.BOTH:
+            raise AssertionError("BOTH is a CLI selection, not an executable task")
+
+
+def _parse_hosted_check_response(
+    task: EvaluationTask,
+    response_payload: object,
+) -> VisionModelOutcome:
+    if not isinstance(response_payload, dict):
+        raise RuntimeError("HFlow hosted check returned JSON that is not an object")
+    raw_response = response_payload.get("raw_response")
+    if not isinstance(raw_response, str):
+        raise RuntimeError("HFlow hosted check response is missing string field 'raw_response'")
+    response_metadata = ModelResponseMetadata(response_model=None, usage={})
+    outcome_kind = response_payload.get("outcome")
+    match outcome_kind:
+        case "parsed":
+            predicted_value = _parse_hosted_prediction(task, response_payload.get("prediction"))
+            return ParsedVisionModelOutcome(
+                raw_response=raw_response,
+                response_metadata=response_metadata,
+                predicted_value=predicted_value,
+            )
+        case "unparsed":
+            parse_error = response_payload.get("parse_error")
+            if not isinstance(parse_error, str) or not parse_error:
+                raise RuntimeError(
+                    "HFlow hosted unparsed outcome is missing non-empty string field 'parse_error'"
+                )
+            return UnparsedVisionModelOutcome(
+                raw_response=raw_response,
+                response_metadata=response_metadata,
+                parse_error=parse_error,
+            )
+        case _:
+            raise RuntimeError(
+                "HFlow hosted check response field 'outcome' must be 'parsed' or 'unparsed'"
+            )
+
+
+def _evaluate_image_with_hflow_hosted_service(
+    *,
+    execution: HFlowHostedExecution,
+    task: EvaluationTask,
+    image_bytes: bytes,
+) -> VisionModelOutcome:
+    if len(image_bytes) > _MAX_HFLOW_HOSTED_IMAGE_BYTES:
+        raise ValueError("HFlow hosted check observation exceeds the 10 MiB image limit")
+    endpoint = _hosted_check_endpoint(execution, task)
+    try:
+        with httpx2.stream(
+            "POST",
+            endpoint,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": _HFLOW_HOSTED_USER_AGENT,
+            },
+            files={"observation": _hosted_observation_upload(image_bytes)},
+            timeout=execution.request_timeout_seconds,
+            # An image-bearing API request must never follow a redirect to another origin.
+            follow_redirects=False,
+        ) as response:
+            response.raise_for_status()
+            response_bytes = _read_bounded_hosted_response(response)
+    except httpx2.HTTPStatusError as error:
+        retry_after = error.response.headers.get("Retry-After")
+        retry_after_suffix = f"; retry after {retry_after}" if retry_after else ""
+        raise RuntimeError(
+            f"HFlow hosted check request failed with HTTP "
+            f"{error.response.status_code}{retry_after_suffix}"
+        ) from error
+    except httpx2.RequestError as error:
+        raise RuntimeError(f"HFlow hosted check endpoint is unreachable: {error}") from error
+    try:
+        response_text = response_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise RuntimeError("HFlow hosted check returned invalid UTF-8") from error
+    try:
+        response_payload = json.loads(response_text)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("HFlow hosted check returned malformed JSON") from error
+    return _parse_hosted_check_response(task, response_payload)
+
+
+def _check_version(configuration: _RegisteredBuildAICheckConfiguration) -> StepVersion:
+    version_contract: dict[str, object] = {
+        "task": configuration.task_definition.task.value,
+        "prompt": configuration.task_definition.prompt,
+        "response_schema": configuration.task_definition.response_schema,
+        "camera": configuration.camera,
+        "frame_time_seconds": configuration.frame_time_seconds,
+    }
+    match configuration.execution:
+        case OpenAICompatibleExecution() as execution:
+            # Keep the existing contract shape so migrating to the explicit
+            # execution value does not invalidate otherwise identical results.
+            version_contract.update(
+                {
+                    "endpoint": execution.endpoint,
+                    "model": execution.model,
+                    "response_format": execution.response_format.value,
+                    "temperature": execution.temperature,
+                    "max_tokens": execution.max_tokens,
+                }
+            )
+        case HFlowHostedExecution() as execution:
+            version_contract.update(
+                {
+                    "execution": "hflow-hosted",
+                    "hosted_check_endpoint": _hosted_check_endpoint(
+                        execution, configuration.task_definition.task
+                    ),
+                }
+            )
+        case unexpected_execution:
+            assert_never(unexpected_execution)
+    return step_version_from_contract("build-ai-single-frame-v1", version_contract)
+
+
+def _register_build_ai_check(
     application: App,
     *,
-    check_name: str,
-    configuration: _RegisteredModelCheckConfiguration,
+    configuration: _RegisteredBuildAICheckConfiguration,
 ) -> CheckFunction:
     client_for_thread = threading.local()
 
-    def model_client() -> Any:
+    def model_client(execution: OpenAICompatibleExecution) -> Any:
         api_key = None
-        if configuration.api_key_environment_variable is not None:
-            api_key = os.environ.get(configuration.api_key_environment_variable)
+        if execution.api_key_environment_variable is not None:
+            api_key = os.environ.get(execution.api_key_environment_variable)
             if not api_key:
                 raise ValueError(
-                    f"{configuration.api_key_environment_variable} is required by {check_name}"
+                    f"{execution.api_key_environment_variable} is required by "
+                    f"{_check_name_for_task(configuration.task_definition.task)}"
                 )
-        cache_key = (configuration.endpoint, api_key)
+        cache_key = (execution.endpoint, api_key, execution.max_retries)
         if getattr(client_for_thread, "cache_key", None) != cache_key:
             try:
                 openai_module = importlib.import_module("openai")
@@ -487,8 +711,8 @@ def _register_model_check(
                 ) from error
             client_for_thread.client = openai_module.OpenAI(
                 api_key=api_key or "not-needed",
-                base_url=configuration.endpoint,
-                max_retries=configuration.max_retries,
+                base_url=execution.endpoint,
+                max_retries=execution.max_retries,
             )
             client_for_thread.cache_key = cache_key
         return client_for_thread.client
@@ -506,25 +730,40 @@ def _register_model_check(
                 f"camera {configuration.camera!r}"
             )
         selected_frame = extracted_frames[0]
-        outcome = evaluate_image_with_model(
-            client=model_client(),
-            model=configuration.model,
-            task_definition=configuration.task_definition,
-            image_data_url=image_file_data_url(selected_frame.path),
-            response_format=configuration.response_format,
-            temperature=configuration.temperature,
-            max_tokens=configuration.max_tokens,
-        )
+        image_bytes = selected_frame.path.read_bytes()
+        match configuration.execution:
+            case OpenAICompatibleExecution() as execution:
+                outcome = evaluate_image_with_model(
+                    client=model_client(execution),
+                    model=execution.model,
+                    task_definition=configuration.task_definition,
+                    image_data_url=image_bytes_data_url(image_bytes),
+                    response_format=execution.response_format,
+                    temperature=execution.temperature,
+                    max_tokens=execution.max_tokens,
+                )
+                requested_model = execution.model
+            case HFlowHostedExecution() as execution:
+                outcome = _evaluate_image_with_hflow_hosted_service(
+                    execution=execution,
+                    task=configuration.task_definition.task,
+                    image_bytes=image_bytes,
+                )
+                requested_model = _hosted_execution_label(
+                    execution, configuration.task_definition.task
+                )
+            case unexpected_execution:
+                assert_never(unexpected_execution)
         return model_output_check_result(
             task=configuration.task_definition.task,
-            requested_model=configuration.model,
+            requested_model=requested_model,
             outcome=outcome,
             observation_id=f"frame:{selected_frame.log_time_ns}",
             timestamp_ns=selected_frame.log_time_ns,
         )
 
     return application.check(
-        name=check_name,
+        name=_check_name_for_task(configuration.task_definition.task),
         version=_check_version(configuration),
         requires=("vision-model",),
     )(evaluate_build_ai_check)
@@ -533,34 +772,22 @@ def _register_model_check(
 def register_hand_visibility(
     application: App,
     *,
-    endpoint: str,
-    model: str,
-    api_key_environment_variable: str | None = None,
-    response_format: ResponseFormat = ResponseFormat.JSON_SCHEMA,
-    temperature: float | None = None,
-    max_tokens: int = 32,
-    max_retries: int = 5,
+    execution: BuildAIExecution,
     camera: str | None = None,
     frame_time_seconds: float = 0.0,
     prompt: str = BUILD_AI_HAND_VISIBILITY_PROMPT,
 ) -> CheckFunction:
-    """Register Build AI's hand-visibility methodology on one model endpoint."""
-    return _register_model_check(
+    """Register Build AI's hand-visibility methodology with one execution strategy."""
+    return _register_build_ai_check(
         application,
-        check_name=BUILD_AI_HAND_VISIBILITY_CHECK_NAME,
-        configuration=_RegisteredModelCheckConfiguration(
-            endpoint=endpoint,
-            model=model,
+        configuration=_RegisteredBuildAICheckConfiguration(
+            execution=execution,
             task_definition=TaskDefinition(
                 task=EvaluationTask.HAND_COUNT,
                 prompt=prompt,
                 response_schema=HAND_COUNT_RESPONSE_SCHEMA,
             ),
-            api_key_environment_variable=api_key_environment_variable,
-            response_format=response_format,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            max_retries=max_retries,
+            published_prompt=BUILD_AI_HAND_VISIBILITY_PROMPT,
             camera=camera,
             frame_time_seconds=frame_time_seconds,
         ),
@@ -570,34 +797,22 @@ def register_hand_visibility(
 def register_active_manipulation(
     application: App,
     *,
-    endpoint: str,
-    model: str,
-    api_key_environment_variable: str | None = None,
-    response_format: ResponseFormat = ResponseFormat.JSON_SCHEMA,
-    temperature: float | None = None,
-    max_tokens: int = 32,
-    max_retries: int = 5,
+    execution: BuildAIExecution,
     camera: str | None = None,
     frame_time_seconds: float = 0.0,
     prompt: str = BUILD_AI_ACTIVE_MANIPULATION_PROMPT,
 ) -> CheckFunction:
-    """Register Build AI's active-manipulation methodology on one endpoint."""
-    return _register_model_check(
+    """Register Build AI's active-manipulation methodology with one execution strategy."""
+    return _register_build_ai_check(
         application,
-        check_name=BUILD_AI_ACTIVE_MANIPULATION_CHECK_NAME,
-        configuration=_RegisteredModelCheckConfiguration(
-            endpoint=endpoint,
-            model=model,
+        configuration=_RegisteredBuildAICheckConfiguration(
+            execution=execution,
             task_definition=TaskDefinition(
                 task=EvaluationTask.ACTIVE_MANIPULATION,
                 prompt=prompt,
                 response_schema=ACTIVE_MANIPULATION_RESPONSE_SCHEMA,
             ),
-            api_key_environment_variable=api_key_environment_variable,
-            response_format=response_format,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            max_retries=max_retries,
+            published_prompt=BUILD_AI_ACTIVE_MANIPULATION_PROMPT,
             camera=camera,
             frame_time_seconds=frame_time_seconds,
         ),

--- a/tests/test_build_ai_vlm_checks.py
+++ b/tests/test_build_ai_vlm_checks.py
@@ -1,25 +1,56 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Iterator
 from pathlib import Path
+from types import TracebackType
 
+import httpx2
 import pytest
 
 import hflow
+from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
 
-def test_build_ai_vlm_checks_register_independent_model_contracts(tmp_path: Path) -> None:
+class _StubHostedResponse:
+    def __init__(self, payload: object) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> _StubHostedResponse:
+        return self
+
+    def __exit__(
+        self,
+        _exception_type: type[BaseException] | None,
+        _exception: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        yield self._body
+
+
+def test_build_ai_vlm_checks_register_independent_execution_contracts(tmp_path: Path) -> None:
     application = hflow.App("model-checks", data_root=tmp_path, default_checks=())
 
     hand_check = hflow.build_ai_vlm_checks.register_hand_visibility(
         application,
-        endpoint="http://hand-model.internal/v1",
-        model="hand-model",
+        execution=hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint="http://hand-model.internal/v1",
+            model="hand-model",
+        ),
     )
     active_manipulation_check = hflow.build_ai_vlm_checks.register_active_manipulation(
         application,
-        endpoint="https://hosted.example/v1",
-        model="manipulation-model",
-        api_key_environment_variable="HOSTED_MODEL_API_KEY",
+        execution=hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint="https://hosted.example/v1",
+            model="manipulation-model",
+            api_key_environment_variable="HOSTED_MODEL_API_KEY",
+        ),
     )
 
     assert hand_check is application.checks[0].function
@@ -41,13 +72,33 @@ def test_build_ai_check_version_changes_with_model_configuration(tmp_path: Path)
 
     hflow.build_ai_vlm_checks.register_hand_visibility(
         first_application,
-        endpoint="http://localhost:8000/v1",
-        model="model-a",
+        execution=hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint="http://localhost:8000/v1",
+            model="model-a",
+        ),
     )
     hflow.build_ai_vlm_checks.register_hand_visibility(
         second_application,
-        endpoint="http://localhost:8000/v1",
-        model="model-b",
+        execution=hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint="http://localhost:8000/v1",
+            model="model-b",
+        ),
+    )
+
+    assert first_application.checks[0].version != second_application.checks[0].version
+
+
+def test_build_ai_check_version_changes_with_hosted_check_version(tmp_path: Path) -> None:
+    first_application = hflow.App("first", data_root=tmp_path / "first", default_checks=())
+    second_application = hflow.App("second", data_root=tmp_path / "second", default_checks=())
+
+    hflow.build_ai_vlm_checks.register_hand_visibility(
+        first_application,
+        execution=hflow.build_ai_vlm_checks.HFlowHostedExecution(check_version=1),
+    )
+    hflow.build_ai_vlm_checks.register_hand_visibility(
+        second_application,
+        execution=hflow.build_ai_vlm_checks.HFlowHostedExecution(check_version=2),
     )
 
     assert first_application.checks[0].version != second_application.checks[0].version
@@ -60,17 +111,142 @@ def test_build_ai_check_version_changes_with_model_configuration(tmp_path: Path)
         ("http://localhost:8000/v1", " ", "model must not be empty"),
     ],
 )
-def test_build_ai_registration_refuses_invalid_model_configuration(
-    tmp_path: Path,
+def test_openai_compatible_execution_refuses_invalid_configuration(
     endpoint: str,
     model: str,
     expected_message: str,
 ) -> None:
-    application = hflow.App("invalid", data_root=tmp_path, default_checks=())
-
     with pytest.raises(ValueError, match=expected_message):
-        hflow.build_ai_vlm_checks.register_hand_visibility(
-            application,
+        hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
             endpoint=endpoint,
             model=model,
+        )
+
+
+def test_hosted_execution_refuses_custom_prompt(tmp_path: Path) -> None:
+    application = hflow.App("invalid-hosted-prompt", data_root=tmp_path, default_checks=())
+
+    with pytest.raises(ValueError, match="does not support prompt overrides"):
+        hflow.build_ai_vlm_checks.register_hand_visibility(
+            application,
+            execution=hflow.build_ai_vlm_checks.HFlowHostedExecution(),
+            prompt="Use a different definition of visibility.",
+        )
+
+
+def test_hosted_execution_refuses_a_base_url_that_cannot_accept_check_paths() -> None:
+    with pytest.raises(ValueError, match="query string or fragment"):
+        hflow.build_ai_vlm_checks.HFlowHostedExecution(
+            base_url="https://checks.example?model=arbitrary"
+        )
+
+
+def test_hosted_execution_sends_the_selected_frame_and_returns_standard_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_episode = synthesize_episode(
+        tmp_path / "episode.mcap",
+        SyntheticEpisodeSpec(
+            duration_s=2.0,
+            cameras=("head_camera",),
+            black_segment=None,
+            joint_jump_at_s=None,
+            timestamp_offset_segment=None,
+        ),
+    )
+    application = hflow.App("hosted-check", data_root=tmp_path / "data", default_checks=())
+    hflow.build_ai_vlm_checks.register_hand_visibility(
+        application,
+        execution=hflow.build_ai_vlm_checks.HFlowHostedExecution(
+            base_url="https://checks.example",
+            check_version=3,
+            request_timeout_seconds=12.0,
+        ),
+    )
+    captured_requests: list[
+        tuple[
+            str,
+            str,
+            dict[str, str],
+            dict[str, tuple[str, bytes, str]],
+            float,
+            bool,
+        ]
+    ] = []
+
+    def hosted_response(
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        files: dict[str, tuple[str, bytes, str]],
+        timeout: float,
+        follow_redirects: bool,
+    ) -> _StubHostedResponse:
+        captured_requests.append((method, url, headers, files, timeout, follow_redirects))
+        return _StubHostedResponse(
+            {
+                "outcome": "parsed",
+                "prediction": 2,
+                "raw_response": "2",
+            }
+        )
+
+    monkeypatch.setattr(httpx2, "stream", hosted_response)
+
+    report = application.test(source_episode, verbose=False)
+    check_run = report.check("build_ai_hand_visibility")
+    assert check_run.result is not None
+    result = check_run.result
+
+    assert len(captured_requests) == 1
+    method, url, headers, files, timeout, follow_redirects = captured_requests[0]
+    assert method == "POST"
+    assert url == ("https://checks.example/v1/checks/build_ai_hand_visibility/versions/3/evaluate")
+    assert timeout == 12.0
+    assert follow_redirects is False
+    assert headers == {
+        "Accept": "application/json",
+        "User-Agent": f"hflow/{hflow.__version__} (+https://hflow.dev)",
+    }
+    filename, uploaded_image_bytes, uploaded_image_mime_type = files["observation"]
+    assert filename == "observation.jpg"
+    assert uploaded_image_bytes.startswith(b"\xff\xd8\xff")
+    assert uploaded_image_mime_type == "image/jpeg"
+    assert result.measurements == {
+        "build_ai/hand_count/raw_response": "2",
+        "build_ai/hand_count/requested_model": "hflow-hosted/build_ai_hand_visibility@3",
+        "build_ai/hand_count/prediction": 2,
+    }
+    assert result.tags == []
+    assert len(result.observations) == 1
+    assert result.observations[0].values["valid"] is True
+    assert result.observations[0].values["prediction"] == 2
+
+
+def test_hosted_unparsed_response_remains_an_evaluation_outcome() -> None:
+    outcome = hflow.build_ai_vlm_checks._parse_hosted_check_response(
+        hflow.build_ai_vlm_checks.EvaluationTask.ACTIVE_MANIPULATION,
+        {
+            "outcome": "unparsed",
+            "raw_response": "probably",
+            "parse_error": 'active manipulation must be "yes" or "no"',
+        },
+    )
+
+    assert isinstance(outcome, hflow.build_ai_vlm_checks.UnparsedVisionModelOutcome)
+    assert outcome.raw_response == "probably"
+    assert outcome.parse_error == 'active manipulation must be "yes" or "no"'
+
+
+def test_hosted_response_refuses_a_prediction_outside_the_check_contract() -> None:
+    with pytest.raises(RuntimeError, match="outside 0, 1, or 2"):
+        hflow.build_ai_vlm_checks._parse_hosted_check_response(
+            hflow.build_ai_vlm_checks.EvaluationTask.HAND_COUNT,
+            {
+                "outcome": "parsed",
+                "prediction": 3,
+                "raw_response": "3",
+            },
         )

--- a/tests/test_evaluate_episode_example.py
+++ b/tests/test_evaluate_episode_example.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from examples.evaluate_episode import build_application
+
+
+def test_recommended_episode_evaluation_combines_default_and_hosted_checks(
+    tmp_path: Path,
+) -> None:
+    application = build_application(
+        data_root=tmp_path,
+        camera="/head_camera",
+        frame_time_seconds=0.0,
+    )
+
+    assert [registered_check.name for registered_check in application.checks] == [
+        "episode_duration",
+        "timestamp_regularity",
+        "camera_frame_stats",
+        "keyframe_interval",
+        "content_digest",
+        "media_digest",
+        "build_ai_hand_visibility",
+        "build_ai_active_manipulation",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -966,6 +966,7 @@ source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
     { name = "foxglove-schemas-protobuf" },
+    { name = "httpx2" },
     { name = "mcap" },
     { name = "mcap-protobuf-support" },
     { name = "mcap-ros2-support" },
@@ -994,7 +995,6 @@ openai = [
 [package.dev-dependencies]
 dev = [
     { name = "hflow-server" },
-    { name = "httpx2" },
     { name = "obstore" },
     { name = "opencv-python-headless" },
     { name = "pyarrow" },
@@ -1008,6 +1008,7 @@ dev = [
 requires-dist = [
     { name = "duckdb", specifier = ">=1.5.5" },
     { name = "foxglove-schemas-protobuf", specifier = ">=0.4.0" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "mcap", specifier = ">=1.4.0" },
     { name = "mcap-protobuf-support", specifier = ">=0.5.4" },
     { name = "mcap-ros2-support", specifier = ">=0.5.7" },
@@ -1024,7 +1025,6 @@ provides-extras = ["arrow", "bucket", "mediapipe", "motion", "openai"]
 [package.metadata.requires-dev]
 dev = [
     { name = "hflow-server", editable = "packages/hflow-server" },
-    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "obstore", specifier = ">=0.11.1" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
     { name = "pyarrow", specifier = ">=25.0.1" },


### PR DESCRIPTION
## Summary

- add explicit per-check hosted and OpenAI-compatible execution strategies for the Build AI checks
- keep DEFAULT_CHECKS offline while making hosted execution the default in the focused Build AI example
- add a recommended real-episode tutorial that combines deterministic and hosted model checks
- use HTTPX2 with a stable HFlow user agent, bounded uploads and responses, and no redirect following

## Validation

- uv run --python 3.14 --locked ruff check --fix
- uv run --python 3.14 --locked ruff format
- uv run --python 3.14 --locked ty check
- uv run --python 3.11 --locked pytest -q (1453 passed, 6 skipped)
- uv run --python 3.14 --locked pytest -q (1453 passed, 6 skipped)
- full repository lychee link check (378 OK, 0 errors)
- live production run on the documented Lightwheel episode returned 2 visible hands and active manipulation yes