### PR TITLE
test(server): stop asserting UTC rendering with a substring that matches the date

### DIFF
--- a/packages/hflow-server/tests/test_server_curation_preview.py
+++ b/packages/hflow-server/tests/test_server_curation_preview.py
@@ -2,7 +2,7 @@
 
 import os
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -76,14 +76,23 @@ def test_preview_stats_render_timestamps_in_utc_on_a_non_utc_host(
     # Rows are UTC ISO text...
     for row in payload["rows"]:
         assert row["recorded_at"].endswith("+00:00")
-    # ...and the column stats agree (same UTC rendering, not the host's -04),
-    # so the stats panel never shows a different offset or calendar day.
+    # ...and the column stats agree, so the stats panel never shows a different
+    # offset or calendar day than the rows above it.
     stats_by_column = {entry["column_name"]: entry for entry in payload["column_stats"]}
     recorded_at_stats = stats_by_column["recorded_at"]
+    row_timestamps = sorted(datetime.fromisoformat(row["recorded_at"]) for row in payload["rows"])
+    expected_bounds = {"min": row_timestamps[0], "max": row_timestamps[-1]}
     for bound_key in ("min", "max"):
         bound_value = recorded_at_stats[bound_key]
         assert bound_value.endswith("+00:00"), bound_value
-        assert "-04" not in bound_value
+        parsed_bound = datetime.fromisoformat(bound_value)
+        assert parsed_bound.utcoffset() == timedelta(0), bound_value
+        assert parsed_bound == expected_bounds[bound_key], bound_value
+    # The fixture stamps recorded_at as it appends, so a correct render lands
+    # near now. Rows and stats pass through the same projection and would shift
+    # together, so agreement alone cannot catch a clock moved into the host zone
+    # and then stamped +00:00; the host offset here is whole hours away from UTC.
+    assert abs(datetime.now(UTC) - expected_bounds["max"]) < timedelta(hours=1)
 
 
 def test_preview_stats_returns_summarize_rows(api: TestClient) -> None:


### PR DESCRIPTION
## Summary

`test_preview_stats_render_timestamps_in_utc_on_a_non_utc_host` asserted `"-04" not in bound_value` to catch the host's `-04:00` offset leaking into the stats panel. That substring also matches the day in `2026-09-04` and the month in any April date, so the test fails on the 4th of every month and through all of April no matter what the code under test does. Main is red today for that reason:

```
AssertionError: assert '-04' not in '2026-09-04T01:44:38.834552+00:00'
```

Reported independently by @akshatpatel64 on #383 and @victorwon2001 on #384, both of whom had to explain it away in their own validation runs.

## Why this shape

The bounds are compared to the row timestamps and to the wall clock instead of sniffed for a substring. That removes the date collision and covers strictly more, which two mutations show:

```
SUMMARIZE over the bare projection (the original defect)   -> FAILED (caught)
clock shifted to host zone, '+00:00' still stamped         -> FAILED (caught)
```

The second one is new. The old substring check passed it, and so does a rows-to-stats comparison on its own, because rows and stats both go through `select_head` and shift together. The fixture stamps `recorded_at` as it appends, so anchoring the max bound near `datetime.now(UTC)` is what makes a whole-hour zone shift visible; `America/New_York` is 4 hours away and the window is 1 hour.

## Validation

`uv run ruff check`, `uv run ruff format --check`, `uv run ty check` clean; `uv run pytest -q` 1453 passed, 6 skipped.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.