### PR TITLE
refactor(lerobot): parse info.json into a typed archive model

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -23,10 +23,10 @@ import struct
 import subprocess
 import tempfile
 import urllib.request
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from pathlib import Path, PurePosixPath
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 from urllib.parse import urlsplit
 
 from mcap.reader import make_reader
@@ -71,7 +71,20 @@ EPISODE_START_TIME_NS = 1_755_000_000_000_000_000
 HUGGING_FACE_TOKEN_ENVIRONMENT_VARIABLES = ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN")
 
 
-class _EpisodeRow(TypedDict):
+@dataclass(frozen=True)
+class _VideoWindow:
+    """One camera's slice of a chunk video for one episode."""
+
+    chunk_index: str
+    file_index: str
+    from_timestamp: float
+    to_timestamp: float
+
+
+@dataclass(frozen=True)
+class _EpisodeRow:
+    """One episode as the ``meta/episodes`` shards describe it."""
+
     episode_index: int
     task: str
     length: int
@@ -79,17 +92,11 @@ class _EpisodeRow(TypedDict):
     data_file: str
     data_from: int
     data_to: int
-    video_windows: NotRequired[dict[str, "_VideoWindow"]]
-    # MAX of the episode's collector-labeled next.success frames, present only
-    # when the source declares that outcome feature at all.
-    success_outcome: NotRequired[bool]
-
-
-class _VideoWindow(TypedDict):
-    chunk_index: str
-    file_index: str
-    from_timestamp: float
-    to_timestamp: float
+    video_windows: Mapping[str, _VideoWindow] = field(default_factory=dict)
+    # MAX of the episode's collector-labeled next.success frames. None when
+    # the source declares no such outcome feature, which carries no label
+    # either way and must not be read as a failure.
+    success_outcome: bool | None = None
 
 
 class _PublishedEpisode(TypedDict):
@@ -119,16 +126,65 @@ class _DatasetRepositoryInformation(TypedDict):
     license: str
 
 
-class _SourceArchive(TypedDict):
-    info: dict
+@dataclass(frozen=True)
+class _NumericFeature:
+    """A declared float32 feature, still unchecked for a supported shape.
+
+    Shape validation stays deferred to :func:`_derive_numeric_schema` because
+    only selected features are required to be convertible: a corpus may ship
+    a float32 feature HFlow never reads, and refusing the whole import for it
+    would reject datasets that convert correctly today.
+    """
+
+    name: str
+    dtype: str
+    shape: tuple[object, ...]
+
+    @property
+    def declared_shape(self) -> list[object]:
+        """The shape as the source document spelled it, for error messages."""
+        return list(self.shape)
+
+
+@dataclass(frozen=True)
+class _DatasetInformation:
+    """The supported fields of ``meta/info.json``, validated once.
+
+    The raw document stays on disk in the cache; nothing downstream of the
+    parser reads it, so an unknown upstream field is ignored rather than
+    carried around untyped.
+    """
+
     fps: int | float
     data_path: str
     video_path: str
-    episodes: list[_EpisodeRow]
-    video_keys: list[str]
-    numeric_features: dict[str, dict]
+    robot_type: str
+    video_feature_names: tuple[str, ...]
+    numeric_features: Mapping[str, _NumericFeature]
+    depth_map_feature_names: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _SourceArchive:
+    """The downloaded corpus metadata every conversion step reads."""
+
+    dataset_information: _DatasetInformation
+    episodes: tuple[_EpisodeRow, ...]
+    video_keys: tuple[str, ...]
     cache_dir: Path
     dataset: DatasetSource
+
+    @property
+    def fps(self) -> int | float:
+        return self.dataset_information.fps
+
+    @property
+    def data_path(self) -> str:
+        return self.dataset_information.data_path
+
+    @property
+    def video_path(self) -> str:
+        return self.dataset_information.video_path
 
 
 def _landing_relative_key(episode_index: int) -> str:
