### PR TITLE
feat: add per-episode LeRobot manifest receipts

### DIFF
--- a/docs/how-to/import-lerobot-v3.md
+++ b/docs/how-to/import-lerobot-v3.md
@@ -26,7 +26,7 @@ data/lerobot_pusht/
 ├── _lerobot_cache/                 # downloaded metadata, Parquet, and video
 ├── landing/
 │   └── lerobot_episode_0001.mcap   # canonical episode
-└── prepared-manifest.json          # source commit and import summary
+└── prepared-manifest.json          # source commit, import summary, and episode receipts
 ```
 
 Re-running against the same output directory reuses downloaded source files.
@@ -50,6 +50,37 @@ that prefix. Hugging Face downloads stay in the local mirror under
 `_lerobot_cache/` (`HFLOW_MIRROR_DIR`, or `$XDG_CACHE_HOME/hflow/mirrors`) and
 are never uploaded into the bucket. The success manifest is published only
 after every selected episode object has been written.
+
+`prepared-manifest.json` uses schema version 3. It keeps the dataset source,
+selected camera keys, converted episode count, and converter version, and adds
+one receipt for every published canonical MCAP:
+
+```json
+{
+  "schema_version": 3,
+  "dataset": {
+    "repo_id": "lerobot/pusht",
+    "revision": "0123456789abcdef0123456789abcdef01234567",
+    "license": "apache-2.0"
+  },
+  "camera_keys": ["observation.image"],
+  "episodes_converted": 1,
+  "episodes": [
+    {
+      "filename": "lerobot_episode_0001.mcap",
+      "content_id": "0123456789abcdef",
+      "size_bytes": 123456
+    }
+  ],
+  "converter_version": "lerobot-converter-v4"
+}
+```
+
+Each `content_id` is HFlow's canonical episode content ID (the first 16 hex
+characters of the SHA-256 over the published MCAP bytes), and `size_bytes` is
+the file size in bytes. `episodes_converted` remains equal to the number of
+entries in `episodes`, so readers that use the existing import summary fields
+can continue to do so while newer readers can identify each delivered file.
 
 For a gated or private repository, export a read token as `HF_TOKEN` (or
 `HUGGING_FACE_HUB_TOKEN`) before running the command. HFlow sends the token

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -31,6 +31,7 @@ from urllib.parse import urlsplit
 
 from mcap.writer import Writer as McapWriter
 
+from hflow.catalog import content_episode_id
 from hflow.ffmpeg import ffmpeg_path, ffmpeg_version, ffprobe_path
 from hflow.storage import LocalStorageRoot, StorageRoot, parse_storage_root
 from hflow.transform import TransformConfig, write_canonical_episode
@@ -74,6 +75,14 @@ class DatasetSource:
     repo_id: str
     revision: str
     license: str
+
+
+@dataclass(frozen=True)
+class _PublishedEpisode:
+    published_uri: str
+    filename: str
+    content_id: str
+    size_bytes: int
 
 
 class _DatasetRepositoryInformation(TypedDict):
@@ -674,11 +683,11 @@ def import_lerobot_dataset(
     selected_episode_indexes = (
         [episode_index] if episode_index is not None else list(range(len(episode_rows)))
     )
-    published_episode_uris: list[str] = []
+    published_episodes: list[_PublishedEpisode] = []
 
     dataset_source = source_archive["dataset"]
     for selected_episode_index in selected_episode_indexes:
-        published_episode_uris.append(
+        published_episodes.append(
             _convert_single_episode(
                 source_archive=source_archive,
                 dataset_source=dataset_source,
@@ -692,14 +701,22 @@ def import_lerobot_dataset(
 
     manifest_contents = json.dumps(
         {
-            "schema_version": 2,
+            "schema_version": 3,
             "dataset": {
                 "repo_id": dataset_source.repo_id,
                 "revision": dataset_source.revision,
                 "license": dataset_source.license,
             },
             "camera_keys": list(resolved_camera_keys),
-            "episodes_converted": len(published_episode_uris),
+            "episodes_converted": len(published_episodes),
+            "episodes": [
+                {
+                    "filename": episode.filename,
+                    "content_id": episode.content_id,
+                    "size_bytes": episode.size_bytes,
+                }
+                for episode in published_episodes
+            ],
             "converter_version": CONVERTER_VERSION,
         },
         indent=2,
@@ -710,7 +727,7 @@ def import_lerobot_dataset(
         temporary_manifest_path.write_text(manifest_contents + "\n", encoding="utf-8")
         published_manifest_uri = storage.publish(temporary_manifest_path, "prepared-manifest.json")
     logger.info("wrote LeRobot import manifest %s", published_manifest_uri)
-    return published_episode_uris
+    return [episode.published_uri for episode in published_episodes]
 
 
 def _convert_single_episode(
@@ -721,10 +738,10 @@ def _convert_single_episode(
     camera_keys: tuple[str, ...],
     numeric_schemas: dict[str, _NumericSchema],
     frames_per_second: int,
-) -> str:
+) -> _PublishedEpisode:
     """Convert a single episode to canonical MCAP and publish it.
 
-    Returns the published episode URI under ``landing/``.
+    Returns the published episode receipt under ``landing/``.
     """
     import duckdb
 
@@ -1003,15 +1020,21 @@ def _convert_single_episode(
             TransformConfig(gop_seconds=1.0),
             source_uri=source_uri,
         )
-        published_uri = storage.publish(canonical_episode_path, landing_relative_key)
+        episode_content_id = content_episode_id(canonical_episode_path)
         episode_size_bytes = canonical_episode_path.stat().st_size
+        published_uri = storage.publish(canonical_episode_path, landing_relative_key)
 
     logger.info(
         "wrote canonical LeRobot episode %s (%.2f MB)",
         published_uri,
         episode_size_bytes / 1_000_000,
     )
-    return published_uri
+    return _PublishedEpisode(
+        published_uri=published_uri,
+        filename=output_file_name,
+        content_id=episode_content_id,
+        size_bytes=episode_size_bytes,
+    )
 
 
 __all__ = ["import_lerobot_dataset"]

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -16,6 +16,7 @@ from typing import cast
 import pytest
 
 import hflow.importers.lerobot as prep
+from hflow.catalog import content_episode_id
 from hflow.cli import main as cli_main
 from hflow.storage import LocalStorageRoot, StorageRoot
 
@@ -328,7 +329,7 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
 
     published_uris: list[str] = []
     for episode_index in (0, 1, 0):
-        uri = prep._convert_single_episode(
+        published_episode = prep._convert_single_episode(
             source_archive=source_archive,
             dataset_source=dataset_source,
             storage=LocalStorageRoot(tmp_path / "output"),
@@ -337,7 +338,7 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
             numeric_schemas=numeric_schemas,
             frames_per_second=30,
         )
-        published_uris.append(uri)
+        published_uris.append(published_episode.published_uri)
 
     assert published_uris[0].endswith("landing/lerobot_episode_0001.mcap")
     assert published_uris[1].endswith("landing/lerobot_episode_0002.mcap")
@@ -960,6 +961,60 @@ def _stub_single_episode_source_archive(
     }
 
 
+def _stub_three_one_frame_source_archive(
+    dataset_source: prep.DatasetSource, cache_dir: Path
+) -> dict:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    data_path = cache_dir / "data" / "chunk-000000-file-000000.parquet"
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    escaped_data_path = str(data_path).replace("'", "''")
+
+    import duckdb
+
+    connection = duckdb.connect()
+    try:
+        connection.execute(
+            "COPY (SELECT * FROM (VALUES "
+            "(0, 0, 0, 0.0::DOUBLE, [1.0], [1.5]), "
+            "(1, 1, 0, 0.0::DOUBLE, [2.0], [2.5]), "
+            "(2, 2, 0, 0.0::DOUBLE, [3.0], [3.5])) "
+            'AS t(index, episode_index, frame_index, timestamp, "observation.state", action)) '
+            f"TO '{escaped_data_path}' (FORMAT parquet)"
+        )
+    finally:
+        connection.close()
+
+    video_path = cache_dir / "videos" / "observation_image-chunk000-file000.mp4"
+    video_path.parent.mkdir(parents=True, exist_ok=True)
+    video_path.write_bytes(b"stub-video")
+
+    return {
+        "info": {"robot_type": "pusht"},
+        "fps": 30,
+        "data_path": "data/{chunk_index}/{file_index}.parquet",
+        "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
+        "episodes": [
+            {
+                "episode_index": episode_index,
+                "task": f"push-{episode_index}",
+                "length": 1,
+                "data_chunk": "000",
+                "data_file": "000",
+                "data_from": episode_index,
+                "data_to": episode_index + 1,
+            }
+            for episode_index in range(3)
+        ],
+        "video_keys": [prep.DEFAULT_CAMERA_KEY],
+        "numeric_features": {
+            "action": {"dtype": "float32", "shape": [1]},
+            "observation.state": {"dtype": "float32", "shape": [1]},
+        },
+        "cache_dir": cache_dir,
+        "dataset": dataset_source,
+    }
+
+
 def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[str]:
     """Exercise StorageRoot.publish without running the video converter."""
 
@@ -974,13 +1029,21 @@ def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         camera_keys: object,
         numeric_schemas: object,
         frames_per_second: object,
-    ) -> str:
+    ) -> prep._PublishedEpisode:
         del source_archive, dataset_source, camera_keys, numeric_schemas, frames_per_second
         relative_key = f"landing/lerobot_episode_{episode_index + 1:04d}.mcap"
         staged = tmp_path / f"staged-{episode_index}.mcap"
         staged.write_bytes(f"episode-{episode_index}".encode())
         published_keys.append(relative_key)
-        return storage.publish(staged, relative_key)
+        episode_content_id = content_episode_id(staged)
+        episode_size_bytes = staged.stat().st_size
+        published_uri = storage.publish(staged, relative_key)
+        return prep._PublishedEpisode(
+            published_uri=published_uri,
+            filename=Path(relative_key).name,
+            content_id=episode_content_id,
+            size_bytes=episode_size_bytes,
+        )
 
     monkeypatch.setattr(prep, "_convert_single_episode", fake_convert)
     return published_keys
@@ -1007,6 +1070,59 @@ def test_import_returns_local_uris_and_keeps_cache_beside_landing(
     assert Path(episode_uris[0]).is_file()
     assert (output_dir / "prepared-manifest.json").is_file()
     assert (output_dir / "_lerobot_cache" / "abc").is_dir()
+
+
+def test_import_manifest_v3_records_each_published_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = tmp_path / "out"
+    dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
+    source_archive = _stub_three_one_frame_source_archive(dataset_source, tmp_path / "cache")
+
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_ensure_source_archive", lambda source, cache_dir: source_archive)
+    monkeypatch.setattr(prep, "_transcode_mp4_to_h264", lambda path, *args: [b"access-unit"])
+    monkeypatch.setattr(prep, "_get_video_pts_times", lambda path: [0.0])
+    monkeypatch.setattr(prep, "ffmpeg_version", lambda: "test-ffmpeg")
+    monkeypatch.setattr(
+        prep,
+        "write_canonical_episode",
+        lambda source_path, output_path, *_args, **_kwargs: shutil.copy(source_path, output_path),
+    )
+
+    episode_uris = prep.import_lerobot_dataset(
+        dataset_repo="fake/repo",
+        revision="main",
+        output_dir=output_dir,
+    )
+
+    landing_paths = sorted((output_dir / "landing").glob("*.mcap"))
+    assert episode_uris == [str(path.resolve()) for path in landing_paths]
+    assert [path.name for path in landing_paths] == [
+        "lerobot_episode_0001.mcap",
+        "lerobot_episode_0002.mcap",
+        "lerobot_episode_0003.mcap",
+    ]
+
+    manifest = json.loads((output_dir / "prepared-manifest.json").read_text())
+    manifest_episodes = manifest["episodes"]
+    assert manifest["schema_version"] == 3
+    assert manifest["dataset"] == {
+        "repo_id": "fake/repo",
+        "revision": "abc",
+        "license": "apache-2.0",
+    }
+    assert manifest["camera_keys"] == [prep.DEFAULT_CAMERA_KEY]
+    assert manifest["episodes_converted"] == len(manifest_episodes) == 3
+    assert manifest["converter_version"] == prep.CONVERTER_VERSION
+    assert [episode["filename"] for episode in manifest_episodes] == [
+        path.name for path in landing_paths
+    ]
+    for manifest_episode, landing_path in zip(manifest_episodes, landing_paths, strict=True):
+        assert manifest_episode["size_bytes"] == landing_path.stat().st_size
+        assert manifest_episode["content_id"] == content_episode_id(landing_path)
 
 
 def test_import_publishes_into_a_bucket_data_root_without_uploading_cache(
@@ -1077,7 +1193,7 @@ def test_import_skips_bucket_manifest_when_an_episode_publish_fails(
         camera_keys: object,
         numeric_schemas: object,
         frames_per_second: object,
-    ) -> str:
+    ) -> prep._PublishedEpisode:
         nonlocal convert_calls
         del source_archive, dataset_source, camera_keys, numeric_schemas, frames_per_second
         convert_calls += 1
@@ -1086,7 +1202,15 @@ def test_import_skips_bucket_manifest_when_an_episode_publish_fails(
         relative_key = f"landing/lerobot_episode_{episode_index + 1:04d}.mcap"
         staged = tmp_path / f"staged-{episode_index}.mcap"
         staged.write_bytes(b"first")
-        return storage.publish(staged, relative_key)
+        episode_content_id = content_episode_id(staged)
+        episode_size_bytes = staged.stat().st_size
+        published_uri = storage.publish(staged, relative_key)
+        return prep._PublishedEpisode(
+            published_uri=published_uri,
+            filename=Path(relative_key).name,
+            content_id=episode_content_id,
+            size_bytes=episode_size_bytes,
+        )
 
     monkeypatch.setattr(
         prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}


### PR DESCRIPTION
## Summary

- Upgrade `prepared-manifest.json` to schema version 3 and record `filename`, `content_id`, and `size_bytes` for every published LeRobot episode.
- Reuse `hflow.catalog.content_episode_id()` on the staged canonical MCAP instead of introducing another hashing implementation.
- Preserve the existing `episodes_converted`, dataset, camera, converter-version fields, public `list[str]` return contract, and manifest-last publication behavior.
- Document the v3 receipt format. The verify command remains deferred as requested and can later consume this schema additively.

Fixes #379

## Why

The previous manifest recorded only how many episodes were converted, so a delivered corpus had no per-file identity or size receipt. Recording those values at conversion time provides the required provenance without changing canonical MCAP bytes, `CONVERTER_VERSION`, transform behavior, or curation identity semantics.

## Validation

- `uv run pytest -q tests/test_lerobot_converter.py tests/test_transform.py` — 57 passed.
- `uv run ruff check --fix` — passed with no changes.
- `uv run ruff format` — passed; all 212 files unchanged.
- `uv run ty check` — passed.
- `lychee --no-progress --include-fragments --exclude '^https://github\.com/Hebbian-Robotics/hflow/(issues|security/advisories/new)$' --exclude-path references/mcap-spec.md --exclude-path references/foxglove-CompressedVideo.proto .` — 0 link errors.
- `uv run pytest -q` — 1453 passed, 6 skipped, with one unrelated date-sensitive failure in `test_preview_stats_render_timestamps_in_utc_on_a_non_utc_host`: on 2026-09-04 the UTC timestamp itself contains the substring `-04` that the test forbids.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.