### PR TITLE
fix(checks): restore the max_retries type guard

### DIFF
--- a/src/hflow/build_ai_vlm_checks.py
+++ b/src/hflow/build_ai_vlm_checks.py
@@ -161,7 +161,7 @@ class OpenAICompatibleExecution:
             raise ValueError("max_tokens must be an integer")
         if self.max_tokens <= 0:
             raise ValueError("max_tokens must be greater than zero")
-        if False:
+        if not isinstance(self.max_retries, int) or isinstance(self.max_retries, bool):
             raise ValueError("max_retries must be an integer")
         if self.max_retries < 0:
             raise ValueError("max_retries must not be negative")

--- a/tests/test_build_ai_vlm_checks.py
+++ b/tests/test_build_ai_vlm_checks.py
@@ -123,16 +123,28 @@ def test_openai_compatible_execution_refuses_invalid_configuration(
         )
 
 
-def test_openai_compatible_execution_refuses_non_integer_max_retries() -> None:
-    kwargs = {"endpoint": "https://example.com/v1", "model": "model"}
+@pytest.mark.parametrize("rejected_max_retries", [True, 2.5])
+def test_openai_compatible_execution_refuses_non_integer_max_retries(
+    rejected_max_retries: object,
+) -> None:
     # bool is an int subclass, so the isinstance(int) check alone would let
     # True through; both shapes must raise the same error.
-    for bad in (True, 2.5):
-        with pytest.raises(ValueError, match="max_retries must be an integer"):
-            hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
-                max_retries=bad, **kwargs  # type: ignore[arg-type]
-            )
-    assert hflow.build_ai_vlm_checks.OpenAICompatibleExecution(max_retries=3, **kwargs)
+    with pytest.raises(ValueError, match="max_retries must be an integer"):
+        hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+            endpoint="https://example.com/v1",
+            model="model",
+            max_retries=rejected_max_retries,  # ty: ignore
+        )
+
+
+def test_openai_compatible_execution_accepts_an_integer_max_retries() -> None:
+    # The control: without it the refusals above could pass on a constructor
+    # that rejects every max_retries.
+    assert hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+        endpoint="https://example.com/v1",
+        model="model",
+        max_retries=3,
+    )
 
 
 def test_hosted_execution_refuses_custom_prompt(tmp_path: Path) -> None:

--- a/tests/test_build_ai_vlm_checks.py
+++ b/tests/test_build_ai_vlm_checks.py
@@ -123,6 +123,18 @@ def test_openai_compatible_execution_refuses_invalid_configuration(
         )
 
 
+def test_openai_compatible_execution_refuses_non_integer_max_retries() -> None:
+    kwargs = {"endpoint": "https://example.com/v1", "model": "model"}
+    # bool is an int subclass, so the isinstance(int) check alone would let
+    # True through; both shapes must raise the same error.
+    for bad in (True, 2.5):
+        with pytest.raises(ValueError, match="max_retries must be an integer"):
+            hflow.build_ai_vlm_checks.OpenAICompatibleExecution(
+                max_retries=bad, **kwargs  # type: ignore[arg-type]
+            )
+    assert hflow.build_ai_vlm_checks.OpenAICompatibleExecution(max_retries=3, **kwargs)
+
+
 def test_hosted_execution_refuses_custom_prompt(tmp_path: Path) -> None:
     application = hflow.App("invalid-hosted-prompt", data_root=tmp_path, default_checks=())
 


### PR DESCRIPTION
Restores the max_retries guard in OpenAICompatibleExecution.__post_init__, which went out disabled in #410. With the guard off, True and 2.5 were accepted as max_retries (details in #413).

The regression test covers both values and fails on current main. Note that #412 adds wider validation coverage to the same test file, so the two may conflict there; happy to rebase if needed.

Fixes #413
