### PR TITLE
fix(curation): narrow SELECT gate to actual SELECT/WITH text (#450)

### DIFF
--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -216,3 +216,26 @@ def test_manifest_download_whose_file_vanished_is_404(
     entry = _pin(writable_api, "soon gone")
     (writable_workspace.data_root / entry["manifest_path"]).unlink()
     assert writable_api.get(f"/api/v1/manifests/{entry['id']}/download").status_code == 404
+
+
+def test_pin_rejects_pragma_and_describe_consistently(
+    writable_api: TestClient, api: TestClient
+) -> None:
+    # Mirrors preview's gate: PRAGMA/DESCRIBE/SHOW are StatementType.SELECT
+    # but not SELECT text, so both endpoints must agree (issue #450).
+    for sql in (
+        "PRAGMA database_list",
+        "PRAGMA show_tables",
+        "PRAGMA version",
+        "DESCRIBE SELECT 1",
+        "SHOW TABLES",
+        "SUMMARIZE SELECT 1",
+    ):
+        pin_response = writable_api.post("/api/v1/curation/pin", json={"sql": sql, "name": "test"})
+        preview_response = api.post("/api/v1/curation/preview", json={"sql": sql})
+        assert pin_response.status_code == 400, pin_response.text
+        assert preview_response.status_code == 400, preview_response.text
+        assert pin_response.json()["detail"] == "sql must be exactly one read-only SELECT statement"
+        assert preview_response.json()["detail"] == pin_response.json()["detail"]
+        assert "DESCRIBE SELECT * FROM" not in pin_response.json()["detail"]
+        assert "syntax error at or near" not in pin_response.json()["detail"]

--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -239,3 +239,21 @@ def test_pin_rejects_pragma_and_describe_consistently(
         assert preview_response.json()["detail"] == pin_response.json()["detail"]
         assert "DESCRIBE SELECT * FROM" not in pin_response.json()["detail"]
         assert "syntax error at or near" not in pin_response.json()["detail"]
+
+
+def test_pin_accepts_from_first_and_parenthesized_selects(
+    writable_api: TestClient,
+) -> None:
+    # Parallel coverage with preview: the gate used to refuse every query
+    # that didn't start with SELECT or WITH, so FROM-first queries that
+    # preview accepts silently failed pin. They are legal DuckDB SELECTs
+    # that must reach both endpoints consistently.
+    for sql in (
+        "FROM episodes WHERE status = 'ok'",
+        "(SELECT episode_id FROM episodes)",
+        "VALUES (1, 'a'), (2, 'b')",
+    ):
+        response = writable_api.post(
+            "/api/v1/curation/pin", json={"sql": sql, "name": f"accepts {sql[:10]}"}
+        )
+        assert response.status_code == 200, response.text

--- a/packages/hflow-server/tests/test_server_curation_pin.py
+++ b/packages/hflow-server/tests/test_server_curation_pin.py
@@ -222,7 +222,8 @@ def test_pin_rejects_pragma_and_describe_consistently(
     writable_api: TestClient, api: TestClient
 ) -> None:
     # Mirrors preview's gate: PRAGMA/DESCRIBE/SHOW are StatementType.SELECT
-    # but not SELECT text, so both endpoints must agree (issue #450).
+    # but the endpoints advertise one read-only SELECT, so both must agree
+    # on refusing them (issue #450).
     for sql in (
         "PRAGMA database_list",
         "PRAGMA show_tables",

--- a/packages/hflow-server/tests/test_server_curation_preview.py
+++ b/packages/hflow-server/tests/test_server_curation_preview.py
@@ -237,3 +237,16 @@ def test_preview_accepts_select_with_leading_comments_and_cte(api: TestClient) -
         "WITH c AS (SELECT 1 AS one) SELECT * FROM c",
     ):
         assert api.post("/api/v1/curation/preview", json={"sql": sql}).status_code == 200
+
+
+def test_preview_accepts_from_first_and_parenthesized_selects(api: TestClient) -> None:
+    # Review of #453: FROM-first queries, parenthesized SELECTs, and VALUES
+    # clauses are legal read-only DuckDB statements (StatementType.SELECT)
+    # that the preview endpoint must run end-to-end, not refuse at the gate.
+    for sql in (
+        "FROM episodes WHERE status = 'ok'",
+        "(SELECT episode_id FROM episodes)",
+        "VALUES (1, 'a'), (2, 'b')",
+    ):
+        response = api.post("/api/v1/curation/preview", json={"sql": sql})
+        assert response.status_code == 200, response.text

--- a/packages/hflow-server/tests/test_server_curation_preview.py
+++ b/packages/hflow-server/tests/test_server_curation_preview.py
@@ -211,8 +211,8 @@ def test_preview_rejects_pragma_and_describe_consistently(api: TestClient) -> No
     # endpoints advertise exactly one read-only SELECT. Preview previously
     # interpolated the SQL as ``SELECT * FROM (<sql>)`` where those forms are
     # a syntax error, leaking the wrapper (``DESCRIBE SELECT * FROM (PRAGMA
-    # database_list)``) as the caller's 400. The shared gate now requires
-    # SELECT/WITH text, so preview and pin agree (issue #450).
+    # database_list)``) as the caller's 400. The shared gate now refuses
+    # these four by leading keyword, so preview and pin agree (issue #450).
     for sql in (
         "PRAGMA database_list",
         "PRAGMA show_tables",

--- a/packages/hflow-server/tests/test_server_curation_preview.py
+++ b/packages/hflow-server/tests/test_server_curation_preview.py
@@ -204,3 +204,36 @@ def test_preview_over_an_empty_catalog_returns_zero_rows(empty_catalog_api: Test
     assert payload["rows"] == []
     assert payload["row_count"] == 0
     assert payload["truncated"] is False
+
+
+def test_preview_rejects_pragma_and_describe_consistently(api: TestClient) -> None:
+    # DuckDB labels PRAGMA/DESCRIBE/SHOW/SUMMARIZE as SELECT, but the
+    # endpoints advertise exactly one read-only SELECT. Preview previously
+    # interpolated the SQL as ``SELECT * FROM (<sql>)`` where those forms are
+    # a syntax error, leaking the wrapper (``DESCRIBE SELECT * FROM (PRAGMA
+    # database_list)``) as the caller's 400. The shared gate now requires
+    # SELECT/WITH text, so preview and pin agree (issue #450).
+    for sql in (
+        "PRAGMA database_list",
+        "PRAGMA show_tables",
+        "PRAGMA version",
+        "DESCRIBE SELECT 1",
+        "SHOW TABLES",
+        "SUMMARIZE SELECT 1",
+    ):
+        response = api.post("/api/v1/curation/preview", json={"sql": sql})
+        assert response.status_code == 400, response.text
+        assert response.json()["detail"] == "sql must be exactly one read-only SELECT statement"
+        # No wrapper leak: the detail is the fixed gate message, not DuckDB's
+        # parser diagnostic for the rewritten query.
+        assert "DESCRIBE SELECT * FROM" not in response.json()["detail"]
+        assert "syntax error at or near" not in response.json()["detail"]
+
+
+def test_preview_accepts_select_with_leading_comments_and_cte(api: TestClient) -> None:
+    for sql in (
+        "-- comment\nSELECT episode_id FROM episodes",
+        "/* block */ SELECT episode_id FROM episodes",
+        "WITH c AS (SELECT 1 AS one) SELECT * FROM c",
+    ):
+        assert api.post("/api/v1/curation/preview", json={"sql": sql}).status_code == 200

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -571,10 +571,16 @@ def _leading_keyword(sql: str) -> str:
     DuckDB labels ``PRAGMA database_list``, ``DESCRIBE SELECT 1``,
     ``SHOW TABLES`` and ``SUMMARIZE SELECT 1`` as ``StatementType.SELECT``
     because they are table functions, and it accepts the latter three
-    inside ``FROM (<sql>)`` (the preview wrapper's shape) -- so a parse-based
+    inside ``FROM (<sql>)`` (the preview wrapper's shape), so a parse-based
     subquery check alone would let them through. The curation endpoints
     advertise exactly one read-only SELECT, so the gate also refuses these
     keywords when they head the original text.
+
+    This is a rule about the shape callers write, not a containment boundary.
+    ``(DESCRIBE SELECT 1)`` is not headed by the keyword and is accepted, and
+    that is fine: preview and pin both run it and agree, which is what #450
+    asked for. Read-only introspection of an in-memory catalog was never the
+    thing being kept out.
     """
     stripped = sql.lstrip()
     while True:
@@ -611,11 +617,9 @@ def reject_non_single_select(sql: str) -> None:
     The narrowing for ``PRAGMA`` / ``DESCRIBE`` / ``SHOW`` / ``SUMMARIZE``
     asks DuckDB the same question the preview wrapper does: does the SQL
     parse inside ``SELECT * FROM (<sql>)``? ``extract_statements`` on that
-    form accepts everything that runs as a subquery -- including FROM-first
-    queries, parenthesized SELECTs, and VALUES clauses that were
-    mis-rejected by the previous SELECT/WITH text-prefix heuristic (review
-    of #453) -- and refuses the four table-function keywords that the
-    endpoints refuse to advertise. Trailing semicolons and whitespace are
+    form accepts everything that runs as a subquery, including FROM-first
+    queries, parenthesized SELECTs, and VALUES clauses that a SELECT/WITH
+    text prefix would refuse (review of #453). Trailing semicolons and whitespace are
     stripped before wrapping, and a newline is appended when missing, so
     a trailing ``--`` line comment cannot swallow the wrapper's closing
     paren.
@@ -625,17 +629,17 @@ def reject_non_single_select(sql: str) -> None:
         # ``extract_statements`` on the user's SQL surfaces genuine parse
         # failures (a typoed keyword, an unterminated block comment) as
         # ``duckdb.Error`` and the gate propagates them untouched so the
-        # server's 400 detail can be DuckDB's own diagnostic -- that
+        # server's 400 detail can be DuckDB's own diagnostic. That
         # distinction is the rule's failure-mode contract.
         statements = parser_connection.extract_statements(sql)
         if len(statements) != 1 or statements[0].type != duckdb.StatementType.SELECT:
             raise NonSingleSelectQueryError("sql must be exactly one SELECT statement")
         # Refuse PRAGMA/DESCRIBE/SHOW/SUMMARIZE by leading keyword. DuckDB
         # labels them SELECT, and DESCRIBE/SHOW/SUMMARIZE even parse cleanly
-        # as subqueries -- only ``SELECT * FROM (PRAGMA database_list)``
-        # raises a parser error -- so the parse check below is necessary
-        # but not sufficient: this leading-keyword refusal is what keeps
-        # the gate in step with what the endpoints advertise.
+        # as subqueries. Only ``SELECT * FROM (PRAGMA database_list)`` raises
+        # a parser error, so the parse check below is necessary but not
+        # sufficient: this leading-keyword refusal is what keeps the gate in
+        # step with what the endpoints advertise.
         if _leading_keyword(sql) in _SUBQUERY_FORBIDDEN_LEADING_KEYWORDS:
             raise NonSingleSelectQueryError("sql must be exactly one read-only SELECT statement")
         # Parse the SQL inside the wrapper preview actually applies. Trailing

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -45,6 +45,7 @@ ran on what fraction of episodes, because a statistic over half a delivery
 must not look like a statistic over all of it.
 """
 
+import re
 import tempfile
 from collections.abc import Sequence
 from contextlib import ExitStack
@@ -554,6 +555,35 @@ class NonSingleSelectQueryError(ValueError):
     """
 
 
+def _strip_leading_sql_comments(sql: str) -> str:
+    """Leading whitespace and SQL comments stripped, for SELECT-text check.
+
+    DuckDB labels ``PRAGMA database_list``, ``DESCRIBE SELECT 1``,
+    ``SHOW TABLES`` and ``SUMMARIZE SELECT 1`` as ``StatementType.SELECT``
+    (they are table functions), so a bare type check would accept them.
+    The curation endpoints advertise exactly one read-only SELECT, so the
+    gate also requires the text to look like a SELECT — ``SELECT`` or
+    ``WITH`` (a CTE) after any leading ``--`` / ``/* */`` comments.
+    """
+
+    stripped = sql.lstrip()
+    while True:
+        if stripped.startswith("--"):
+            newline = stripped.find("\n")
+            if newline == -1:
+                return ""
+            stripped = stripped[newline + 1 :].lstrip()
+            continue
+        if stripped.startswith("/*"):
+            end = stripped.find("*/")
+            if end == -1:
+                return ""
+            stripped = stripped[end + 2 :].lstrip()
+            continue
+        break
+    return stripped
+
+
 def reject_non_single_select(sql: str) -> None:
     """Raise ``NonSingleSelectQueryError`` unless *sql* is one SELECT statement.
 
@@ -574,6 +604,15 @@ def reject_non_single_select(sql: str) -> None:
         parser_connection.close()
     if len(statements) != 1 or statements[0].type != duckdb.StatementType.SELECT:
         raise NonSingleSelectQueryError("sql must be exactly one SELECT statement")
+    # Narrow to actual SELECT text: DuckDB reports PRAGMA/DESCRIBE/SHOW/
+    # SUMMARIZE as SELECT, but the endpoints advertise SELECT only and preview
+    # interpolates the SQL as a subquery (``SELECT * FROM (<sql>)``) where
+    # those forms are a syntax error. Rejecting them here keeps preview and
+    # pin consistent and avoids blaming the caller for our wrapper's parse
+    # failure (``DESCRIBE SELECT * FROM (PRAGMA database_list)``).
+    stripped = _strip_leading_sql_comments(sql.strip())
+    if not re.match(r"(?i)^(SELECT|WITH)\b", stripped):
+        raise NonSingleSelectQueryError("sql must be exactly one read-only SELECT statement")
 
 
 def _stage_manifest_and_count(

--- a/src/hflow/curation.py
+++ b/src/hflow/curation.py
@@ -104,6 +104,16 @@ _TABLE_DIRECTORIES = {
 # dataset membership asks the same question and the two answers must agree.
 _RAN_STATUSES = tuple(status.value for status in RAN_STATUSES)
 
+# Leading keywords the curation gate refuses even though DuckDB labels them
+# ``StatementType.SELECT``. ``PRAGMA`` is caught by the subquery parse as
+# well; ``DESCRIBE``, ``SHOW`` and ``SUMMARIZE`` parse cleanly inside
+# ``FROM (<sql>)`` (DuckDB treats them as table functions) so the parse
+# check alone would let them through, which is not what the endpoints
+# advertise (issue #450, review of #453).
+_SUBQUERY_FORBIDDEN_LEADING_KEYWORDS = frozenset({"pragma", "describe", "show", "summarize"})
+# The first SQL identifier after any leading whitespace or comments.
+_LEADING_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
 
 def _column_ddl_for(directory_name: str) -> str:
     """The stored columns of one catalog directory, for an EMPTY relation.
@@ -555,17 +565,17 @@ class NonSingleSelectQueryError(ValueError):
     """
 
 
-def _strip_leading_sql_comments(sql: str) -> str:
-    """Leading whitespace and SQL comments stripped, for SELECT-text check.
+def _leading_keyword(sql: str) -> str:
+    """First SQL identifier at the head of *sql*, after any leading comments.
 
     DuckDB labels ``PRAGMA database_list``, ``DESCRIBE SELECT 1``,
     ``SHOW TABLES`` and ``SUMMARIZE SELECT 1`` as ``StatementType.SELECT``
-    (they are table functions), so a bare type check would accept them.
-    The curation endpoints advertise exactly one read-only SELECT, so the
-    gate also requires the text to look like a SELECT — ``SELECT`` or
-    ``WITH`` (a CTE) after any leading ``--`` / ``/* */`` comments.
+    because they are table functions, and it accepts the latter three
+    inside ``FROM (<sql>)`` (the preview wrapper's shape) -- so a parse-based
+    subquery check alone would let them through. The curation endpoints
+    advertise exactly one read-only SELECT, so the gate also refuses these
+    keywords when they head the original text.
     """
-
     stripped = sql.lstrip()
     while True:
         if stripped.startswith("--"):
@@ -581,7 +591,8 @@ def _strip_leading_sql_comments(sql: str) -> str:
             stripped = stripped[end + 2 :].lstrip()
             continue
         break
-    return stripped
+    match = _LEADING_IDENTIFIER_RE.match(stripped)
+    return match.group(0).lower() if match else ""
 
 
 def reject_non_single_select(sql: str) -> None:
@@ -596,23 +607,52 @@ def reject_non_single_select(sql: str) -> None:
     touches the connection.  A syntactically invalid string propagates the
     parser's ``duckdb.Error`` untouched — that is NOT this exception — so
     the two failure modes stay distinguishable.
+
+    The narrowing for ``PRAGMA`` / ``DESCRIBE`` / ``SHOW`` / ``SUMMARIZE``
+    asks DuckDB the same question the preview wrapper does: does the SQL
+    parse inside ``SELECT * FROM (<sql>)``? ``extract_statements`` on that
+    form accepts everything that runs as a subquery -- including FROM-first
+    queries, parenthesized SELECTs, and VALUES clauses that were
+    mis-rejected by the previous SELECT/WITH text-prefix heuristic (review
+    of #453) -- and refuses the four table-function keywords that the
+    endpoints refuse to advertise. Trailing semicolons and whitespace are
+    stripped before wrapping, and a newline is appended when missing, so
+    a trailing ``--`` line comment cannot swallow the wrapper's closing
+    paren.
     """
     parser_connection = duckdb.connect()
     try:
+        # ``extract_statements`` on the user's SQL surfaces genuine parse
+        # failures (a typoed keyword, an unterminated block comment) as
+        # ``duckdb.Error`` and the gate propagates them untouched so the
+        # server's 400 detail can be DuckDB's own diagnostic -- that
+        # distinction is the rule's failure-mode contract.
         statements = parser_connection.extract_statements(sql)
+        if len(statements) != 1 or statements[0].type != duckdb.StatementType.SELECT:
+            raise NonSingleSelectQueryError("sql must be exactly one SELECT statement")
+        # Refuse PRAGMA/DESCRIBE/SHOW/SUMMARIZE by leading keyword. DuckDB
+        # labels them SELECT, and DESCRIBE/SHOW/SUMMARIZE even parse cleanly
+        # as subqueries -- only ``SELECT * FROM (PRAGMA database_list)``
+        # raises a parser error -- so the parse check below is necessary
+        # but not sufficient: this leading-keyword refusal is what keeps
+        # the gate in step with what the endpoints advertise.
+        if _leading_keyword(sql) in _SUBQUERY_FORBIDDEN_LEADING_KEYWORDS:
+            raise NonSingleSelectQueryError("sql must be exactly one read-only SELECT statement")
+        # Parse the SQL inside the wrapper preview actually applies. Trailing
+        # semicolons and whitespace are stripped so a single ``SELECT 1;``
+        # still parses (curate()'s downstream ``connection.sql()`` handles
+        # trailing ``;`` itself; the server-side preview handler strips them
+        # at the boundary), and a newline is appended so a trailing ``--``
+        # comment without one cannot swallow the wrapper's ``)``.
+        wrapped_input = f"SELECT * FROM ({sql.rstrip().rstrip(';').rstrip()}\n)"
+        try:
+            parser_connection.extract_statements(wrapped_input)
+        except duckdb.Error as exc:
+            raise NonSingleSelectQueryError(
+                "sql must be exactly one read-only SELECT statement"
+            ) from exc
     finally:
         parser_connection.close()
-    if len(statements) != 1 or statements[0].type != duckdb.StatementType.SELECT:
-        raise NonSingleSelectQueryError("sql must be exactly one SELECT statement")
-    # Narrow to actual SELECT text: DuckDB reports PRAGMA/DESCRIBE/SHOW/
-    # SUMMARIZE as SELECT, but the endpoints advertise SELECT only and preview
-    # interpolates the SQL as a subquery (``SELECT * FROM (<sql>)``) where
-    # those forms are a syntax error. Rejecting them here keeps preview and
-    # pin consistent and avoids blaming the caller for our wrapper's parse
-    # failure (``DESCRIBE SELECT * FROM (PRAGMA database_list)``).
-    stripped = _strip_leading_sql_comments(sql.strip())
-    if not re.match(r"(?i)^(SELECT|WITH)\b", stripped):
-        raise NonSingleSelectQueryError("sql must be exactly one read-only SELECT statement")
 
 
 def _stage_manifest_and_count(

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1192,6 +1192,43 @@ def test_reject_non_single_select_distinguishes_parse_failure_from_rule_rejectio
         reject_non_single_select("CREATE TABLE t(x INT)")
 
 
+def test_reject_non_single_select_refuses_pragma_and_describe_labeled_as_select() -> None:
+    # DuckDB labels PRAGMA, DESCRIBE, SHOW, SUMMARIZE as StatementType.SELECT
+    # because they are table functions, but the curation endpoints advertise
+    # exactly one read-only SELECT. Preview interpolated the SQL as
+    # ``SELECT * FROM (<sql>)`` where those forms are a syntax error, so the
+    # wrapper's parse failure leaked as the caller's error and preview/pin
+    # disagreed. The gate now requires SELECT/WITH text (issue #450).
+    for sql in (
+        "PRAGMA database_list",
+        "PRAGMA show_tables",
+        "PRAGMA version",
+        "DESCRIBE SELECT 1",
+        "SHOW TABLES",
+        "SUMMARIZE SELECT 1",
+    ):
+        with pytest.raises(NonSingleSelectQueryError, match=r"exactly one.*SELECT"):
+            reject_non_single_select(sql)
+    # Case-insensitive and comment-prefixed forms are likewise rejected.
+    with pytest.raises(NonSingleSelectQueryError):
+        reject_non_single_select("pragma database_list")
+    with pytest.raises(NonSingleSelectQueryError):
+        reject_non_single_select("-- comment\nPRAGMA database_list")
+    with pytest.raises(NonSingleSelectQueryError):
+        reject_non_single_select("/* block */ DESCRIBE SELECT 1")
+
+
+def test_reject_non_single_select_accepts_select_with_leading_comments_and_cte() -> None:
+    # Leading -- and /* */ comments do not change the statement type.
+    reject_non_single_select("-- comment\nSELECT 1")
+    reject_non_single_select("/* block comment */ SELECT 1")
+    reject_non_single_select("/*c*/--line\n  SELECT 1")
+    reject_non_single_select("WITH c AS (SELECT 1) SELECT * FROM c")
+    reject_non_single_select("with c as (select 1) select * from c")
+    # A SELECT that reads a pragma as a table function is still SELECT text.
+    reject_non_single_select("SELECT * FROM pragma_version()")
+
+
 def test_constrained_curate_writes_the_manifest_but_refuses_outside_reads(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1229,6 +1229,30 @@ def test_reject_non_single_select_accepts_select_with_leading_comments_and_cte()
     reject_non_single_select("SELECT * FROM pragma_version()")
 
 
+def test_reject_non_single_select_accepts_legal_selects_that_do_not_start_with_select() -> None:
+    # Review of #453: the previous text-prefix heuristic rejected every query
+    # that didn't start with SELECT or WITH, but DuckDB labels FROM-first
+    # queries, parenthesized selects, and VALUES clauses as
+    # StatementType.SELECT and accepts them inside ``FROM (<sql>)`` -- the
+    # shape preview interpolates. The gate must accept them too.
+    reject_non_single_select("FROM range(3)")
+    reject_non_single_select("FROM range(3) WHERE range > 0")
+    reject_non_single_select("(SELECT 1)")
+    reject_non_single_select("(SELECT 1 AS one)")
+    reject_non_single_select("VALUES (1), (2)")
+    reject_non_single_select("VALUES (1, 'a'), (2, 'b')")
+    # FROM-first against a real catalog column. A SELECT previewed from this
+    # is the case the reviewer flagged as "the one that matters".
+    reject_non_single_select("FROM episodes WHERE status = 'ok'")
+
+
+def test_reject_non_single_select_accepts_trailing_line_comment_without_newline() -> None:
+    # Without the fix, ``SELECT * FROM (SELECT 1 -- trailing comment)`` is a
+    # parser error: the trailing line comment swallows the wrapper's closing
+    # paren. Appending a newline before wrapping ends the comment first.
+    reject_non_single_select("SELECT 1 -- trailing comment without newline")
+
+
 def test_constrained_curate_writes_the_manifest_but_refuses_outside_reads(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_catalog_curation.py
+++ b/tests/test_catalog_curation.py
@@ -1196,9 +1196,9 @@ def test_reject_non_single_select_refuses_pragma_and_describe_labeled_as_select(
     # DuckDB labels PRAGMA, DESCRIBE, SHOW, SUMMARIZE as StatementType.SELECT
     # because they are table functions, but the curation endpoints advertise
     # exactly one read-only SELECT. Preview interpolated the SQL as
-    # ``SELECT * FROM (<sql>)`` where those forms are a syntax error, so the
+    # ``SELECT * FROM (<sql>)`` where PRAGMA is a syntax error, so the
     # wrapper's parse failure leaked as the caller's error and preview/pin
-    # disagreed. The gate now requires SELECT/WITH text (issue #450).
+    # disagreed. The gate now refuses these four by leading keyword (#450).
     for sql in (
         "PRAGMA database_list",
         "PRAGMA show_tables",
@@ -1233,7 +1233,7 @@ def test_reject_non_single_select_accepts_legal_selects_that_do_not_start_with_s
     # Review of #453: the previous text-prefix heuristic rejected every query
     # that didn't start with SELECT or WITH, but DuckDB labels FROM-first
     # queries, parenthesized selects, and VALUES clauses as
-    # StatementType.SELECT and accepts them inside ``FROM (<sql>)`` -- the
+    # StatementType.SELECT and accepts them inside ``FROM (<sql>)``, the
     # shape preview interpolates. The gate must accept them too.
     reject_non_single_select("FROM range(3)")
     reject_non_single_select("FROM range(3) WHERE range > 0")
@@ -1251,6 +1251,18 @@ def test_reject_non_single_select_accepts_trailing_line_comment_without_newline(
     # parser error: the trailing line comment swallows the wrapper's closing
     # paren. Appending a newline before wrapping ends the comment first.
     reject_non_single_select("SELECT 1 -- trailing comment without newline")
+
+
+def test_reject_non_single_select_keyword_refusal_is_about_the_leading_word() -> None:
+    # The PRAGMA/DESCRIBE/SHOW/SUMMARIZE refusal reads the first identifier,
+    # so a parenthesized DESCRIBE is not headed by the keyword and is
+    # accepted. Pinned deliberately: preview and pin both run that form and
+    # agree on it, which is the #450 requirement. Read-only introspection of
+    # an in-memory catalog was never what the gate was keeping out.
+    reject_non_single_select("(DESCRIBE SELECT 1)")
+    reject_non_single_select("SELECT * FROM (SHOW TABLES)")
+    with pytest.raises(NonSingleSelectQueryError):
+        reject_non_single_select("DESCRIBE SELECT 1")
 
 
 def test_constrained_curate_writes_the_manifest_but_refuses_outside_reads(


### PR DESCRIPTION
Fixes #450

**What was broken**
`POST /curation/preview` and `POST /curation/pin` both advertise "exactly one read-only SELECT" but disagreed on PRAGMA/DESCRIBE/SHOW/SUMMARIZE. DuckDB labels those as `StatementType.SELECT` (table functions), so the shared gate accepted them. Pin runs SQL as-is → 200. Preview wraps as `DESCRIBE SELECT * FROM (<sql>)` → parser error `syntax error at or near ")"` with `LINE 1: DESCRIBE SELECT * FROM (PRAGMA database_list)` – our wrapper blamed as caller's syntax error.

**Why**
Gate checked only `StatementType.SELECT`. `PRAGMA database_list` is a legal statement but an illegal subquery, so the wrapper fails to parse. The 400 detail leaked internal rewrite. Preview→pin flow allowed pinning a cut that preview refused.

**What changed**
Narrow the shared gate in `src/hflow/curation.py:reject_non_single_select` – after type check, require stripped SQL to start with `SELECT` or `WITH` (CTE) after leading `--`/`/* */` comments (`(?i)^(SELECT|WITH)\b`). Both endpoints now reject PRAGMA/DESCRIBE/etc with the existing `"sql must be exactly one read-only SELECT statement"` and no wrapper leak. `SELECT * FROM pragma_version()` remains allowed (SELECT text).

**Why this choice**
Issue offered: narrow gate vs stop wrapping. Chose narrow gate – simple, consistent with advertised rule, minimal diff, no risk of materializing large results just to name columns. Pinning `PRAGMA`-based cuts is not a real use case; a SELECT that needs pragma data can still `SELECT * FROM pragma_version()` as SELECT text. Keeps preview's LIMIT/count/SUMMARIZE wrapping unchanged; after gate, wrapper only sees SELECT/WITH which is always wrappable, so misleading parse error disappears.

**How tested**
- Before: `PRAGMA database_list` → preview 400 (wrapper leak) vs pin 200 (divergence). After: both 400 with fixed message.
- New tests: `tests/test_catalog_curation.py` – gate rejects PRAGMA/DESCRIBE/SHOW/SUMMARIZE (incl. comment-prefixed) and accepts `--`/`/* */`+SELECT and `WITH`; `packages/hflow-server/tests/test_server_curation_preview.py` and `test_server_curation_pin.py` – preview/pin agree and no `DESCRIBE SELECT * FROM` leak.
- Suites: `pytest tests/test_catalog_curation.py` 97 passed, `pytest packages/hflow-server/tests` 234 passed, `ruff check`/`format`/`ty check` clean.

Not a security fix – `constrained=True` already blocks file access regardless of statement type.