### PR TITLE
docs: document C compiler prerequisite for default tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,22 @@ You need:
 
 - Git and [uv](https://docs.astral.sh/uv/)
 - Python 3.11 or newer
+- A system C compiler/toolchain that provides `cc` for the native-overlay tests
 - ffmpeg and ffprobe on `PATH` for the test suite
 - Docker with Compose v2 only when working on the Airflow runtime integration
 - [lychee](https://github.com/lycheeverse/lychee) when editing Markdown links
+
+`uv sync --locked` installs the Python-side native-build dependencies, including
+Cython and setuptools, but it cannot install the system compiler they invoke.
+Before running the default suite, confirm that a compiler is available:
+
+```bash
+command -v cc
+```
+
+On Ubuntu (including WSL2), install the toolchain with
+`sudo apt-get install build-essential` if that command prints nothing. On
+macOS, install the Xcode Command Line Tools with `xcode-select --install`.
 
 ## Platform support
 


### PR DESCRIPTION
## Summary

Document the system C compiler/toolchain required by the default native-overlay tests.

`uv sync --locked` installs the Python-side build dependencies (including Cython and setuptools), but it cannot install the external compiler that setuptools invokes. A contributor following the current setup can therefore reach the packaging tests with no `cc` available and get repeated native-build failures.

This update:

- lists a system toolchain providing `cc` as a development prerequisite;
- adds `command -v cc` as a portable preflight;
- gives actionable setup guidance for Ubuntu/WSL2 (`build-essential`) and macOS (Xcode Command Line Tools);
- makes the boundary between `uv`-managed Python dependencies and the system compiler explicit.

No runtime or test behavior is changed.

Closes #398.

## Validation

Documentation-only change. The diff was checked against current `main`; no Python behavior changed. The repository's external-link check was not run from this environment.

AI assistance disclosure: AI assistance was used to inspect the issue and prepare this focused documentation update.