@@ -557,18 +613,14 @@ def _episode_metadata_cache_path(
     return episodes_metadata_directory / relative_path
 
 
-def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _SourceArchive:
-    """Download the corpus parquets and video chunks needed for the given episodes."""
-    import duckdb
+def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation:
+    """Turn a raw ``meta/info.json`` document into immutable internal values.
 
-    dataset_base_url = (
-        "https://huggingface.co/datasets/"
-        f"{dataset_source.repo_id}/resolve/{dataset_source.revision}"
-    )
-    metadata_directory = cache_dir / "meta"
-    dataset_information = _fetch_info_json(
-        dataset_source.repo_id, dataset_source.revision, cache_dir
-    )
+    Every supported field is validated here, once, so that nothing after this
+    boundary inspects the external document again. Unknown upstream fields are
+    ignored: LeRobot adds them, and refusing one would fail imports that
+    convert correctly.
+    """
     frames_per_second = dataset_information.get("fps")
     if (
         isinstance(frames_per_second, bool)
@@ -588,6 +640,53 @@ def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _S
     )
     if not isinstance(video_path_template, str) or not video_path_template.strip():
         raise ValueError("LeRobot meta/info.json must define a non-empty video_path template")
+
+    dataset_features = dataset_information.get("features")
+    if not isinstance(dataset_features, dict):
+        raise ValueError("LeRobot meta/info.json must define a features object")
+
+    video_feature_names: list[str] = []
+    numeric_features: dict[str, _NumericFeature] = {}
+    depth_map_feature_names: set[str] = set()
+    for feature_name, feature_specification in dataset_features.items():
+        if not isinstance(feature_specification, dict):
+            continue
+        declared_dtype = feature_specification.get("dtype")
+        if declared_dtype == "video":
+            video_feature_names.append(str(feature_name))
+        if _is_depth_map_feature(feature_specification):
+            depth_map_feature_names.add(str(feature_name))
+        if declared_dtype == "float32":
+            declared_shape = feature_specification.get("shape") or []
+            numeric_features[str(feature_name)] = _NumericFeature(
+                name=str(feature_name),
+                dtype=declared_dtype,
+                shape=tuple(declared_shape) if isinstance(declared_shape, list | tuple) else (),
+            )
+
+    return _DatasetInformation(
+        fps=frames_per_second,
+        data_path=data_path_template,
+        video_path=video_path_template,
+        robot_type=str(dataset_information.get("robot_type") or "unknown"),
+        video_feature_names=tuple(sorted(video_feature_names)),
+        numeric_features=numeric_features,
+        depth_map_feature_names=frozenset(depth_map_feature_names),
+    )
+
+
+def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _SourceArchive:
+    """Download the corpus parquets and video chunks needed for the given episodes."""
+    import duckdb
+
+    dataset_base_url = (
+        "https://huggingface.co/datasets/"
+        f"{dataset_source.repo_id}/resolve/{dataset_source.revision}"
+    )
+    metadata_directory = cache_dir / "meta"
+    parsed_information = _parse_dataset_information(
+        _fetch_info_json(dataset_source.repo_id, dataset_source.revision, cache_dir)
+    )
 
     # Determine the episodes parquet location (v3 uses meta/episodes/*.parquet)
     episodes_metadata_directory = metadata_directory / "episodes"
@@ -651,25 +750,26 @@ def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _S
         for parquet_episode_row in parquet_episode_rows:
             tasks = parquet_episode_row[1]
             task = (str(tasks[0]) if tasks else "") if isinstance(tasks, list) else str(tasks or "")
-            episode_row_value: _EpisodeRow = {
-                "episode_index": int(parquet_episode_row[0]),
-                "task": task,
-                "length": int(parquet_episode_row[2]),
-                "data_chunk": str(parquet_episode_row[3]).split("/")[-1],
-                "data_file": str(parquet_episode_row[4]).split("/")[-1],
-                "data_from": int(parquet_episode_row[5]),
-                "data_to": int(parquet_episode_row[6]),
-            }
+            success_outcome: bool | None = None
             if has_outcome_aggregate:
                 # Episode outcome = MAX over the episode's collector-labeled
                 # next.success frames: any success frame makes the episode a
                 # success. An empty aggregate carries no label either way.
                 outcome_frames = parquet_episode_row[7]
                 if outcome_frames is not None and len(outcome_frames) > 0:
-                    episode_row_value["success_outcome"] = any(
-                        bool(value) for value in outcome_frames
-                    )
-            episode_rows.append(episode_row_value)
+                    success_outcome = any(bool(value) for value in outcome_frames)
+            episode_rows.append(
+                _EpisodeRow(
+                    episode_index=int(parquet_episode_row[0]),
+                    task=task,
+                    length=int(parquet_episode_row[2]),
+                    data_chunk=str(parquet_episode_row[3]).split("/")[-1],
+                    data_file=str(parquet_episode_row[4]).split("/")[-1],
+                    data_from=int(parquet_episode_row[5]),
+                    data_to=int(parquet_episode_row[6]),
+                    success_outcome=success_outcome,
+                )
+            )
 
         # Video window columns: videos/<camera>/{chunk_index,file_index,from_timestamp,to_timestamp}
         flattened_column_names = [
@@ -712,53 +812,39 @@ def _ensure_source_archive(dataset_source: DatasetSource, cache_dir: Path) -> _S
             for camera_key in video_keys:
                 video_chunk_index = video_window_by_column.get(f"vc_{camera_key}")
                 video_file_index = video_window_by_column.get(f"vf_{camera_key}")
-                video_windows_by_episode[episode_index][camera_key] = {
-                    "chunk_index": (
+                video_windows_by_episode[episode_index][camera_key] = _VideoWindow(
+                    chunk_index=(
                         "" if video_chunk_index is None else str(video_chunk_index).split("/")[-1]
                     ),
-                    "file_index": (
+                    file_index=(
                         "" if video_file_index is None else str(video_file_index).split("/")[-1]
                     ),
-                    "from_timestamp": float(
-                        video_window_by_column.get(f"vfrom_{camera_key}") or 0.0
-                    ),
-                    "to_timestamp": float(video_window_by_column.get(f"vto_{camera_key}") or 0.0),
-                }
-        for episode_row in episode_rows:
-            episode_row["video_windows"] = dict(
-                video_windows_by_episode.get(episode_row["episode_index"], {})
+                    from_timestamp=float(video_window_by_column.get(f"vfrom_{camera_key}") or 0.0),
+                    to_timestamp=float(video_window_by_column.get(f"vto_{camera_key}") or 0.0),
+                )
+        episode_rows = [
+            replace(
+                episode_row,
+                video_windows=dict(video_windows_by_episode.get(episode_row.episode_index, {})),
             )
+            for episode_row in episode_rows
+        ]
     finally:
         connection.close()
 
-    dataset_features = dataset_information.get("features")
-    if not isinstance(dataset_features, dict):
-        raise ValueError("LeRobot meta/info.json must define a features object")
-    video_keys_from_schema = sorted(
-        feature_name
-        for feature_name, feature_specification in dataset_features.items()
-        if isinstance(feature_specification, dict) and feature_specification.get("dtype") == "video"
-    )
+    # The parquet columns are the authority on which cameras this corpus
+    # actually stores; the declared video features are the fallback for a
+    # corpus whose episode metadata carries no video window columns.
     if not video_keys:
-        video_keys = video_keys_from_schema
-    numeric_features = {
-        feature_name: feature_specification
-        for feature_name, feature_specification in dataset_features.items()
-        if isinstance(feature_specification, dict)
-        and feature_specification.get("dtype") == "float32"
-    }
+        video_keys = list(parsed_information.video_feature_names)
 
-    return {
-        "info": dataset_information,
-        "fps": frames_per_second,
-        "data_path": data_path_template,
-        "video_path": video_path_template,
-        "episodes": episode_rows,
-        "video_keys": video_keys,
-        "numeric_features": numeric_features,
-        "cache_dir": cache_dir,
-        "dataset": dataset_source,
-    }
+    return _SourceArchive(
+        dataset_information=parsed_information,
+        episodes=tuple(episode_rows),
+        video_keys=tuple(video_keys),
+        cache_dir=cache_dir,
+        dataset=dataset_source,
+    )
 
 
 @dataclass
@@ -800,9 +886,10 @@ def _is_depth_map_feature(feature_specification: object) -> bool:
     )
 
 
-def _derive_numeric_schema(feature_name: str, feature_specification: dict) -> _NumericSchema:
-    declared_dtype = feature_specification.get("dtype")
-    declared_shape = feature_specification.get("shape") or []
+def _derive_numeric_schema(numeric_feature: _NumericFeature) -> _NumericSchema:
+    feature_name = numeric_feature.name
+    declared_dtype = numeric_feature.dtype
+    declared_shape = numeric_feature.declared_shape
     if declared_dtype != "float32":
         raise ValueError(
             f"unsupported feature {feature_name}: "
@@ -902,26 +989,25 @@ def import_lerobot_dataset(
         cache_directory,
     )
 
+    dataset_information = source_archive.dataset_information
     for camera_key in resolved_camera_keys:
-        if camera_key not in source_archive["video_keys"]:
+        if camera_key not in source_archive.video_keys:
             raise ValueError(
                 f"camera key '{camera_key}' not found in dataset. "
-                f"Available: {source_archive['video_keys']}"
+                f"Available: {list(source_archive.video_keys)}"
             )
 
-    dataset_features = source_archive["info"].get("features")
-    if isinstance(dataset_features, dict):
-        for camera_key in resolved_camera_keys:
-            if _is_depth_map_feature(dataset_features.get(camera_key)):
-                raise ValueError(
-                    f"LeRobot feature '{camera_key}' is a depth-map video; HFlow's RGB H.264 "
-                    "conversion cannot preserve depth values"
-                )
+    for camera_key in resolved_camera_keys:
+        if camera_key in dataset_information.depth_map_feature_names:
+            raise ValueError(
+                f"LeRobot feature '{camera_key}' is a depth-map video; HFlow's RGB H.264 "
+                "conversion cannot preserve depth values"
+            )
 
     # Numeric schemas derived from metadata (fail before any conversion)
     numeric_schemas = {
-        feature_name: _derive_numeric_schema(feature_name, feature_specification)
-        for feature_name, feature_specification in source_archive["numeric_features"].items()
+        feature_name: _derive_numeric_schema(numeric_feature)
+        for feature_name, numeric_feature in dataset_information.numeric_features.items()
         if feature_name in ("observation.state", "action")
         or feature_name.startswith("observation.")
     }
@@ -932,7 +1018,7 @@ def import_lerobot_dataset(
             + ", ".join(sorted(missing_required_features))
         )
 
-    episode_rows = source_archive["episodes"]
+    episode_rows = source_archive.episodes
     if episode_index is not None and episode_index >= len(episode_rows):
         raise ValueError(
             f"episode_index {episode_index} is out of range for {len(episode_rows)} episode(s)"
@@ -943,7 +1029,7 @@ def import_lerobot_dataset(
     published_episodes: list[_PublishedEpisode] = []
     episodes_converted = 0
 
-    dataset_source = source_archive["dataset"]
+    dataset_source = source_archive.dataset
     for selected_episode_index in selected_episode_indexes:
         reused_episode = _try_reuse_completed_episode(
             storage,
@@ -967,7 +1053,7 @@ def import_lerobot_dataset(
                 episode_index=selected_episode_index,
                 camera_keys=resolved_camera_keys,
                 numeric_schemas=numeric_schemas,
-                frames_per_second=int(source_archive["fps"]),
+                frames_per_second=int(source_archive.fps),
             )
         )
         episodes_converted += 1
@@ -1012,20 +1098,20 @@ def _convert_single_episode(
     """
     import duckdb
 
-    episode_row = source_archive["episodes"][episode_index]
-    if episode_row["length"] is None or episode_row["length"] < 1:
+    episode_row = source_archive.episodes[episode_index]
+    if episode_row.length is None or episode_row.length < 1:
         raise ValueError(f"episode {episode_index} has no frames")
 
     dataset_base_url = (
         "https://huggingface.co/datasets/"
         f"{dataset_source.repo_id}/resolve/{dataset_source.revision}"
     )
-    cache_directory = source_archive["cache_dir"]
+    cache_directory = source_archive.cache_dir
 
     # Locate the data parquet for this episode
-    data_chunk_index = episode_row["data_chunk"]
-    data_file_index = episode_row["data_file"]
-    data_relative_path = source_archive["data_path"].format(
+    data_chunk_index = episode_row.data_chunk
+    data_file_index = episode_row.data_file
+    data_relative_path = source_archive.data_path.format(
         chunk_index=int(data_chunk_index), file_index=int(data_file_index)
     )
     local_data_path = (
@@ -1040,11 +1126,11 @@ def _convert_single_episode(
     video_time_window_by_camera: dict[str, tuple[float, float]] = {}
     video_metadata_by_camera: dict[str, _VideoWindow] = {}
     for camera_key in camera_keys:
-        video_window = episode_row.get("video_windows", {}).get(camera_key)
-        if video_window:
+        video_window = episode_row.video_windows.get(camera_key)
+        if video_window is not None:
             video_time_window_by_camera[camera_key] = (
-                video_window["from_timestamp"],
-                video_window["to_timestamp"],
+                video_window.from_timestamp,
+                video_window.to_timestamp,
             )
             video_metadata_by_camera[camera_key] = video_window
 
@@ -1064,8 +1150,8 @@ def _convert_single_episode(
             ]
             else "frame_index"
         )
-        data_start_index = int(episode_row["data_from"])
-        data_end_index = int(episode_row["data_to"])
+        data_start_index = int(episode_row.data_from)
+        data_end_index = int(episode_row.data_to)
         episode_data_rows = connection.execute(
             f"SELECT * FROM read_parquet('{escaped_data_path}') "
             f"WHERE {index_column_name} >= {data_start_index} "
@@ -1099,24 +1185,24 @@ def _convert_single_episode(
     # Per-camera video: download chunk video, slice to episode window, transcode
     video_data_by_camera: dict[str, tuple[list[bytes], list[float]]] = {}
     for camera_key in camera_keys:
-        camera_video_metadata = video_metadata_by_camera.get(camera_key, {})
+        camera_video_metadata = video_metadata_by_camera.get(camera_key)
         video_time_window = video_time_window_by_camera.get(camera_key)
         video_start_seconds = video_time_window[0] if video_time_window is not None else 0.0
         video_end_seconds = video_time_window[1] if video_time_window is not None else 0.0
 
         video_chunk_index = (
-            str(camera_video_metadata.get("chunk_index"))
-            if camera_video_metadata.get("chunk_index") is not None
+            camera_video_metadata.chunk_index
+            if camera_video_metadata is not None
             else (data_chunk_index or "0")
         )
         video_chunk_index = video_chunk_index.split("/")[-1]
         video_file_index = (
-            str(camera_video_metadata.get("file_index"))
-            if camera_video_metadata.get("file_index") is not None
+            camera_video_metadata.file_index
+            if camera_video_metadata is not None
             else (data_file_index or "0")
         )
         video_file_index = video_file_index.split("/")[-1]
-        video_relative_path = source_archive["video_path"].format(
+        video_relative_path = source_archive.video_path.format(
             chunk_index=int(video_chunk_index or 0),
             file_index=int(video_file_index or 0),
             video_key=camera_key,
@@ -1260,9 +1346,9 @@ def _convert_single_episode(
                 )
 
             episode_record: dict[str, str] = {
-                "task": str(episode_row["task"] or ""),
+                "task": str(episode_row.task or ""),
                 "operator": "lerobot_converter",
-                "embodiment": str(source_archive["info"].get("robot_type") or "unknown"),
+                "embodiment": source_archive.dataset_information.robot_type,
                 "source_dataset": dataset_source.repo_id,
                 "source_revision": dataset_source.revision,
                 "source_episode_index": str(episode_index),
@@ -1276,7 +1362,7 @@ def _convert_single_episode(
             # the data; when it does not, the key is omitted rather than
             # invented (FORMAT.md: every episode/v1 key is optional and the
             # record is copied/merged from the source recording).
-            success_outcome = episode_row.get("success_outcome")
+            success_outcome = episode_row.success_outcome
             if success_outcome is not None:
                 episode_record["success"] = "true" if success_outcome else "false"
                 episode_record["success_derivation"] = _SUCCESS_DERIVATION

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -11,8 +11,9 @@ import logging
 import shutil
 import subprocess
 import urllib.request
+from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -23,6 +24,33 @@ from hflow.storage import LocalStorageRoot, StorageRoot
 
 _DERIVE = prep._derive_numeric_schema
 _ENCODE = prep._encode_cdr_float32_array
+
+
+def _numeric_feature(name: str, dtype: str, shape: list) -> prep._NumericFeature:
+    return prep._NumericFeature(name=name, dtype=dtype, shape=tuple(shape))
+
+
+def _source_archive(
+    dataset_source: prep.DatasetSource,
+    cache_dir: Path,
+    *,
+    info: dict,
+    episodes: Sequence[prep._EpisodeRow] = (),
+    video_keys: Sequence[str] = (),
+) -> prep._SourceArchive:
+    """A source archive whose metadata went through the real info.json parser.
+
+    Building the fakes this way keeps them honest: a test corpus that the
+    parser would refuse cannot reach the conversion code under test.
+    """
+    return prep._SourceArchive(
+        dataset_information=prep._parse_dataset_information(info),
+        episodes=tuple(episodes),
+        video_keys=tuple(video_keys),
+        cache_dir=cache_dir,
+        dataset=dataset_source,
+    )
+
 
 _FFMPEG = shutil.which("ffmpeg")
 _FFPROBE = shutil.which("ffprobe")
@@ -149,24 +177,24 @@ def _build_fake_corpus(tmp_path: Path) -> dict:
 
 
 def test_derive_numeric_schema_float32_vector() -> None:
-    schema = _DERIVE("observation.state", {"dtype": "float32", "shape": [6]})
+    schema = _DERIVE(_numeric_feature("observation.state", "float32", [6]))
     assert schema.name == "observation.state"
     assert schema.dim == 6
 
 
 def test_derive_numeric_schema_rejects_unsupported() -> None:
     with pytest.raises(ValueError, match="unsupported feature"):
-        _DERIVE("action", {"dtype": "float64", "shape": [6]})
+        _DERIVE(_numeric_feature("action", "float64", [6]))
     with pytest.raises(ValueError, match="unsupported feature"):
-        _DERIVE("observation.state", {"dtype": "float32", "shape": [2, 3]})
+        _DERIVE(_numeric_feature("observation.state", "float32", [2, 3]))
     with pytest.raises(ValueError, match="unsupported feature"):
-        _DERIVE("observation.state", {"dtype": "float32", "shape": []})
+        _DERIVE(_numeric_feature("observation.state", "float32", []))
     for shape in ([True], [False]):
         with pytest.raises(
             ValueError,
             match=rf"unsupported feature action: dtype=float32, shape=\[{shape[0]}\]",
         ):
-            _DERIVE("action", {"dtype": "float32", "shape": shape})
+            _DERIVE(_numeric_feature("action", "float32", shape))
 
 
 def test_import_rejects_required_boolean_dimension_without_dataset_output(
@@ -182,24 +210,25 @@ def test_import_rejects_required_boolean_dimension_without_dataset_output(
     monkeypatch.setattr(
         prep,
         "_ensure_source_archive",
-        lambda source, cache_dir: {
-            "info": {
+        lambda source, cache_dir: _source_archive(
+            dataset_source,
+            cache_dir,
+            info={
+                "fps": 30,
+                "data_path": "data/{chunk_index}/{file_index}.parquet",
+                "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
                 "features": {
                     prep.DEFAULT_CAMERA_KEY: {
                         "dtype": "video",
                         "shape": [480, 640, 3],
                         "info": {"is_depth_map": False},
-                    }
-                }
+                    },
+                    "action": {"dtype": "float32", "shape": [True]},
+                    "observation.state": {"dtype": "float32", "shape": [6]},
+                },
             },
-            "numeric_features": {
-                "action": {"dtype": "float32", "shape": [True]},
-                "observation.state": {"dtype": "float32", "shape": [6]},
-            },
-            "video_keys": [prep.DEFAULT_CAMERA_KEY],
-            "episodes": [],
-            "dataset": dataset_source,
-        },
+            video_keys=[prep.DEFAULT_CAMERA_KEY],
+        ),
     )
 
     with pytest.raises(
@@ -259,15 +288,15 @@ def test_index_discovery_multi_camera_metadata(
 
     ds = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
     found = prep._ensure_source_archive(ds, tmp_path)
-    assert len(found["episodes"]) == 4
-    assert found["episodes"][0]["length"] == 60
-    assert found["episodes"][1]["length"] == 65
-    assert found["episodes"][0]["data_from"] == 0
-    assert found["episodes"][0]["data_to"] == 60
-    assert set(found["video_keys"]) == {"observation.images.up", "observation.images.side"}
-    assert found["episodes"][0]["video_windows"]["observation.images.up"][
-        "to_timestamp"
-    ] == pytest.approx(2.0)
+    assert len(found.episodes) == 4
+    assert found.episodes[0].length == 60
+    assert found.episodes[1].length == 65
+    assert found.episodes[0].data_from == 0
+    assert found.episodes[0].data_to == 60
+    assert set(found.video_keys) == {"observation.images.up", "observation.images.side"}
+    assert found.episodes[0].video_windows["observation.images.up"].to_timestamp == pytest.approx(
+        2.0
+    )
 
 
 @pytest.mark.parametrize(
@@ -342,15 +371,15 @@ def test_index_discovery_reads_every_metadata_shard(
 
     assert set(downloaded_destinations) == set(shard_paths)
     assert len(set(downloaded_destinations.values())) == len(shard_paths)
-    assert [episode["episode_index"] for episode in found["episodes"]] == [0, 1, 2, 3]
-    assert set(found["video_keys"]) == {"observation.images.up", "observation.images.side"}
-    for episode in found["episodes"]:
-        episode_index = episode["episode_index"]
-        assert episode["length"] == 60 + episode_index * 5
-        for camera_key in found["video_keys"]:
-            window = episode["video_windows"][camera_key]
-            assert window["chunk_index"] == "chunk-000"
-            assert window["to_timestamp"] == pytest.approx(2.0 + episode_index * 0.2)
+    assert [episode.episode_index for episode in found.episodes] == [0, 1, 2, 3]
+    assert set(found.video_keys) == {"observation.images.up", "observation.images.side"}
+    for episode in found.episodes:
+        episode_index = episode.episode_index
+        assert episode.length == 60 + episode_index * 5
+        for camera_key in found.video_keys:
+            window = episode.video_windows[camera_key]
+            assert window.chunk_index == "chunk-000"
+            assert window.to_timestamp == pytest.approx(2.0 + episode_index * 0.2)
 
 
 @pytest.mark.parametrize(
@@ -376,32 +405,31 @@ def test_video_cache_distinguishes_file_indices_and_reuses_same_source(
     camera_key = "observation.images.up"
     dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
 
-    def episode_row(episode_index: int, video_file_index: int) -> dict:
-        return {
-            "episode_index": episode_index,
-            "task": f"task-{episode_index}",
-            "length": 1,
-            "data_chunk": "000",
-            "data_file": "000",
-            "data_from": 0,
-            "data_to": 1,
-            "video_windows": {
-                camera_key: {
-                    "chunk_index": "000",
-                    "file_index": f"{video_file_index:03d}",
-                    "from_timestamp": 0.0,
-                    "to_timestamp": 0.0,
-                }
+    def episode_row(episode_index: int, video_file_index: int) -> prep._EpisodeRow:
+        return prep._EpisodeRow(
+            episode_index=episode_index,
+            task=f"task-{episode_index}",
+            length=1,
+            data_chunk="000",
+            data_file="000",
+            data_from=0,
+            data_to=1,
+            video_windows={
+                camera_key: prep._VideoWindow(
+                    chunk_index="000",
+                    file_index=f"{video_file_index:03d}",
+                    from_timestamp=0.0,
+                    to_timestamp=0.0,
+                )
             },
-        }
+        )
 
-    source_archive = cast(
-        prep._SourceArchive,
-        {
-            **corpus,
-            "episodes": [episode_row(0, 0), episode_row(1, 1)],
-            "video_keys": [camera_key],
-        },
+    source_archive = _source_archive(
+        dataset_source,
+        corpus["cache_dir"],
+        info=corpus["info"],
+        episodes=[episode_row(0, 0), episode_row(1, 1)],
+        video_keys=[camera_key],
     )
     numeric_schemas = {
         "observation.state": prep._NumericSchema(name="observation.state", dim=6),
@@ -539,26 +567,28 @@ def test_import_namespaces_source_cache_by_resolved_revision(
         lambda repo, revision: {"sha": resolved_shas[revision], "license": "apache-2.0"},
     )
 
-    def fake_ensure_source_archive(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+    def fake_ensure_source_archive(
+        dataset_source: prep.DatasetSource, cache_dir: Path
+    ) -> prep._SourceArchive:
         cache_dir.mkdir(parents=True, exist_ok=True)
         source_marker = cache_dir / "source-marker.txt"
         if not source_marker.exists():
             source_marker.write_text(dataset_source.revision)
         cache_observations.append((dataset_source.revision, cache_dir, source_marker.read_text()))
-        return {
-            "info": {},
-            "fps": 30,
-            "data_path": "data/{chunk_index}/{file_index}.parquet",
-            "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
-            "episodes": [],
-            "video_keys": [prep.DEFAULT_CAMERA_KEY],
-            "numeric_features": {
-                "action": {"dtype": "float32", "shape": [1]},
-                "observation.state": {"dtype": "float32", "shape": [1]},
+        return _source_archive(
+            dataset_source,
+            cache_dir,
+            info={
+                "fps": 30,
+                "data_path": "data/{chunk_index}/{file_index}.parquet",
+                "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
+                "features": {
+                    "action": {"dtype": "float32", "shape": [1]},
+                    "observation.state": {"dtype": "float32", "shape": [1]},
+                },
             },
-            "cache_dir": cache_dir,
-            "dataset": dataset_source,
-        }
+            video_keys=[prep.DEFAULT_CAMERA_KEY],
+        )
 
     monkeypatch.setattr(prep, "_ensure_source_archive", fake_ensure_source_archive)
 
@@ -1047,46 +1077,54 @@ def test_info_json_accepts_normal_positive_fps(
 
     dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
     source_archive = prep._ensure_source_archive(dataset_source, tmp_path / "cache")
-    assert source_archive["fps"] == 30
+    assert source_archive.fps == 30
+
+
+def _stub_single_episode_info(camera_metadata: dict | None = None) -> dict:
+    """One RGB camera and the two required numeric features.
+
+    ``camera_metadata`` replaces the camera feature outright, which is how the
+    depth-refusal tests mark the same camera as depth.
+    """
+    return {
+        "robot_type": "pusht",
+        "fps": 30,
+        "data_path": "data/{chunk_index}/{file_index}.parquet",
+        "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
+        "features": {
+            prep.DEFAULT_CAMERA_KEY: camera_metadata
+            or {
+                "dtype": "video",
+                "shape": [480, 640, 3],
+                "info": {"is_depth_map": False},
+            },
+            "action": {"dtype": "float32", "shape": [1]},
+            "observation.state": {"dtype": "float32", "shape": [1]},
+        },
+    }
 
 
 def _stub_single_episode_source_archive(
     dataset_source: prep.DatasetSource, cache_dir: Path
-) -> dict:
+) -> prep._SourceArchive:
     cache_dir.mkdir(parents=True, exist_ok=True)
-    return {
-        "info": {
-            "robot_type": "pusht",
-            "features": {
-                prep.DEFAULT_CAMERA_KEY: {
-                    "dtype": "video",
-                    "shape": [480, 640, 3],
-                    "info": {"is_depth_map": False},
-                }
-            },
-        },
-        "fps": 30,
-        "data_path": "data/{chunk_index}/{file_index}.parquet",
-        "video_path": "videos/{camera_key}/{chunk_index}/{file_index}.mp4",
-        "episodes": [
-            {
-                "episode_index": 0,
-                "task": "push",
-                "length": 1,
-                "data_chunk": "000",
-                "data_file": "000",
-                "data_from": 0,
-                "data_to": 1,
-            }
+    return _source_archive(
+        dataset_source,
+        cache_dir,
+        info=_stub_single_episode_info(),
+        episodes=[
+            prep._EpisodeRow(
+                episode_index=0,
+                task="push",
+                length=1,
+                data_chunk="000",
+                data_file="000",
+                data_from=0,
+                data_to=1,
+            )
         ],
-        "video_keys": [prep.DEFAULT_CAMERA_KEY],
-        "numeric_features": {
-            "action": {"dtype": "float32", "shape": [1]},
-            "observation.state": {"dtype": "float32", "shape": [1]},
-        },
-        "cache_dir": cache_dir,
-        "dataset": dataset_source,
-    }
+        video_keys=[prep.DEFAULT_CAMERA_KEY],
+    )
 
 
 def _install_publish_through_convert(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[str]:
@@ -1143,16 +1181,18 @@ def test_import_refuses_a_depth_video_before_publishing_dataset_output(
 ) -> None:
     output_dir = tmp_path / "out"
 
-    def ensure_depth_archive(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+    def ensure_depth_archive(
+        dataset_source: prep.DatasetSource, cache_dir: Path
+    ) -> prep._SourceArchive:
         archive = _stub_single_episode_source_archive(dataset_source, cache_dir)
-        archive["info"]["features"] = {
-            prep.DEFAULT_CAMERA_KEY: {
-                "dtype": "video",
-                "shape": [24, 32, 1],
-                **depth_metadata,
-            }
-        }
-        return archive
+        return replace(
+            archive,
+            dataset_information=prep._parse_dataset_information(
+                _stub_single_episode_info(
+                    {"dtype": "video", "shape": [24, 32, 1], **depth_metadata}
+                )
+            ),
+        )
 
     monkeypatch.setattr(
         prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
@@ -1235,31 +1275,30 @@ def test_converter_version_reaches_the_canonical_episode_provenance(
     corpus = _build_fake_corpus(tmp_path)
     camera_key = "observation.images.up"
     dataset_source = prep.DatasetSource(repo_id="fake/repo", revision="abc", license="apache-2.0")
-    source_archive = cast(
-        prep._SourceArchive,
-        {
-            **corpus,
-            "episodes": [
-                {
-                    "episode_index": 0,
-                    "task": "pick-and-place",
-                    "length": 1,
-                    "data_chunk": "000",
-                    "data_file": "000",
-                    "data_from": 0,
-                    "data_to": 1,
-                    "video_windows": {
-                        camera_key: {
-                            "chunk_index": "000",
-                            "file_index": "000",
-                            "from_timestamp": 0.0,
-                            "to_timestamp": 0.0,
-                        }
-                    },
-                }
-            ],
-            "video_keys": [camera_key],
-        },
+    source_archive = _source_archive(
+        dataset_source,
+        corpus["cache_dir"],
+        info=corpus["info"],
+        episodes=[
+            prep._EpisodeRow(
+                episode_index=0,
+                task="pick-and-place",
+                length=1,
+                data_chunk="000",
+                data_file="000",
+                data_from=0,
+                data_to=1,
+                video_windows={
+                    camera_key: prep._VideoWindow(
+                        chunk_index="000",
+                        file_index="000",
+                        from_timestamp=0.0,
+                        to_timestamp=0.0,
+                    )
+                },
+            )
+        ],
+        video_keys=[camera_key],
     )
     numeric_schemas = {
         "observation.state": prep._NumericSchema(name="observation.state", dim=6),
@@ -1425,17 +1464,17 @@ def test_import_skips_bucket_manifest_when_an_episode_publish_fails(
     data_root, remote_dir = bucket_over_tmp
     assert isinstance(data_root, BucketStorageRoot)
 
-    def ensure_two_episodes(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+    def ensure_two_episodes(
+        dataset_source: prep.DatasetSource, cache_dir: Path
+    ) -> prep._SourceArchive:
         archive = _stub_single_episode_source_archive(dataset_source, cache_dir)
-        archive["episodes"] = [
-            archive["episodes"][0],
-            {
-                **archive["episodes"][0],
-                "episode_index": 1,
-                "task": "second",
-            },
-        ]
-        return archive
+        return replace(
+            archive,
+            episodes=(
+                archive.episodes[0],
+                replace(archive.episodes[0], episode_index=1, task="second"),
+            ),
+        )
 
     convert_calls = 0
 
@@ -1680,17 +1719,17 @@ def test_reuse_refuses_an_empty_landing_episode(tmp_path: Path) -> None:
     )
 
 
-def _ensure_two_episode_archive(dataset_source: prep.DatasetSource, cache_dir: Path) -> dict:
+def _ensure_two_episode_archive(
+    dataset_source: prep.DatasetSource, cache_dir: Path
+) -> prep._SourceArchive:
     archive = _stub_single_episode_source_archive(dataset_source, cache_dir)
-    archive["episodes"] = [
-        archive["episodes"][0],
-        {
-            **archive["episodes"][0],
-            "episode_index": 1,
-            "task": "second",
-        },
-    ]
-    return archive
+    return replace(
+        archive,
+        episodes=(
+            archive.episodes[0],
+            replace(archive.episodes[0], episode_index=1, task="second"),
+        ),
+    )
 
 
 def test_import_resumes_after_mid_batch_failure_without_rewriting_completed_episode(

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -119,6 +119,43 @@ def test_import_refuses_empty_path_templates(
     _assert_no_dataset_output(output_dir)
 
 
+def test_import_refuses_info_json_without_features_before_listing_episodes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal fires at the parse boundary, not after a shard download.
+
+    #433 moved this ahead of episode discovery. Asserting only the message
+    would pass either way, so the point of the test is the second assertion:
+    a corpus with no ``features`` must not cost a listing of ``meta/episodes``.
+    """
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(
+        prep,
+        "_fetch_info_json",
+        lambda _repo, _revision, _cache: {
+            "fps": 30,
+            "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+            "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        },
+    )
+    listed_paths: list[str] = []
+
+    def recording_hf_tree(_repo: str, _revision: str, path: str) -> list[dict[str, str]]:
+        listed_paths.append(path)
+        return []
+
+    monkeypatch.setattr(prep, "_hf_tree", recording_hf_tree)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(
+        ValueError, match=_exactly("LeRobot meta/info.json must define a features object")
+    ):
+        _import(output_dir)
+
+    assert listed_paths == []
+    _assert_no_dataset_output(output_dir)
+
+
 def test_import_refuses_repository_without_episode_parquets(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #320.

`meta/info.json` is now parsed once, at the boundary, into immutable values. Nothing after
that point reads the external document.

## The typed model

`_parse_dataset_information(document) -> _DatasetInformation` validates and returns:

- `fps`, `data_path`, `video_path`: the existing guards, moved here unchanged
- `robot_type`: normalised to `"unknown"` once, instead of at the provenance write
- `video_feature_names`: the `dtype: video` features, the fallback for a corpus whose
  episode metadata carries no video window columns
- `numeric_features`: `dict[str, _NumericFeature]`, each carrying name, dtype and shape
- `depth_map_feature_names`: computed with the existing `_is_depth_map_feature()`

`_SourceArchive`, `_EpisodeRow` and `_VideoWindow` are frozen dataclasses. The archive holds
the parsed information, a tuple of episodes, the video keys, the cache dir and the
`DatasetSource`. `fps`, `data_path` and `video_path` stay reachable as properties so the
conversion code reads what it read before.

Shape validation stays in `_derive_numeric_schema()` and still runs only on selected
features. A corpus may declare a float32 feature HFlow never reads, and refusing the import
for it would reject datasets that convert today. `_NumericFeature` gives that function
attributes to read, so no `.get()` on a raw spec survives past the parser.

The downloaded `info.json` is still written to the cache as the original document.

## One behaviour change

The "must define a features object" refusal now fires before episode discovery instead of
after it. A corpus missing `features` used to download every `meta/episodes` shard first.
Same refusal, same message, earlier.

Everything else is the same: same selected episodes, same paths, same schemas, same
provenance, same manifest, and the fps, dtype, shape and required-feature refusals still
fail before any output.

## Tests

The archive fakes in `test_lerobot_converter.py` were dict literals. They now build through
the real parser, so a fake corpus the parser would refuse cannot reach the conversion code
under test. The `_derive_numeric_schema` cases construct `_NumericFeature` directly and keep
their exact expected messages, boolean dimension included.

## Validation

```
uv run ruff check --fix        clean
uv run ruff format             clean
uv run ty check                clean
uv run pytest -q tests/test_lerobot_converter.py    77 passed
uv run pytest -q               1554 passed, 28 failed
```

The 28 are pre-existing on this machine and unrelated: 27 in `test_packaging*` refusing to
build the native overlay off Linux, and one in `test_end_to_end` where the local ffmpeg has
no `filter_script:v`. Both fail the same way on `origin/main`.
