### PR TITLE
test(server): pin the non-single-SELECT refusal on pin and preview

### DIFF
--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -137,6 +137,27 @@ def test_concurrent_pins_all_land_in_the_registry(
     assert len(manifest_files) == len(names)
 
 
+def test_pin_refuses_sql_that_is_not_a_single_select(
+    writable_api: TestClient, writable_workspace: PopulatedWorkspace
+) -> None:
+    # Well-formed SQL that is not exactly one read-only SELECT is refused
+    # with the fixed sentence, and nothing is registered or written.
+    hostile_sql = [
+        "SELECT 1; DROP TABLE episodes",
+        "COPY (SELECT 1) TO '/tmp/hflow-nope.csv'",
+        "CREATE TABLE should_not_exist AS SELECT 1",
+        "DELETE FROM episodes",
+    ]
+    for sql in hostile_sql:
+        response = writable_api.post("/api/v1/curation/pin", json={"sql": sql, "name": "hostile"})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "sql must be exactly one read-only SELECT statement"
+    manifests_directory = writable_workspace.data_root / "manifests"
+    if manifests_directory.exists():
+        assert list(manifests_directory.glob("*.parquet")) == []
+    assert writable_api.get("/api/v1/manifests").json()["manifests"] == []
+
+
 def test_pin_with_bad_sql_is_400_and_registers_nothing(
     writable_api: TestClient, writable_workspace: PopulatedWorkspace
 ) -> None:

--- a/packages/hflow-server/tests/test_server_curation_preview.py
+++ b/packages/hflow-server/tests/test_server_curation_preview.py
@@ -111,6 +111,16 @@ def test_preview_handles_json_hostile_result_types(api: TestClient) -> None:
     assert payload["rows"] == [{"a_decimal": 1.5, "a_list": [1, 2]}]
 
 
+def test_preview_refuses_sql_that_is_not_a_single_select(api: TestClient) -> None:
+    # The parser accepts these; the gate refuses them because they are not
+    # exactly one read-only SELECT, with the same sentence pin uses.
+    hostile_sql = ["SELECT 1; DROP TABLE episodes", "DELETE FROM episodes"]
+    for sql in hostile_sql:
+        response = api.post("/api/v1/curation/preview", json={"sql": sql})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "sql must be exactly one read-only SELECT statement"
+
+
 def test_preview_bad_sql_is_400_with_the_duckdb_message(api: TestClient) -> None:
     response = api.post("/api/v1/curation/preview", json={"sql": "SELEC 1"})
     assert response.status_code == 400


### PR DESCRIPTION
Fixes #448

**The gap:** `_reject_non_single_select` (`packages/hflow-server/src/hflow_server/_curation.py:161-177`) is the boundary that decides what tenant-supplied SQL the HTTP surface runs, and the `NonSingleSelectQueryError` mapping onto the fixed 400 sentence was the one curation refusal nothing tested. The issue neutered each refusal in turn; this is the one that matters most.

**What changed:** two regression tests.

- `test_server_curation_pin.py` — four hostile-but-well-formed shapes on `POST /api/v1/curation/pin` (`SELECT 1; DROP TABLE episodes`, `COPY (SELECT 1) TO ...`, `CREATE TABLE ... AS SELECT 1`, `DELETE FROM episodes`), each asserting the fixed sentence, plus nothing registered and no parquet stranded.
- `test_server_curation_preview.py` — the multi-statement and DELETE shapes on `POST /api/v1/curation/preview` with the same sentence.

**Red/green:** neutering the `NonSingleSelectQueryError` branch turns these two tests red and only these two (the SQL then escapes into the preview wrapper / execution path and fails with a different message). Restored, both files pass: 31/31.

**Gates run:** `ruff check`, `ruff format --check`, `ty check` all clean on both files; `pytest packages/hflow-server/tests/test_server_curation_pin.py packages/hflow-server/tests/test_server_curation_preview.py` → 31 passed. No server code touched.