### PR TITLE
test(server): cover curation registry caps

### DIFF
--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -76,9 +76,7 @@ def test_pinned_manifest_registry_cap_refuses_the_first_entry_past_the_limit(
     monkeypatch.setattr(_curation, "_MAX_PINNED_MANIFESTS", cap)
 
     first = _pin(writable_api, "first")
-    over_cap = writable_api.post(
-        "/api/v1/curation/pin", json={"sql": OK_CUT_SQL, "name": "second"}
-    )
+    over_cap = writable_api.post("/api/v1/curation/pin", json={"sql": OK_CUT_SQL, "name": "second"})
     assert over_cap.status_code == 409
     assert over_cap.json()["detail"] == (
         f"this workspace already has {cap} pinned manifests "

--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -67,6 +67,29 @@ def test_second_pin_with_the_same_name_gets_a_distinct_file(
     assert listed_ids == [second_entry["id"], first_entry["id"]]
 
 
+def test_pinned_manifest_registry_cap_refuses_the_first_entry_past_the_limit(
+    writable_api: TestClient,
+    writable_workspace: PopulatedWorkspace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cap = 1
+    monkeypatch.setattr(_curation, "_MAX_PINNED_MANIFESTS", cap)
+
+    first = _pin(writable_api, "first")
+    over_cap = writable_api.post(
+        "/api/v1/curation/pin", json={"sql": OK_CUT_SQL, "name": "second"}
+    )
+    assert over_cap.status_code == 409
+    assert over_cap.json()["detail"] == (
+        f"this workspace already has {cap} pinned manifests "
+        "(the registry cap); remove some before pinning more"
+    )
+    assert writable_api.get("/api/v1/manifests").json()["manifests"] == [first]
+    assert list((writable_workspace.data_root / "manifests").glob("*.parquet")) == [
+        writable_workspace.data_root / first["manifest_path"]
+    ]
+
+
 def test_a_filename_collision_is_refused_never_overwritten(
     writable_api: TestClient,
     writable_workspace: PopulatedWorkspace,

--- a/packages/hflow-server/tests/test_server_queries.py
+++ b/packages/hflow-server/tests/test_server_queries.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Iterator
 
+import pytest
 from fastapi.testclient import TestClient
-from hflow_server import ServerSettings, create_app
+from hflow_server import ServerSettings, _curation, create_app
 from ui_test_fixtures import PopulatedWorkspace
 
 
@@ -15,6 +16,24 @@ def _created_query(api: TestClient, name: str, sql: str) -> dict:
 
 def test_queries_start_empty(writable_api: TestClient) -> None:
     assert writable_api.get("/api/v1/queries").json() == {"queries": []}
+
+
+def test_saved_query_registry_cap_refuses_the_first_entry_past_the_limit(
+    writable_api: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cap = 1
+    monkeypatch.setattr(_curation, "_MAX_SAVED_QUERIES", cap)
+
+    first = writable_api.post("/api/v1/queries", json={"name": "first", "sql": "SELECT 1"})
+    assert first.status_code == 200
+
+    over_cap = writable_api.post("/api/v1/queries", json={"name": "second", "sql": "SELECT 2"})
+    assert over_cap.status_code == 409
+    assert over_cap.json()["detail"] == (
+        f"this workspace already has {cap} saved queries "
+        "(the sidecar cap); remove some before saving more"
+    )
+    assert writable_api.get("/api/v1/queries").json()["queries"] == [first.json()]
 
 
 def test_create_list_update_delete_roundtrip(writable_api: TestClient) -> None:


### PR DESCRIPTION
Fixes #449

## Summary

Add focused regression coverage for both curation sidecar registry caps without creating anything close to the production limit of 1000 entries.

- patch `_MAX_PINNED_MANIFESTS` to `1`, assert the first pin succeeds and the next returns the exact `409` detail, and verify the refused request does not strand an extra Parquet file;
- patch `_MAX_SAVED_QUERIES` to `1`, assert the first saved query succeeds and the next returns the exact `409` detail, and verify the registry remains unchanged.

The default production caps remain untouched.

## Why this shape

The refusal branches are important bounded-state protections, but testing them at the real cap would make the suite needlessly expensive, especially for pinned manifests. Monkeypatching the constants keeps the tests fast while exercising the real request and persistence paths.

## Validation

I reviewed the diff against current fork `main`; it only changes the two focused server test modules. The fork's GitHub Actions workflow may require upstream approval before jobs execute, so CI is the authoritative repository-wide validation once approved.

AI assistance disclosure: AI assistance was used to inspect the issue and repository tests, prepare the focused regression coverage, collision-check for existing work, and review the resulting diff.