### PR TITLE
fix(lerobot): refuse depth videos before conversion

### DIFF
--- a/docs/how-to/import-lerobot-v3.md
+++ b/docs/how-to/import-lerobot-v3.md
@@ -82,17 +82,24 @@ channels named `/observation.state` and `/action`.
 
 | Feature | Support |
 |---|---|
-| Video features with `dtype: video` | Supported; select them with `--camera` |
+| RGB video features with `dtype: video` | Supported; select them with `--camera` |
 | One-dimensional fixed-width `float32` observation state | Supported |
 | One-dimensional fixed-width `float32` action | Supported |
 | Image-only features | Not supported |
-| Language tensors, depth maps, or arbitrary nested features | Not supported |
+| Video depth maps | Refused before publication; the RGB H.264 path cannot preserve their values |
+| Language tensors, image depth maps, or arbitrary nested features | Not supported |
 
 The importer reads `meta/info.json`, the episode index, Parquet feature
 columns, frame rate, episode boundaries, and video-path templates. Episode
 metadata split across several `meta/episodes` shards is read in full, so
 every episode keeps its own video window. It refuses an unsupported or
 missing required feature before publishing an episode.
+
+Depth video features are detected through LeRobot's current
+`info.is_depth_map` marker and its legacy `info["video.is_depth_map"]` and
+`video_info["video.is_depth_map"]` spellings. Selecting one fails before an
+episode or prepared manifest is published. Converting it through the RGB path
+would discard the depth quantization and physical-unit semantics.
 
 Every output records the source repository, resolved commit, source episode
 index, task, embodiment, importer version, and FFmpeg build. Video is encoded

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -2,7 +2,7 @@
 
 The converter reads repository metadata (feature schema, fps, episode
 boundaries, video paths) instead of encoding dataset-specific assumptions.
-Every selected camera is converted into its own foxglove.CompressedVideo
+Every selected RGB camera is converted into its own foxglove.CompressedVideo
 channel; numeric state and action schemas are derived from the declared
 dtype and shape, failing loud before conversion when a feature is
 unsupported.
@@ -602,6 +602,23 @@ class _NumericSchema:
     dim: int
 
 
+def _is_depth_map_feature(feature_specification: object) -> bool:
+    if not isinstance(feature_specification, dict):
+        return False
+    feature_information = feature_specification.get("info")
+    legacy_video_information = feature_specification.get("video_info")
+    return (
+        isinstance(feature_information, dict)
+        and (
+            feature_information.get("is_depth_map") is True
+            or feature_information.get("video.is_depth_map") is True
+        )
+    ) or (
+        isinstance(legacy_video_information, dict)
+        and legacy_video_information.get("video.is_depth_map") is True
+    )
+
+
 def _derive_numeric_schema(feature_name: str, feature_specification: dict) -> _NumericSchema:
     declared_dtype = feature_specification.get("dtype")
     declared_shape = feature_specification.get("shape") or []
