### PR TITLE
refactor: remove unreachable validation guards

### DIFF
--- a/examples/egosuite_evaluation/evaluate.py
+++ b/examples/egosuite_evaluation/evaluate.py
@@ -170,7 +170,7 @@ def load_projected_hand_label_report(
             f"{schema_version!r}; supported value is {SCHEMA_VERSION}"
         )
     label_type = report_payload.get("label_type")
-    if not isinstance(label_type, str) or label_type != PROJECTED_HAND_LABEL_TYPE:
+    if label_type != PROJECTED_HAND_LABEL_TYPE:
         raise ValueError(
             f"projected-hand label report {report_path} field 'label_type' has value "
             f"{label_type!r}; supported value is {PROJECTED_HAND_LABEL_TYPE!r}"

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -160,8 +160,6 @@ def _episode_identity_matches(
 
     reader = None
     try:
-        if local_episode_path.stat().st_size < 1:
-            return False
         reader = open_reader(local_episode_path)
         metadata_records = reader.metadata()
     except (OSError, McapError, ValueError):
@@ -206,6 +204,7 @@ def _try_reuse_completed_episode(
     if not storage.exists(relative_key):
         return None
     try:
+        # Avoid fetching an empty remote object only to reject it as invalid MCAP.
         if storage.file_size(relative_key) < 1:
             return None
         local_episode_path = storage.fetch(relative_key)


### PR DESCRIPTION
Closes #423.

## Summary

Removes the redundant post-fetch zero-size check from the LeRobot resume path, while documenting why the pre-fetch check remains useful for remote storage. It also simplifies the EgoSuite label-type check to direct comparison. The separate `bool` schema-version guard remains unchanged and tested.

## Why

An empty MCAP is already rejected by the existing reader exception path after fetch, and a non-string label type cannot equal the supported string constant. Removing those dead conditions reduces misleading defensive logic without changing observable behavior. The storage-level size check remains because it can avoid fetching an empty remote object.

## Validation

- `uv run ruff check` — passed
- `uv run ruff format --check` — 222 files already formatted
- `uv run ty check` — passed
- `uv run pytest -q tests/test_lerobot_converter.py` — 75 passed
- `uv run --locked --project examples/egosuite_evaluation ruff check examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation ruff format --check examples/egosuite_evaluation` — 6 files already formatted
- `uv run --locked --project examples/egosuite_evaluation ty check --project examples/egosuite_evaluation --extra-search-path . examples/egosuite_evaluation` — passed
- `uv run --locked --project examples/egosuite_evaluation pytest -q examples/egosuite_evaluation/tests` — 55 passed
- Required bool guard case — 1 passed
- Full root suite — 1,578 passed, 6 skipped, 1 unrelated local FFmpeg 9.0 failure (`-filter_script:v` is unavailable)

## Checklist

- [x] No test changes: #423 explicitly identifies these branches as dead; existing outcome-focused coverage passes.
- [x] No documentation update: observable behavior, flags, formats, and requirements are unchanged.
- [x] I ran `uv run ruff check`, `uv run ruff format --check`, and `uv run ty check`.
- [x] I ran the relevant pytest suites.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] Stored-data compatibility is unchanged; no behavior-version bump is required.

Developed with assistance from OpenAI Codex.