### PR TITLE
fix(catalog): refuse a non-string interval label

### DIFF
--- a/src/hflow/catalog.py
+++ b/src/hflow/catalog.py
@@ -416,7 +416,7 @@ def _normalized_scalar_values(
 
 
 def _normalized_intervals(check_name: str, intervals: list[Interval]) -> list[Interval]:
-    """Coerce NumPy scalar interval bounds to Python ints; refuse the rest.
+    """Validate the label, coerce NumPy scalar bounds to ints, refuse the rest.
 
     A user check computing segment boundaries from ``channel.to_numpy()``
     gets ``np.int64`` bounds from plain indexing, and those reach the run
@@ -429,6 +429,29 @@ def _normalized_intervals(check_name: str, intervals: list[Interval]) -> list[In
     """
     normalized: list[Interval] = []
     for interval in intervals:
+        # The label first: the bound errors below interpolate it, and it
+        # reaches the run fingerprint, where it is sorted against the other
+        # intervals' labels. A non-string only meets one when two intervals
+        # share both bounds, so the TypeError it raises there fires on some
+        # corpora and not others, several frames from the check that caused
+        # it and naming neither the check nor the field.
+        #
+        # Empty is the dataclass default and stays legal. Padding is refused
+        # for the reason an observation id is: both are stored verbatim, so
+        # " freeze " and "freeze" would be two labels for one thing.
+        label = interval.label
+        if not isinstance(label, str):
+            raise ValueError(
+                f"check {check_name!r} set an interval label as "
+                f"{type(label).__name__} (start_ns={interval.start_ns!r}, "
+                f"end_ns={interval.end_ns!r}): interval labels are strings"
+            )
+        if label != label.strip():
+            raise ValueError(
+                f"check {check_name!r} set interval label {label!r} with leading "
+                "or trailing whitespace: interval labels are stored verbatim"
+            )
+
         bounds: dict[str, int] = {}
         for bound_name in ("start_ns", "end_ns"):
             value = getattr(interval, bound_name)

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1473,6 +1473,91 @@ def test_a_negative_interval_bound_is_refused(tmp_path: Path) -> None:
         _appended_with_interval(tmp_path, hflow.Interval(start_ns=-5, end_ns=-1, label="gap"))
 
 
+def test_a_non_string_interval_label_is_refused_naming_the_check(tmp_path: Path) -> None:
+    """A label that is not a string reaches the run fingerprint and breaks its sort.
+
+    The failure it replaces was data dependent: the fingerprint sorts
+    ``(start_ns, end_ns, label)`` tuples, so a bad label is only ever compared
+    against another when two intervals share both bounds. One interval stored
+    fine, two colliding ones raised a ``TypeError`` several frames inside
+    ``append_episode`` naming neither the check nor the field (#392).
+    """
+    with pytest.raises(ValueError, match=r"segment_check.*NoneType.*labels are strings"):
+        _appended_with_interval(
+            # cast: the misuse this test exists to refuse.
+            tmp_path,
+            hflow.Interval(start_ns=0, end_ns=10, label=cast(str, None)),
+        )
+    assert list((tmp_path / "catalog" / "episodes").glob("*.parquet")) == []
+
+
+def test_colliding_intervals_with_a_bad_label_are_refused_not_crashed(tmp_path: Path) -> None:
+    """The case that used to raise TypeError from inside the fingerprint sort.
+
+    Two intervals sharing both bounds are the only shape that reaches the label
+    comparison, so this is the arrangement the old code died on rather than
+    stored.
+    """
+    canonical = tmp_path / "e.canonical.mcap"
+    canonical.write_bytes(b"episode-bytes")
+    row = CheckRunRow(
+        check_name="segment_check",
+        check_version="v1",
+        critical=False,
+        status=hflow.CheckStatus.MEASURED,
+        duration_s=0.1,
+        intervals=[
+            hflow.Interval(start_ns=0, end_ns=10, label="freeze"),
+            # cast: the misuse this test exists to refuse.
+            hflow.Interval(start_ns=0, end_ns=10, label=cast(str, None)),
+        ],
+    )
+    with pytest.raises(ValueError, match=r"segment_check.*NoneType.*labels are strings"):
+        Catalog(tmp_path / "catalog").append_episode(
+            canonical_path=canonical,
+            stamps=FAKE_STAMPS,
+            episode_metadata={},
+            check_rows=[row],
+        )
+
+
+def test_a_non_serializable_interval_label_is_refused_before_the_fingerprint(
+    tmp_path: Path,
+) -> None:
+    """An unserializable label used to surface as a json.dumps TypeError.
+
+    That one fired whatever the bounds were, because the fingerprint payload is
+    serialized after the sort. It is now refused where the bounds are, so the
+    message names the check.
+    """
+    with pytest.raises(ValueError, match=r"segment_check.*object.*labels are strings"):
+        _appended_with_interval(
+            # cast: the misuse this test exists to refuse.
+            tmp_path,
+            hflow.Interval(start_ns=0, end_ns=10, label=cast(str, object())),
+        )
+
+
+def test_a_padded_interval_label_is_refused(tmp_path: Path) -> None:
+    """Labels are stored verbatim, so " freeze " and "freeze" would be two names
+    for one thing. The same rule an observation id already carries."""
+    with pytest.raises(ValueError, match=r"segment_check.*' freeze '.*stored verbatim"):
+        _appended_with_interval(tmp_path, hflow.Interval(start_ns=0, end_ns=10, label=" freeze "))
+
+
+def test_an_empty_interval_label_is_allowed(tmp_path: Path) -> None:
+    """``label: str = ""`` is the dataclass default, so empty is a real value
+    rather than an omission. Pinned so the padding rule above cannot grow into
+    refusing it."""
+    _appended_with_interval(tmp_path, hflow.Interval(start_ns=0, end_ns=10))
+
+    connection = open_catalog_connection(tmp_path / "catalog")
+    try:
+        assert connection.execute("SELECT label FROM intervals").fetchall() == [("",)]
+    finally:
+        connection.close()
+
+
 def test_a_zero_length_interval_is_allowed(tmp_path: Path) -> None:
     """An instant is a real thing to record, so only end < start is refused.
 


### PR DESCRIPTION
Closes #392.

`_normalized_intervals` validated both bounds and nothing else, so a label reached the run fingerprint unchecked. The fingerprint sorts `(start_ns, end_ns, label)` tuples, so a non-string only ever met a string when two intervals shared both bounds:

```
single None label                   STORED
None + str, same bounds             TypeError
None + str, different bounds        STORED
```

A check labelling spans from a lookup passes every fixture where the spans differ, then fails on a corpus where two land together. The label is now validated first, before the bounds, since the bound errors interpolate it.

Non-string is refused rather than coerced, per your call and the precedent the bounds set with `bool`. Empty stays legal because `label: str = ""` is the dataclass default; padding is refused for the reason an `observation_id` already is, since both are stored verbatim.

Five tests beside the existing bound-rule ones. Four fail with the guard deleted: a `None` label, two intervals sharing bounds, an unserializable label, a padded label. The fifth pins that empty still stores and passes either way, so it is a regression guard rather than a reproduction and its docstring says so.

The `object()` case moved from `json.dumps` at `:612` into `_normalized_intervals`, so its message now names the check. Nothing asserted on the old text. `_run_fingerprint` is unchanged.

Full suite: 1475 passed, 11 skipped. The 17 `tests/test_packaging.py` failures are the native overlay build, which needs CPython on Linux and fails identically on unmodified `main` here. `ruff check` and `ruff format --check` clean.