### PR TITLE
fix(storage): refuse bucket URLs naming no object directly in fetch_uri (#435)

### DIFF
--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -685,6 +685,9 @@ def fetch_uri(uri: "str | Path") -> Path:
     one-off ``app.process("gs://...")`` sources.
     """
     if isinstance(uri, str) and is_bucket_url(uri):
+        _scheme, _sep, remainder = uri.partition("://")
+        if "/" not in remainder or not remainder.partition("/")[2].strip("/"):
+            raise ValueError(f"bucket URI {uri!r} names no object")
         parent_url, _, name = uri.rpartition("/")
         if not name:
             raise ValueError(f"bucket URI {uri!r} names no object")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,6 +12,7 @@ A live object-store integration test runs only when
 
 import errno
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -392,16 +393,18 @@ class TestFetchUri:
         with pytest.raises(FileNotFoundError):
             fetch_uri(tmp_path / "missing.mcap")
 
-    def test_default_mirror_is_stable_per_url(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HFLOW_MIRROR_DIR", str(tmp_path / "mirrors"))
-        first = BucketStorageRoot("gs://bucket/prefix")
-        second = BucketStorageRoot("gs://bucket/prefix/")
-        other = BucketStorageRoot("gs://bucket/other")
-        assert first.mirror == second.mirror
-        assert first.mirror != other.mirror
-        assert first.mirror.is_relative_to(tmp_path / "mirrors")
+    def test_bucket_uri_naming_no_object_is_refused(self) -> None:
+        refused = [
+            "gs://bucket/",
+            "s3://bucket/prefix/",
+            "gs://bucket//",
+            "gs://bucket",
+            "s3://bucket",
+        ]
+        for uri in refused:
+            pattern = rf"^bucket URI {re.escape(repr(uri))} names no object$"
+            with pytest.raises(ValueError, match=pattern):
+                fetch_uri(uri)
 
 
 class TestBucketPipeline:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -393,6 +393,17 @@ class TestFetchUri:
         with pytest.raises(FileNotFoundError):
             fetch_uri(tmp_path / "missing.mcap")
 
+    def test_default_mirror_is_stable_per_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HFLOW_MIRROR_DIR", str(tmp_path / "mirrors"))
+        first = BucketStorageRoot("gs://bucket/prefix")
+        second = BucketStorageRoot("gs://bucket/prefix/")
+        other = BucketStorageRoot("gs://bucket/other")
+        assert first.mirror == second.mirror
+        assert first.mirror != other.mirror
+        assert first.mirror.is_relative_to(tmp_path / "mirrors")
+
     def test_bucket_uri_naming_no_object_is_refused(self) -> None:
         refused = [
             "gs://bucket/",


### PR DESCRIPTION
## Summary
Resolves #435.

Ensures `fetch_uri` explicitly validates and refuses bucket URLs that name no object before delegating to `BucketStorageRoot`, returning an error citing the exact URI supplied by the caller instead of a truncated prefix.

## Changes
- In `src/hflow/storage.py`: checked that the bucket URL contains an object segment after the bucket/container before delegating to `BucketStorageRoot`.
- In `tests/test_storage.py`: added `test_bucket_uri_naming_no_object_is_refused` in `TestFetchUri` testing trailing slashes (`gs://bucket/`, `s3://bucket/prefix/`, `gs://bucket//`) and bare bucket names (`gs://bucket`, `s3://bucket`).
- Formatted and linted with `ruff`.

## Validation
- `uv run pytest -q tests/test_storage.py` (44 passed, 1 skipped)
- `uv run ruff check src/hflow/storage.py tests/test_storage.py`
- `uv run ruff format --check src/hflow/storage.py tests/test_storage.py`