@@ -649,9 +666,10 @@ def import_lerobot_dataset(
     in the workspace -- the local directory itself, or the bucket mirror under
     ``HFLOW_MIRROR_DIR`` -- and is never uploaded into a bucket root.
 
-    Dataset v3 video features and one-dimensional, fixed-width float32 state
-    and action vectors are supported. Unsupported feature layouts fail before
-    any episode is published. The returned values are the published episode
+    Dataset v3 RGB video features and one-dimensional, fixed-width float32
+    state and action vectors are supported. Depth-marked videos and other
+    unsupported feature layouts fail before any episode is published. The
+    returned values are the published episode
     URIs (absolute path strings for local roots; ``s3://`` / ``gs://`` /
     ``az://`` object URIs for buckets).
     """
@@ -703,6 +721,15 @@ def import_lerobot_dataset(
                 f"camera key '{camera_key}' not found in dataset. "
                 f"Available: {source_archive['video_keys']}"
             )
+
+    dataset_features = source_archive["info"].get("features")
+    if isinstance(dataset_features, dict):
+        for camera_key in resolved_camera_keys:
+            if _is_depth_map_feature(dataset_features.get(camera_key)):
+                raise ValueError(
+                    f"LeRobot feature '{camera_key}' is a depth-map video; HFlow's RGB H.264 "
+                    "conversion cannot preserve depth values"
+                )
 
     # Numeric schemas derived from metadata (fail before any conversion)
     numeric_schemas = {

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -603,19 +603,35 @@ class _NumericSchema:
 
 
 def _is_depth_map_feature(feature_specification: object) -> bool:
+    """Whether LeRobot marks this feature as depth, by its own definition.
+
+    Deliberately truthy rather than ``is True``, matching LeRobot's own
+    ``is_depth_map()`` in ``lerobot/configs/video.py``, which returns
+    ``bool(info.get("is_depth_map") or ...)``. Anything LeRobot calls depth
+    must be refused here; a stricter test would let a corpus carrying
+    ``"is_depth_map": "true"`` or ``1`` through the RGB path, which is the
+    outcome the refusal exists to prevent.
+
+    Canonically ``feature["info"]["is_depth_map"]``, with the legacy
+    ``video.is_depth_map`` spelling in either ``info`` or a separate
+    ``video_info`` dict.
+    """
     if not isinstance(feature_specification, dict):
         return False
     feature_information = feature_specification.get("info")
     legacy_video_information = feature_specification.get("video_info")
-    return (
-        isinstance(feature_information, dict)
-        and (
-            feature_information.get("is_depth_map") is True
-            or feature_information.get("video.is_depth_map") is True
+    return bool(
+        (
+            isinstance(feature_information, dict)
+            and (
+                feature_information.get("is_depth_map")
+                or feature_information.get("video.is_depth_map")
+            )
         )
-    ) or (
-        isinstance(legacy_video_information, dict)
-        and legacy_video_information.get("video.is_depth_map") is True
+        or (
+            isinstance(legacy_video_information, dict)
+            and legacy_video_information.get("video.is_depth_map")
+        )
     )
 
 

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -182,6 +182,15 @@ def test_import_rejects_required_boolean_dimension_without_dataset_output(
         prep,
         "_ensure_source_archive",
         lambda source, cache_dir: {
+            "info": {
+                "features": {
+                    prep.DEFAULT_CAMERA_KEY: {
+                        "dtype": "video",
+                        "shape": [480, 640, 3],
+                        "info": {"is_depth_map": False},
+                    }
+                }
+            },
             "numeric_features": {
                 "action": {"dtype": "float32", "shape": [True]},
                 "observation.state": {"dtype": "float32", "shape": [6]},
@@ -1045,7 +1054,16 @@ def _stub_single_episode_source_archive(
 ) -> dict:
     cache_dir.mkdir(parents=True, exist_ok=True)
     return {
-        "info": {"robot_type": "pusht"},
+        "info": {
+            "robot_type": "pusht",
+            "features": {
+                prep.DEFAULT_CAMERA_KEY: {
+                    "dtype": "video",
+                    "shape": [480, 640, 3],
+                    "info": {"is_depth_map": False},
+                }
+            },
+        },
         "fps": 30,
         "data_path": "data/{chunk_index}/{file_index}.parquet",
         "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
@@ -1099,6 +1117,53 @@ def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
     monkeypatch.setattr(prep, "_convert_single_episode", fake_convert)
     return published_keys
+
+
+@pytest.mark.parametrize(
+    "depth_metadata",
+    [
+        {"info": {"is_depth_map": True}},
+        {"info": {"video.is_depth_map": True}},
+        {"video_info": {"video.is_depth_map": True}},
+    ],
+)
+def test_import_refuses_a_depth_video_before_publishing_dataset_output(
+    depth_metadata: dict,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+
+    def ensure_depth_archive(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+        archive = _stub_single_episode_source_archive(dataset_source, cache_dir)
+        archive["info"]["features"] = {
+            prep.DEFAULT_CAMERA_KEY: {
+                "dtype": "video",
+                "shape": [24, 32, 1],
+                **depth_metadata,
+            }
+        }
+        return archive
+
+    monkeypatch.setattr(
+        prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
+    )
+    monkeypatch.setattr(prep, "_ensure_source_archive", ensure_depth_archive)
+    _install_publish_through_convert(monkeypatch, tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"observation\.image.*depth-map video.*cannot preserve depth values",
+    ):
+        prep.import_lerobot_dataset(
+            dataset_repo="fake/repo",
+            revision="main",
+            output_dir=output_dir,
+            episode_index=0,
+        )
+
+    assert not (output_dir / "landing").exists()
+    assert not (output_dir / "prepared-manifest.json").exists()
 
 
 def test_import_returns_local_uris_and_keeps_cache_beside_landing(

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -1125,6 +1125,14 @@ def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         {"info": {"is_depth_map": True}},
         {"info": {"video.is_depth_map": True}},
         {"video_info": {"video.is_depth_map": True}},
+        # LeRobot's own is_depth_map() is truthy, not an identity test, so a
+        # corpus marked with a string or an int is depth to LeRobot and must
+        # not be RGB to us. An `is True` check here would send exactly these
+        # down the H.264 path.
+        {"info": {"is_depth_map": "true"}},
+        {"info": {"is_depth_map": 1}},
+        {"info": {"video.is_depth_map": "yes"}},
+        {"video_info": {"video.is_depth_map": 1}},
     ],
 )
 def test_import_refuses_a_depth_video_before_publishing_dataset_output(


### PR DESCRIPTION
## Summary

- detect LeRobot depth video features through the current and legacy metadata markers
- refuse selected depth videos before publishing an episode or prepared manifest
- keep explicitly non-depth RGB videos on the existing import path
- document the supported boundary and why RGB H.264 cannot preserve depth values

## Why

The importer currently treats every `dtype: video` feature as RGB. Current LeRobot depth streams carry `is_depth_map` metadata and may store quantized 12-bit physical depth in HEVC Main 12.

A controlled four-frame input changed from `hevc/gray12le` to `h264/yuv420p10le` through the current transform, and its decoded values were no longer exactly equal. Allowing that path would silently discard depth precision and the metadata needed to recover physical units.

This PR takes the smallest safe scope from #399: fail loud before publication. It does not choose a canonical depth representation or claim end-to-end depth support.

Closes #399.

## Validation

- TDD red: all three depth-marker cases initially failed with `DID NOT RAISE ValueError`
- TDD green: `uv run pytest -q tests/test_lerobot_converter.py` — 50 passed
- `uv run ruff check --fix` — passed
- `uv run ruff format` — 215 files unchanged
- `uv run ty check` — passed
- `uv run pytest -q --ignore=tests/test_packaging.py` — 1477 passed, 6 skipped
- `uv run pytest -q tests/test_packaging.py` — 17 failed, 1 passed because this machine has no `cc`; the same clean-main environment limitation is reported separately in #398

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
