### PR TITLE
fix: validate horizontal field of view before camera selection

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1001,6 +1001,15 @@ def camera_stability(
     ):
         raise ValueError("unstable_min_duration_s must be finite and non-negative")
 
+    if (
+        isinstance(horizontal_field_of_view_degrees, bool)
+        or not np.isfinite(horizontal_field_of_view_degrees)
+        or not 0 < horizontal_field_of_view_degrees <= 360
+    ):
+        raise ValueError(
+            f"horizontal_field_of_view_degrees must be finite and in (0, 360], got {horizontal_field_of_view_degrees}"
+        )
+
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     intervals: list[Interval] = []

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -395,7 +395,7 @@ def test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode(
         tmp_path / "episode.mcap",
         SyntheticEpisodeSpec(duration_s=2.0, cameras=(), joint_jump_at_s=1.0),
     )
-    bad_values: list[float] = [-5.0, 0.0, float("nan"), float("inf"), True]  # type: ignore[arg-type]
+    bad_values: list[float] = [-5.0, 0.0, 361.0, float("nan"), float("inf"), True]
     for bad_value in bad_values:
         with (
             hflow.Episode(episode_path) as episode,
@@ -404,7 +404,13 @@ def test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode(
                 match=r"^horizontal_field_of_view_degrees must be finite and in \(0, 360\], got .+$",
             ),
         ):
-            camera_stability(episode, horizontal_field_of_view_degrees=bad_value)  # type: ignore[arg-type]
+            camera_stability(episode, horizontal_field_of_view_degrees=bad_value)
+
+    # The bound is inclusive at 360, and the guard must not refuse the widest
+    # legal lens. Without this the whole range check could be `< 360` and every
+    # case above would still pass.
+    with hflow.Episode(episode_path) as episode:
+        assert camera_stability(episode, horizontal_field_of_view_degrees=360.0).measurements == {}
 
 
 def test_the_check_knobs_raise_the_bar_without_changing_the_rate_measurements(

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -331,8 +331,18 @@ def stability_episode(still_texture: Path, tmp_path_factory: pytest.TempPathFact
             "unstable_min_duration_s",
             lambda episode, value: camera_stability(episode, unstable_min_duration_s=value),
         ),
+        (
+            "horizontal_field_of_view_degrees",
+            lambda episode, value: camera_stability(
+                episode, horizontal_field_of_view_degrees=value
+            ),
+        ),
     ],
-    ids=["shake_threshold_dps", "unstable_min_duration_s"],
+    ids=[
+        "shake_threshold_dps",
+        "unstable_min_duration_s",
+        "horizontal_field_of_view_degrees",
+    ],
 )
 @pytest.mark.parametrize(
     "value",
@@ -345,19 +355,56 @@ def test_camera_stability_refuses_a_bad_tuning_value(
     call_with: Callable[[hflow.Episode, float], hflow.CheckResult],
     value: float,
 ) -> None:
-    """Both knobs refuse the same four values, each under its own name.
+    """All three knobs refuse the same four bad values, each under its own name.
 
     ``True`` is in the list because ``bool`` subclasses ``int``: without the
-    guard it would pass as one degree per second, or one second of run.
+    guard it would pass as one degree per second, one second of run, or one
+    degree of field of view.
 
     Each case passes its argument through a real keyword rather than unpacking
-    a dict, so the call stays type-checked.
+    a dict, so the call stays type-checked. The field-of-view guard needs
+    (0, 360] while the other two accept zero, so zero is covered separately
+    in test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode.
     """
+    if parameter == "horizontal_field_of_view_degrees":
+        expected_match = (
+            r"^horizontal_field_of_view_degrees must be finite and in \(0, 360\], got .+$"
+        )
+    else:
+        expected_match = rf"^{parameter} must be finite and non-negative$"
     with (
         hflow.Episode(stability_episode) as episode,
-        pytest.raises(ValueError, match=rf"^{parameter} must be finite and non-negative$"),
+        pytest.raises(ValueError, match=expected_match),
     ):
         call_with(episode, value)
+
+
+def test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode(
+    tmp_path: Path,
+) -> None:
+    """The field-of-view guard must run even when no camera is present.
+
+    The other two guards already ran before the camera loop; the field-of-view
+    check used to live inside that loop, so a state-only episode bypassed it.
+    This is the regression: without the top-level guard the call below would
+    be accepted, while the same bad value on a video episode is refused.
+    """
+    from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
+
+    episode_path = synthesize_episode(
+        tmp_path / "episode.mcap",
+        SyntheticEpisodeSpec(duration_s=2.0, cameras=(), joint_jump_at_s=1.0),
+    )
+    bad_values: list[float] = [-5.0, 0.0, float("nan"), float("inf"), True]  # type: ignore[arg-type]
+    for bad_value in bad_values:
+        with (
+            hflow.Episode(episode_path) as episode,
+            pytest.raises(
+                ValueError,
+                match=r"^horizontal_field_of_view_degrees must be finite and in \(0, 360\], got .+$",
+            ),
+        ):
+            camera_stability(episode, horizontal_field_of_view_degrees=bad_value)  # type: ignore[arg-type]
 
 
 def test_the_check_knobs_raise_the_bar_without_changing_the_rate_measurements(


### PR DESCRIPTION
Resolves #445

## Summary
Validates `horizontal_field_of_view_degrees` at the top of `camera_stability` before `selected_cameras` is resolved, matching the existing guards for `shake_threshold_dps` and `unstable_min_duration_s`. Rejects `bool`, non-finite, `<=0` and `>360` with `ValueError: horizontal_field_of_view_degrees must be finite and in (0, 360], got <value>`. Leaves `CameraMotionSettings` guard in `_video_measurements/_camera_motion.py:73-80` intact for its other callers.

## Why
The field-of-view check lived inside the per-camera loop via `CameraMotionSettings`. On a state-only episode (`cameras=()`) the loop never runs, so the same bad value was accepted (`measurements={}`) on state-only episodes and refused on video episodes. A `functools.partial(camera_stability, horizontal_field_of_view_degrees=…)` with a typo would pass every state-only episode and crash on the first camera episode.

## Changes
- `src/hflow/checks.py`: add top-level guard `(0, 360]` before `selected_cameras`
- `tests/test_motion.py`: extend `test_camera_stability_refuses_a_bad_tuning_value` to include `horizontal_field_of_view_degrees` (12 cases) and add `test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode` covering negative, zero, non-finite, bool on a `cameras=()` episode

## Validation
```
uv sync --locked --all-extras
uv run ruff check
uv run ruff format --check
uv run ty check
uv run pytest tests/test_motion.py -q
```
- `ruff check` All checks passed
- `ruff format --check` 223 files already formatted
- `ty check` All checks passed
- `pytest tests/test_motion.py -q` 22 passed
- Removing the guard makes `test_camera_stability_refuses_a_bad_fov_on_a_camera_less_episode` fail with `DID NOT RAISE` (verified)
