### PR TITLE
test(lerobot): cover metadata refusal paths

### DIFF
--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -1,0 +1,184 @@
+"""Regression coverage for LeRobot metadata refusal boundaries (#405)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.request import Request
+
+import pytest
+
+import hflow.importers.lerobot as prep
+
+
+_REPO = "fake/repo"
+_SHA = "abcdef1234567890"
+
+
+class _Response:
+    def __init__(self, body: bytes, *, link: str | None = None) -> None:
+        self._body = body
+        self.headers = {} if link is None else {"Link": link}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def _stub_repo_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        prep,
+        "_hf_repo_info",
+        lambda _repo, _revision: {"sha": _SHA, "license": "apache-2.0"},
+    )
+
+
+def _assert_no_dataset_output(output_dir: Path) -> None:
+    assert not (output_dir / "landing").exists()
+    assert not (output_dir / "prepared-manifest.json").exists()
+
+
+def _import(output_dir: Path) -> None:
+    prep.import_lerobot_dataset(dataset_repo=_REPO, output_dir=output_dir)
+
+
+def test_import_refuses_repository_without_lerobot_v3_info(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(RuntimeError, match="^meta/info.json not found; not a LeRobot v3 repository$"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_refuses_info_json_that_is_not_an_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(
+        prep,
+        "_hf_tree",
+        lambda _repo, _revision, _path: [{"path": "meta/info.json", "type": "file"}],
+    )
+    monkeypatch.setattr(prep.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(b"[]"))
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="^LeRobot meta/info.json is not a JSON object$"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("data_path", "", "LeRobot meta/info.json must define a non-empty data_path template"),
+        ("video_path", "", "LeRobot meta/info.json must define a non-empty video_path template"),
+    ],
+)
+def test_import_refuses_empty_path_templates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    _stub_repo_info(monkeypatch)
+    info = {
+        "fps": 30,
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {},
+    }
+    info[field] = value
+    monkeypatch.setattr(prep, "_fetch_info_json", lambda _repo, _revision, _cache: info)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_refuses_repository_without_episode_parquets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(
+        prep,
+        "_fetch_info_json",
+        lambda _repo, _revision, _cache: {
+            "fps": 30,
+            "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+            "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+            "features": {},
+        },
+    )
+    monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(RuntimeError, match="^no meta/episodes parquet files found$"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_refuses_tree_response_that_is_not_a_list_of_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(prep.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(b"{}"))
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(
+        ValueError,
+        match="^Hugging Face tree response for 'meta' is not a list of objects$",
+    ):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_refuses_repeated_pagination_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    initial_url = f"https://huggingface.co/api/datasets/{_REPO}/tree/{_SHA}/meta?recursive=true"
+
+    def fake_urlopen(request: Request, **_kwargs: object) -> _Response:
+        assert request.full_url == initial_url
+        return _Response(b"[]", link=f'<{initial_url}>; rel="next"')
+
+    monkeypatch.setattr(prep.urllib.request, "urlopen", fake_urlopen)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="repeated an already fetched pagination URL"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_refuses_invalid_pagination_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_repo_info(monkeypatch)
+    invalid_url = "https://[invalid"
+
+    def fake_urlopen(_request: Request, **_kwargs: object) -> _Response:
+        return _Response(b"[]", link=f'<{invalid_url}>; rel="next"')
+
+    monkeypatch.setattr(prep.urllib.request, "urlopen", fake_urlopen)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="contains an invalid pagination URL"):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from urllib.request import Request
 
-import hflow.importers.lerobot as prep
 import pytest
+
+import hflow.importers.lerobot as prep
 
 _REPO = "fake/repo"
 _SHA = "abcdef1234567890"
+
+
+def _exactly(message: str) -> str:
+    """A ``match=`` pattern pinning the whole message, metacharacters and all.
+
+    #405 asks for these to be byte-identical, and several contain a ``.``
+    (``meta/info.json``), which unescaped would also match ``meta/infoXjson``.
+    """
+    return rf"^{re.escape(message)}$"
 
 
 class _Response:
@@ -51,7 +62,9 @@ def test_import_refuses_repository_without_lerobot_v3_info(
     monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
     output_dir = tmp_path / "out"
 
-    with pytest.raises(RuntimeError, match=r"^meta/info.json not found; not a LeRobot v3 repository$"):
+    with pytest.raises(
+        RuntimeError, match=_exactly("meta/info.json not found; not a LeRobot v3 repository")
+    ):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -69,7 +82,7 @@ def test_import_refuses_info_json_that_is_not_an_object(
     monkeypatch.setattr(prep.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(b"[]"))
     output_dir = tmp_path / "out"
 
-    with pytest.raises(ValueError, match=r"^LeRobot meta/info.json is not a JSON object$"):
+    with pytest.raises(ValueError, match=_exactly("LeRobot meta/info.json is not a JSON object")):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -100,7 +113,7 @@ def test_import_refuses_empty_path_templates(
     monkeypatch.setattr(prep, "_fetch_info_json", lambda _repo, _revision, _cache: info)
     output_dir = tmp_path / "out"
 
-    with pytest.raises(ValueError, match=f"^{message}$"):
+    with pytest.raises(ValueError, match=_exactly(message)):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -123,7 +136,7 @@ def test_import_refuses_repository_without_episode_parquets(
     monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
     output_dir = tmp_path / "out"
 
-    with pytest.raises(RuntimeError, match=r"^no meta/episodes parquet files found$"):
+    with pytest.raises(RuntimeError, match=_exactly("no meta/episodes parquet files found")):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -138,7 +151,7 @@ def test_import_refuses_tree_response_that_is_not_a_list_of_objects(
 
     with pytest.raises(
         ValueError,
-        match=r"^Hugging Face tree response for 'meta' is not a list of objects$",
+        match=_exactly("Hugging Face tree response for 'meta' is not a list of objects"),
     ):
         _import(output_dir)
 
@@ -151,8 +164,18 @@ def test_import_refuses_repeated_pagination_url(
     _stub_repo_info(monkeypatch)
     initial_url = f"https://huggingface.co/api/datasets/{_REPO}/tree/{_SHA}/meta?recursive=true"
 
+    fetched_urls: list[str] = []
+
     def fake_urlopen(request: Request, **_kwargs: object) -> _Response:
         assert request.full_url == initial_url
+        fetched_urls.append(request.full_url)
+        # Bounded on purpose. Without the visited-URL guard this server would
+        # feed the loop its own URL forever, and the test would hang rather
+        # than fail: CI would report nothing and a human would wait. Dropping
+        # the `next` link after a few passes lets a guard-less loop terminate
+        # and fail on the missing refusal instead.
+        if len(fetched_urls) > 4:
+            return _Response(b"[]")
         return _Response(b"[]", link=f'<{initial_url}>; rel="next"')
 
     monkeypatch.setattr(prep.urllib.request, "urlopen", fake_urlopen)
@@ -161,6 +184,10 @@ def test_import_refuses_repeated_pagination_url(
     with pytest.raises(ValueError, match="repeated an already fetched pagination URL"):
         _import(output_dir)
 
+    # The guard fires on the second pass, before a second fetch: one request
+    # went out, not five. Without this the bound above could be doing the
+    # stopping and the test would still pass.
+    assert fetched_urls == [initial_url]
     _assert_no_dataset_output(output_dir)
 
 

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.request import Request
 
-import pytest
-
 import hflow.importers.lerobot as prep
-
+import pytest
 
 _REPO = "fake/repo"
 _SHA = "abcdef1234567890"
@@ -53,7 +51,7 @@ def test_import_refuses_repository_without_lerobot_v3_info(
     monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
     output_dir = tmp_path / "out"
 
-    with pytest.raises(RuntimeError, match="^meta/info.json not found; not a LeRobot v3 repository$"):
+    with pytest.raises(RuntimeError, match=r"^meta/info.json not found; not a LeRobot v3 repository$"):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -71,7 +69,7 @@ def test_import_refuses_info_json_that_is_not_an_object(
     monkeypatch.setattr(prep.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(b"[]"))
     output_dir = tmp_path / "out"
 
-    with pytest.raises(ValueError, match="^LeRobot meta/info.json is not a JSON object$"):
+    with pytest.raises(ValueError, match=r"^LeRobot meta/info.json is not a JSON object$"):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -125,7 +123,7 @@ def test_import_refuses_repository_without_episode_parquets(
     monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
     output_dir = tmp_path / "out"
 
-    with pytest.raises(RuntimeError, match="^no meta/episodes parquet files found$"):
+    with pytest.raises(RuntimeError, match=r"^no meta/episodes parquet files found$"):
         _import(output_dir)
 
     _assert_no_dataset_output(output_dir)
@@ -140,7 +138,7 @@ def test_import_refuses_tree_response_that_is_not_a_list_of_objects(
 
     with pytest.raises(
         ValueError,
-        match="^Hugging Face tree response for 'meta' is not a list of objects$",
+        match=r"^Hugging Face tree response for 'meta' is not a list of objects$",
     ):
         _import(output_dir)
 


### PR DESCRIPTION
## Summary

Add regression coverage for the eight LeRobot importer metadata refusals called out in #405.

The tests exercise the supported `import_lerobot_dataset` entry point and pin failures for:

- repositories without `meta/info.json`;
- `meta/info.json` values that are not JSON objects;
- empty `data_path` and `video_path` templates;
- repositories without `meta/episodes` parquet shards;
- tree responses that are not lists of objects;
- repeated pagination URLs;
- malformed pagination URLs.

The pagination cases use a small `urlopen` response stub so they exercise the real `_hf_tree` loop while remaining network-free. Each refusal also asserts that no landing directory or prepared manifest is published.

No production behavior or refusal text is changed.

Closes #405.

## Validation

- Tests are isolated from network access and use the existing pytest monkeypatch style.
- GitHub Actions is the authoritative full-suite validation for this branch.

AI assistance disclosure: AI assistance was used to inspect the open issue, trace the importer paths, prepare the focused regression tests, and review the resulting change.