### PR TITLE
fix(example): persist Build AI missing-key policy

### DIFF
--- a/examples/build_ai_evaluation/evaluate.py
+++ b/examples/build_ai_evaluation/evaluate.py
@@ -529,6 +529,8 @@ def _run_metadata_document(configuration: EvaluationConfiguration) -> dict[str, 
         "fingerprint": hflow.fingerprint_contract(result_contract),
         **result_contract,
         "api_key_environment_variable": configuration.api_key_environment_variable,
+        # Waiving API-key presence affects replay setup, not evaluation results.
+        "allow_missing_api_key": configuration.allow_missing_api_key,
         # Execution parallelism changes throughput, not evaluation results.
         "worker_count": configuration.worker_count,
     }

--- a/examples/build_ai_evaluation/tests/test_evaluation.py
+++ b/examples/build_ai_evaluation/tests/test_evaluation.py
@@ -486,9 +486,13 @@ def test_run_fingerprint_changes_with_max_retries_but_not_worker_count(tmp_path:
     parallel = _run_metadata_document(
         replace(configuration, worker_count=configuration.worker_count + 1)
     )
+    missing_key_policy_changed = _run_metadata_document(
+        replace(configuration, allow_missing_api_key=not configuration.allow_missing_api_key)
+    )
 
     assert retried["fingerprint"] != original["fingerprint"]
     assert parallel["fingerprint"] == original["fingerprint"]
+    assert missing_key_policy_changed["fingerprint"] == original["fingerprint"]
 
 
 def test_run_fingerprint_for_unchanged_methodology_is_stable(tmp_path: Path) -> None:
@@ -603,6 +607,7 @@ def test_run_metadata_document_persists_the_existing_schema(tmp_path: Path) -> N
     assert document == metadata.to_json_dict()
     assert set(document) == {
         "adapter_schema_version",
+        "allow_missing_api_key",
         "api_key_environment_variable",
         "base_url",
         "dataset_repository",
@@ -623,6 +628,7 @@ def test_run_metadata_document_persists_the_existing_schema(tmp_path: Path) -> N
         "temperature",
         "worker_count",
     }
+    assert document["allow_missing_api_key"] is True
     assert document["label"] == "run-label"
     assert document["row_limit_per_source"] is None
     assert document["schema_version"] == 1


### PR DESCRIPTION
## Summary

Fixes the Build AI evaluation example run metadata so unauthenticated-endpoint runs can be replayed from their own `run.json` record.

## Changes

- Persist `configuration.allow_missing_api_key` in the generated run metadata document.
- Keep `allow_missing_api_key` outside the hashed `result_contract`, matching its runtime/replay setup role rather than result semantics.
- Add regression coverage for the persisted metadata field and unchanged stable fingerprint when only the missing-key policy changes.

## Testing

- `uv run --locked --project examples/build_ai_evaluation ruff check examples/build_ai_evaluation`
- `uv run --locked --project examples/build_ai_evaluation ruff format --check examples/build_ai_evaluation`
- `uv run --locked --project examples/build_ai_evaluation ty check --project examples/build_ai_evaluation --extra-search-path . examples/build_ai_evaluation`
- `uv run --locked --project examples/build_ai_evaluation pytest -q examples/build_ai_evaluation/tests`
- `git diff --check origin/main...HEAD`

## Related Issue

Fixes #427
