### PR TITLE
fix(example): include max_retries in Build AI run fingerprint

### DIFF
--- a/docs/how-to/run-build-ai-evaluation.md
+++ b/docs/how-to/run-build-ai-evaluation.md
@@ -335,7 +335,7 @@ For an unauthenticated self-hosted endpoint, add
 default because Build AI did not publish one; set it explicitly when a model
 comparison requires a fixed non-default value. The run fingerprint captures
 the endpoint, model, prompt contents, schema mode, temperature, token limit,
-selected rows, sources, and tasks so incompatible experiments cannot silently
+retry policy, selected rows, sources, and tasks so incompatible experiments cannot silently
 reuse the same output directory.
 
 ## Inspect and compare results

--- a/docs/how-to/run-build-ai-evaluation.md
+++ b/docs/how-to/run-build-ai-evaluation.md
@@ -335,8 +335,8 @@ For an unauthenticated self-hosted endpoint, add
 default because Build AI did not publish one; set it explicitly when a model
 comparison requires a fixed non-default value. The run fingerprint captures
 the endpoint, model, prompt contents, schema mode, temperature, token limit,
-retry policy, selected rows, sources, and tasks so incompatible experiments cannot silently
-reuse the same output directory.
+retry policy, selected rows, sources, and tasks so incompatible experiments
+cannot silently reuse the same output directory.
 
 ## Inspect and compare results
 

--- a/examples/build_ai_evaluation/evaluate.py
+++ b/examples/build_ai_evaluation/evaluate.py
@@ -519,6 +519,7 @@ def _run_metadata_document(configuration: EvaluationConfiguration) -> dict[str, 
         "response_format": configuration.response_format.value,
         "temperature": configuration.temperature,
         "max_tokens": configuration.max_tokens,
+        "max_retries": configuration.max_retries,
         "row_limit_per_source": configuration.row_limit_per_source,
         "prompts": prompt_metadata,
     }
@@ -528,8 +529,8 @@ def _run_metadata_document(configuration: EvaluationConfiguration) -> dict[str, 
         "fingerprint": hflow.fingerprint_contract(result_contract),
         **result_contract,
         "api_key_environment_variable": configuration.api_key_environment_variable,
+        # Execution parallelism changes throughput, not evaluation results.
         "worker_count": configuration.worker_count,
-        "max_retries": configuration.max_retries,
     }
 
 

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -29,6 +29,7 @@ from examples.build_ai_evaluation.evaluate import (
     _argument_parser,
     _prepare_output_directory,
     _run_configuration_from_arguments,
+    _run_metadata_document,
     _sample_result,
     _sanitize_base_url,
     iter_evaluation_frames,
@@ -474,6 +475,30 @@ def test_prepare_output_directory_writes_and_resumes_the_same_fingerprint(
     assert second.label == "run-label"
     assert second.model == "vision-model"
     assert second.prompt_sha256s == first.prompt_sha256s
+
+
+def test_run_fingerprint_changes_with_max_retries_but_not_worker_count(tmp_path: Path) -> None:
+    configuration = _evaluation_configuration(tmp_path / "run")
+    original = _run_metadata_document(configuration)
+    retried = _run_metadata_document(
+        replace(configuration, max_retries=configuration.max_retries + 1)
+    )
+    parallel = _run_metadata_document(
+        replace(configuration, worker_count=configuration.worker_count + 1)
+    )
+
+    assert retried["fingerprint"] != original["fingerprint"]
+    assert parallel["fingerprint"] == original["fingerprint"]
+
+
+def test_run_fingerprint_for_unchanged_methodology_is_stable(tmp_path: Path) -> None:
+    configuration = _evaluation_configuration(tmp_path / "run")
+    document = _run_metadata_document(configuration)
+
+    assert (
+        document["fingerprint"]
+        == "6e58a791b9fb05d793fbb10cfbb3f894d6f896691d8285e90fa5fc6e4685aa15"
+    )
 
 
 def test_prepare_output_directory_refuses_a_different_experiment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Include `max_retries` in the Build AI evaluation result contract so runs with different retry policies cannot silently reuse the same output directory.

`max_retries` changes which requests recover from transient failures and therefore changes evaluation coverage. `worker_count` remains outside the fingerprint because it changes throughput only, not methodology or results.

## Changes

- move `max_retries` into the hashed result contract
- keep `worker_count` execution-only, with an explanatory comment
- add regression coverage proving retry changes alter the fingerprint while worker-count changes do not
- pin the unchanged methodology fingerprint to catch accidental identity drift
- document retry policy as part of the run fingerprint

Existing run directories created before this change will no longer match the new fingerprint, which is intentional because their retry methodology was not represented in their identity.

## Validation

- `ruff format` on the changed Python files — passed
- `ruff check` on the changed Python files — passed
- `git diff --check` — passed
- focused fingerprint behavior verified directly in the locked example environment: stable golden fingerprint, changed fingerprint for `max_retries`, unchanged fingerprint for `worker_count`
- full pytest collection is blocked on this Windows machine by the repository's POSIX `fcntl` dependency (`ModuleNotFoundError: fcntl`)

Closes #422

AI assistance disclosure: AI assistance was used to inspect the issue and code, prepare the focused implementation and tests, run validation, and review the resulting diff.