### PR TITLE
feat(verify): check LeRobot prepared-manifest deliveries against receipts

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -236,13 +236,23 @@ Every `hflow` command follows the same three-value convention:
 - `0` - success: the command did what it was asked.
 - `1` - ran, and found something to report: `doctor`, a non-conforming file;
   `stale --exit-code`, stale episodes found; `up`, started then failed, so
-  containers may still be running; `ingest`, episodes failed.
+  containers may still be running; `ingest`, episodes failed; `verify`, a
+  delivery whose receipts no longer match the claimed objects.
 - `2` - bad input, nothing useful happened: an invalid flag combination, an
   unreachable endpoint, a missing catalog, a `serve` launch that never started
   (a port outside 1-65535, a data root that exists and is not a directory, a
-  host with no free port), or a `doctor` run in which no file could be
-  diagnosed at all. A data root that is not there yet is not bad input: it is a
+  host with no free port), a `doctor` run in which no file could be
+  diagnosed at all, or a `verify` run whose root or receipt file cannot be
+  read. A data root that is not there yet is not bad input: it is a
   workspace nothing has ingested into, and `serve` and `up` both accept one.
+
+The `verify` family adds one further code so CI can tell an unverifiable
+delivery apart from a damaged one:
+
+- `3` - the command could read the data root, but there is no receipt to
+  verify against (for example `hflow verify lerobot-import` with no
+  `prepared-manifest.json`, or `hflow verify snapshot` with no integrity
+  receipt in `format.json`).
 
 `doctor` treats an unreadable file as at least as bad as a non-conforming one
 (exit 1), and reserves 2 for runs where nothing was diagnosed, so a batch run

--- a/docs/how-to/import-lerobot-v3.md
+++ b/docs/how-to/import-lerobot-v3.md
@@ -59,8 +59,21 @@ Durable outputs land as `landing/*.mcap` and `prepared-manifest.json` under
 that prefix. The manifest (schema version 3) carries a `episodes` receipt
 list: every delivered episode's published URI, its `content_id` (the sha256
 content address of the canonical bytes, the same value the catalog uses for
-dedupe), and its `size_bytes`, so a delivery can be checked against the
-manifest without re-running the import. Hugging Face downloads stay in the
+dedupe), and its `size_bytes`. Check a delivery without re-running the import:
+
+```bash
+uv run hflow verify lerobot-import ./data/lerobot_pusht
+# or, from Python:
+# hflow.verify_lerobot_import("./data/lerobot_pusht")
+```
+
+Verification resolves each episode as `landing/<basename>` under the data root
+you pass in (the same layout the importer writes). The receipt `uri` is
+publish-time provenance kept on findings; it is not opened as a lookup path,
+so a copied delivery is checked in place even when the original publish path
+still exists elsewhere.
+
+Hugging Face downloads stay in the
 local mirror under
 `_lerobot_cache/` (`HFLOW_MIRROR_DIR`, or `$XDG_CACHE_HOME/hflow/mirrors`) and
 are never uploaded into the bucket. The success manifest is published only

--- a/src/hflow/__init__.py
+++ b/src/hflow/__init__.py
@@ -49,7 +49,7 @@ from hflow.fingerprints import (
     step_version_from_contract,
 )
 from hflow.format import GopPreset
-from hflow.importers import import_lerobot_dataset
+from hflow.importers import import_lerobot_dataset, verify_lerobot_import
 from hflow.manifest import (
     DerivedChannelManifest,
     PipelineManifest,
@@ -105,6 +105,11 @@ from hflow.storage import (
     parse_storage_root,
 )
 from hflow.transform import EpisodeStamps, TransformConfig, write_canonical_episode
+from hflow.verification import (
+    VerificationFinding,
+    VerificationReport,
+    VerificationStatus,
+)
 from hflow.workspace import Workspace, WorkspaceIdentity
 
 __all__ = [
@@ -182,6 +187,9 @@ __all__ = [
     "Threshold",
     "TopicInfo",
     "TransformConfig",
+    "VerificationFinding",
+    "VerificationReport",
+    "VerificationStatus",
     "Workspace",
     "WorkspaceIdentity",
     "__version__",
@@ -210,5 +218,6 @@ __all__ = [
     "testing",
     "to_grid",
     "verify_dataset_snapshot",
+    "verify_lerobot_import",
     "write_canonical_episode",
 ]

--- a/src/hflow/cli.py
+++ b/src/hflow/cli.py
@@ -1,7 +1,8 @@
 """Command-line entry point.
 
 Subcommands: ``curate``, ``catalog ui``, ``dataset create``, ``import lerobot``,
-``export snapshot``, ``stale``, ``doctor``, ``manifest``, ``package``, the Compose runtime family
+``export snapshot``, ``verify snapshot``, ``verify lerobot-import``, ``stale``,
+``doctor``, ``manifest``, ``package``, the Compose runtime family
 ``up``/``down``/``ingest``/``status``, ``deploy`` for bring-your-own Airflow,
 and ``serve`` for the workspace HTTP server (a separate ``hflow-server``
 package, imported only when invoked).
@@ -383,7 +384,8 @@ def _build_parser() -> argparse.ArgumentParser:
         description=(
             "Group commands for verifying deliveries against their recorded "
             "receipts. Use `snapshot` to re-check a delivered dataset snapshot "
-            "directory against the integrity receipt inside its format.json."
+            "directory against the integrity receipt inside its format.json. "
+            "Use `lerobot-import` to re-check a LeRobot prepared-manifest delivery."
         ),
     )
     verify_subparsers = verify_parser.add_subparsers(dest="verify_command", required=True)
@@ -400,6 +402,23 @@ def _build_parser() -> argparse.ArgumentParser:
     verify_snapshot_parser.add_argument(
         "directory",
         help="the delivered dataset snapshot directory to verify",
+    )
+    verify_lerobot_import_parser = verify_subparsers.add_parser(
+        "lerobot-import",
+        help="verify a LeRobot import against prepared-manifest.json",
+        description=(
+            "Read schema-3 prepared-manifest.json under a data root and check every "
+            "episode receipt against landing/<basename> under that root. Unlisted "
+            "files under landing/ are ignored. Exit 0 clean, 1 damaged, 2 unreadable "
+            "input, 3 unverifiable (no prepared-manifest)."
+        ),
+    )
+    verify_lerobot_import_parser.add_argument(
+        "data_root",
+        help=(
+            "data root that holds prepared-manifest.json and landing/: local "
+            "directory or object-store prefix (s3://, gs://, az://)"
+        ),
     )
 
     stale_parser = subparsers.add_parser(
@@ -1516,6 +1535,30 @@ def _command_verify_snapshot(arguments: argparse.Namespace) -> int:
     return exit_code_for(report)
 
 
+def _command_verify_lerobot_import(arguments: argparse.Namespace) -> int:
+    from hflow.importers.lerobot_verify import verify_lerobot_import
+    from hflow.verification import exit_code_for
+
+    try:
+        report = verify_lerobot_import(arguments.data_root)
+    except (ValueError, OSError, ModuleNotFoundError) as error:
+        print(f"verify lerobot-import: {error}", file=sys.stderr)
+        return 2
+
+    if report.ok:
+        print("verify lerobot-import: ok")
+        return 0
+
+    for finding in report.findings:
+        print(
+            f"verify lerobot-import: {finding.reason}: {finding.uri}: {finding.detail}",
+            file=sys.stderr,
+        )
+    if not report.findings:
+        print("verify lerobot-import: unverifiable: no prepared-manifest receipt", file=sys.stderr)
+    return exit_code_for(report)
+
+
 def _command_doctor(arguments: argparse.Namespace) -> int:
     # Findings, not exceptions, across files as well: an unreadable path is a
     # finding about the corpus, reported in place, so a batch run never loses
@@ -1691,6 +1734,8 @@ def main(argv: list[str] | None = None) -> int:
     if arguments.command == "verify":
         if arguments.verify_command == "snapshot":
             return _command_verify_snapshot(arguments)
+        if arguments.verify_command == "lerobot-import":
+            return _command_verify_lerobot_import(arguments)
         raise AssertionError(f"unhandled verify command {arguments.verify_command!r}")
     if arguments.command == "stale":
         return _command_stale(arguments)

--- a/src/hflow/importers/__init__.py
+++ b/src/hflow/importers/__init__.py
@@ -1,5 +1,6 @@
 """First-party importers for supported robotics dataset formats."""
 
 from hflow.importers.lerobot import import_lerobot_dataset
+from hflow.importers.lerobot_verify import verify_lerobot_import
 
-__all__ = ["import_lerobot_dataset"]
+__all__ = ["import_lerobot_dataset", "verify_lerobot_import"]

--- a/src/hflow/importers/lerobot_verify.py
+++ b/src/hflow/importers/lerobot_verify.py
@@ -1,0 +1,173 @@
+"""Verify a LeRobot prepared-manifest delivery against its episode receipts.
+
+Shared report types live in :mod:`hflow.verification`. This module owns only
+the import-delivery half: resolve each claimed episode under the verified
+data root as ``landing/<basename>``, compare ``size_bytes`` and
+``content_id``, and ignore unlisted files.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from hflow.catalog import content_episode_id
+from hflow.storage import StorageRoot, parse_storage_root
+from hflow.verification import (
+    REASON_CONTENT_ID_MISMATCH,
+    REASON_MISSING,
+    REASON_SIZE_MISMATCH,
+    VerificationFinding,
+    VerificationReport,
+    VerificationStatus,
+)
+
+PREPARED_MANIFEST_RELATIVE_KEY = "prepared-manifest.json"
+SUPPORTED_PREPARED_MANIFEST_SCHEMA_VERSION = 3
+LANDING_DIRECTORY = "landing"
+
+
+def verify_lerobot_import(data_root: str | Path | StorageRoot) -> VerificationReport:
+    """Check a LeRobot import delivery against its schema-3 prepared manifest.
+
+    Reads ``prepared-manifest.json`` under ``data_root`` and, for each episode
+    receipt, compares ``size_bytes`` and ``content_id`` to
+    ``landing/<basename>`` under that same root (fetched into the local
+    mirror when the root is a bucket). Does not re-convert, does not touch
+    the Hugging Face cache, and ignores unlisted files under ``landing/``.
+
+    Raises:
+        ValueError: the root or manifest cannot be read as a prepared import
+            (CLI exit ``2``).
+    """
+    try:
+        storage = parse_storage_root(data_root)
+    except ValueError as error:
+        raise ValueError(f"cannot read data root: {error}") from error
+
+    if not storage.exists(PREPARED_MANIFEST_RELATIVE_KEY):
+        return VerificationReport(status=VerificationStatus.UNVERIFIABLE)
+
+    try:
+        manifest_path = storage.fetch(PREPARED_MANIFEST_RELATIVE_KEY)
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"{PREPARED_MANIFEST_RELATIVE_KEY} is not valid JSON: {error.msg}"
+        ) from error
+    except OSError as error:
+        raise ValueError(f"cannot read {PREPARED_MANIFEST_RELATIVE_KEY}: {error}") from error
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"{PREPARED_MANIFEST_RELATIVE_KEY} must be a JSON object")
+
+    schema_version = payload.get("schema_version")
+    if schema_version != SUPPORTED_PREPARED_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"{PREPARED_MANIFEST_RELATIVE_KEY} schema_version must be "
+            f"{SUPPORTED_PREPARED_MANIFEST_SCHEMA_VERSION}, got {schema_version!r}"
+        )
+
+    episodes = payload.get("episodes")
+    if not isinstance(episodes, list):
+        raise ValueError(f"{PREPARED_MANIFEST_RELATIVE_KEY} is missing an episodes list")
+    if not episodes:
+        # A readable schema-3 receipt that claims nothing is clean, not
+        # unverifiable: there is no missing receipt for a human to hunt down.
+        return VerificationReport(status=VerificationStatus.OK)
+
+    findings: list[VerificationFinding] = []
+    for index, entry in enumerate(episodes):
+        findings.extend(_findings_for_episode_receipt(storage, entry, index=index))
+
+    if findings:
+        return VerificationReport(status=VerificationStatus.DAMAGED, findings=findings)
+    return VerificationReport(status=VerificationStatus.OK)
+
+
+def _landing_relative_key_from_receipt_uri(uri: str, *, index: int) -> str:
+    """Map a publish-time uri to ``landing/<basename>`` under the verified root.
+
+    Schema 3 stores an absolute publish uri as provenance. The importer always
+    places episodes at ``landing/lerobot_episode_XXXX.mcap``, so the basename
+    is enough to re-resolve under a copied data root without a schema bump.
+    """
+    parsed = urlparse(uri)
+    path_text = unquote(parsed.path) if parsed.scheme else uri
+    basename = PurePosixPath(path_text.replace("\\", "/")).name
+    if not basename or basename in {".", ".."} or "/" in basename or "\\" in basename:
+        raise ValueError(f"episodes[{index}].uri has no usable landing basename: {uri!r}")
+    return f"{LANDING_DIRECTORY}/{basename}"
+
+
+def _findings_for_episode_receipt(
+    storage: StorageRoot, entry: Any, *, index: int
+) -> list[VerificationFinding]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"episodes[{index}] must be a JSON object")
+
+    try:
+        uri = entry["uri"]
+        expected_content_id = entry["content_id"]
+        expected_size_bytes = entry["size_bytes"]
+    except KeyError as error:
+        raise ValueError(
+            f"episodes[{index}] is missing required field {error.args[0]!r}"
+        ) from error
+
+    if not isinstance(uri, str) or not uri:
+        raise ValueError(f"episodes[{index}].uri must be a non-empty string")
+    if not isinstance(expected_content_id, str) or not expected_content_id:
+        raise ValueError(f"episodes[{index}].content_id must be a non-empty string")
+    if not isinstance(expected_size_bytes, int) or isinstance(expected_size_bytes, bool):
+        raise ValueError(f"episodes[{index}].size_bytes must be an integer")
+
+    relative_key = _landing_relative_key_from_receipt_uri(uri, index=index)
+    if not storage.exists(relative_key):
+        return [
+            VerificationFinding(
+                uri=uri,
+                reason=REASON_MISSING,
+                detail=f"landing object missing at {relative_key!r} under the verified root",
+            )
+        ]
+
+    try:
+        local_path = storage.fetch(relative_key)
+    except FileNotFoundError:
+        return [
+            VerificationFinding(
+                uri=uri,
+                reason=REASON_MISSING,
+                detail=f"landing object missing at {relative_key!r} under the verified root",
+            )
+        ]
+    except OSError as error:
+        raise ValueError(f"cannot read episode {relative_key!r}: {error}") from error
+
+    findings: list[VerificationFinding] = []
+    actual_size = local_path.stat().st_size
+    if actual_size != expected_size_bytes:
+        findings.append(
+            VerificationFinding(
+                uri=uri,
+                reason=REASON_SIZE_MISMATCH,
+                detail=f"size_bytes {actual_size} != receipt {expected_size_bytes}",
+            )
+        )
+
+    actual_content_id = content_episode_id(local_path)
+    if actual_content_id != expected_content_id:
+        findings.append(
+            VerificationFinding(
+                uri=uri,
+                reason=REASON_CONTENT_ID_MISMATCH,
+                detail=f"content_id {actual_content_id!r} != receipt {expected_content_id!r}",
+            )
+        )
+    return findings
+
+
+__all__ = ["verify_lerobot_import"]

--- a/src/hflow/verification.py
+++ b/src/hflow/verification.py
@@ -3,9 +3,11 @@
 ``VerificationReport`` is the common surface for delivery verifiers: a
 verifier reads the receipt a delivery carries, compares it to the bytes
 under the root being verified, and returns one report. Files nobody
-listed are ignored. The LeRobot import verifier (#454) and the dataset
-snapshot verifier (#428) both return this shape, so one CLI and one
-exit-code mapping cover every delivered artifact.
+listed are ignored. The LeRobot import verifier
+(:func:`hflow.importers.lerobot_verify.verify_lerobot_import`, #454) and the
+dataset snapshot verifier (:func:`hflow.snapshot.verify_dataset_snapshot`,
+#428) both return this shape, so one CLI and one exit-code mapping cover
+every delivered artifact.
 
 Reasons are fixed strings so callers can branch on them.
 ``exit_code_for`` maps a report to the verify-family exit codes: 0 clean,

--- a/tests/test_lerobot_converter.py
+++ b/tests/test_lerobot_converter.py
@@ -1428,6 +1428,13 @@ def test_manifest_content_id_detects_a_truncated_episode(
 ) -> None:
     """The #379 controlled result as a test: truncating one episode to zero
     bytes is detectable from the delivery by re-hashing against the manifest."""
+    from hflow.importers.lerobot_verify import verify_lerobot_import
+    from hflow.verification import (
+        REASON_CONTENT_ID_MISMATCH,
+        REASON_SIZE_MISMATCH,
+        VerificationStatus,
+    )
+
     output_dir = tmp_path / "out"
     monkeypatch.setattr(
         prep, "_hf_repo_info", lambda repo, revision: {"sha": "abc", "license": "apache-2.0"}
@@ -1452,6 +1459,13 @@ def test_manifest_content_id_detects_a_truncated_episode(
     episode_path.write_bytes(b"")
     assert episode_path.stat().st_size != entry["size_bytes"]
     assert prep.content_episode_id(episode_path) != entry["content_id"]
+
+    report = verify_lerobot_import(output_dir)
+    assert report.status is VerificationStatus.DAMAGED
+    assert {finding.reason for finding in report.findings} == {
+        REASON_SIZE_MISMATCH,
+        REASON_CONTENT_ID_MISMATCH,
+    }
 
 
 def test_import_skips_bucket_manifest_when_an_episode_publish_fails(

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,261 @@
+"""Outcome-focused tests for prepared-manifest delivery verification."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from hflow.catalog import content_episode_id
+from hflow.cli import main
+from hflow.importers.lerobot_verify import verify_lerobot_import
+from hflow.storage import BucketStorageRoot
+from hflow.verification import (
+    REASON_CONTENT_ID_MISMATCH,
+    REASON_MISSING,
+    REASON_SIZE_MISMATCH,
+    VerificationStatus,
+    exit_code_for,
+)
+
+
+def _write_prepared_delivery(root: Path, *, payload: bytes = b"episode-0") -> Path:
+    landing = root / "landing"
+    landing.mkdir(parents=True)
+    episode_path = landing / "lerobot_episode_0001.mcap"
+    episode_path.write_bytes(payload)
+    manifest = {
+        "schema_version": 3,
+        "dataset": {"repo_id": "fake/repo", "revision": "abc", "license": "apache-2.0"},
+        "camera_keys": ["observation.image"],
+        "episodes_converted": 1,
+        "episodes": [
+            {
+                "uri": str(episode_path.resolve()),
+                "content_id": content_episode_id(episode_path),
+                "size_bytes": episode_path.stat().st_size,
+            }
+        ],
+        "converter_version": "test",
+    }
+    (root / "prepared-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return episode_path
+
+
+def test_verify_lerobot_import_accepts_an_unchanged_delivery(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    _write_prepared_delivery(root)
+    (root / "landing" / "extra-unlisted.bin").write_bytes(b"noise")
+
+    report = verify_lerobot_import(root)
+
+    assert report.ok
+    assert report.status is VerificationStatus.OK
+    assert report.findings == []
+    assert exit_code_for(report) == 0
+
+
+def test_verify_lerobot_import_detects_truncation(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    episode_path = _write_prepared_delivery(root)
+    episode_path.write_bytes(b"")
+
+    report = verify_lerobot_import(root)
+
+    assert not report.ok
+    assert report.status is VerificationStatus.DAMAGED
+    reasons = {finding.reason for finding in report.findings}
+    assert reasons == {REASON_SIZE_MISMATCH, REASON_CONTENT_ID_MISMATCH}
+    assert exit_code_for(report) == 1
+
+
+def test_verify_lerobot_import_detects_same_length_byte_replacement(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    episode_path = _write_prepared_delivery(root, payload=b"episode-0")
+    original_size = episode_path.stat().st_size
+    episode_path.write_bytes(b"Episode-0")
+    assert episode_path.stat().st_size == original_size
+
+    report = verify_lerobot_import(root)
+
+    assert report.status is VerificationStatus.DAMAGED
+    assert [finding.reason for finding in report.findings] == [REASON_CONTENT_ID_MISMATCH]
+    assert all(finding.uri.endswith("lerobot_episode_0001.mcap") for finding in report.findings)
+
+
+def test_verify_lerobot_import_detects_a_missing_landing_object(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    episode_path = _write_prepared_delivery(root)
+    episode_path.unlink()
+
+    report = verify_lerobot_import(root)
+
+    assert report.status is VerificationStatus.DAMAGED
+    assert [finding.reason for finding in report.findings] == [REASON_MISSING]
+    assert exit_code_for(report) == 1
+
+
+def test_verify_lerobot_import_is_unverifiable_without_a_manifest(tmp_path: Path) -> None:
+    root = tmp_path / "empty"
+    root.mkdir()
+
+    report = verify_lerobot_import(root)
+
+    assert report.status is VerificationStatus.UNVERIFIABLE
+    assert report.findings == []
+    assert exit_code_for(report) == 3
+
+
+def test_verify_lerobot_import_accepts_an_empty_episodes_list(tmp_path: Path) -> None:
+    """A readable receipt that claims nothing is clean, not unverifiable."""
+    root = tmp_path / "delivery"
+    root.mkdir()
+    (root / "prepared-manifest.json").write_text(
+        json.dumps({"schema_version": 3, "episodes": []}),
+        encoding="utf-8",
+    )
+
+    report = verify_lerobot_import(root)
+
+    assert report.status is VerificationStatus.OK
+    assert report.ok
+    assert exit_code_for(report) == 0
+
+
+def test_verify_lerobot_import_refuses_corrupt_manifest_json(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    root.mkdir()
+    (root / "prepared-manifest.json").write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        verify_lerobot_import(root)
+
+
+def test_verify_lerobot_import_refuses_unsupported_schema_version(tmp_path: Path) -> None:
+    root = tmp_path / "delivery"
+    root.mkdir()
+    (root / "prepared-manifest.json").write_text(
+        json.dumps({"schema_version": 2, "episodes": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be 3"):
+        verify_lerobot_import(root)
+
+
+def test_verify_lerobot_import_reads_a_copied_delivery_not_the_original(
+    tmp_path: Path,
+) -> None:
+    """Kevin's #432 DoD: verify the root handed in, never the publish-time path."""
+    original = tmp_path / "original"
+    original_episode = _write_prepared_delivery(original, payload=b"episode-0")
+    copied = tmp_path / "copied"
+    shutil.copytree(original, copied)
+    copied_episode = copied / "landing" / "lerobot_episode_0001.mcap"
+
+    # Manifest still names the absolute original uri; that is the recipient case.
+    manifest = json.loads((copied / "prepared-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["episodes"][0]["uri"] == str(original_episode.resolve())
+
+    report = verify_lerobot_import(copied)
+    assert report.status is VerificationStatus.OK
+
+    # Prove the copy was hashed: mutating only the original must not matter.
+    original_episode.write_bytes(b"Episode-0")
+    assert verify_lerobot_import(copied).status is VerificationStatus.OK
+
+    # Damaging only the copy must go red (the false-pass Kevin reproduced).
+    copied_episode.write_bytes(b"Episode-0")
+    damaged = verify_lerobot_import(copied)
+    assert damaged.status is VerificationStatus.DAMAGED
+    assert [finding.reason for finding in damaged.findings] == [REASON_CONTENT_ID_MISMATCH]
+
+
+def test_verify_lerobot_import_accepts_a_copy_when_the_original_is_gone(
+    tmp_path: Path,
+) -> None:
+    original = tmp_path / "original"
+    _write_prepared_delivery(original, payload=b"episode-0")
+    copied = tmp_path / "copied"
+    shutil.copytree(original, copied)
+    shutil.rmtree(original)
+
+    report = verify_lerobot_import(copied)
+
+    assert report.status is VerificationStatus.OK
+    assert report.findings == []
+
+
+def test_verify_lerobot_import_resolves_bucket_deliveries_under_the_verified_root(
+    tmp_path: Path,
+    bucket_over_tmp: tuple[BucketStorageRoot, Path],
+) -> None:
+    """Bucket roots use the same landing/<basename> fetch; no cloud credentials."""
+    original_root, original_remote = bucket_over_tmp
+    payload = b"episode-0"
+    staged = tmp_path / "staged.mcap"
+    staged.write_bytes(payload)
+    published_uri = original_root.publish(staged, "landing/lerobot_episode_0001.mcap")
+    content_id = content_episode_id(staged)
+    size_bytes = staged.stat().st_size
+    manifest = {
+        "schema_version": 3,
+        "episodes": [
+            {
+                "uri": published_uri,
+                "content_id": content_id,
+                "size_bytes": size_bytes,
+            }
+        ],
+    }
+    manifest_path = tmp_path / "prepared-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    original_root.publish(manifest_path, "prepared-manifest.json")
+
+    assert verify_lerobot_import(original_root).status is VerificationStatus.OK
+
+    copied_remote = tmp_path / "bucket-copy"
+    shutil.copytree(original_remote, copied_remote)
+    copied_root = BucketStorageRoot(
+        f"file://{copied_remote}",
+        mirror=tmp_path / "bucket-copy-mirror",
+    )
+
+    assert verify_lerobot_import(copied_root).status is VerificationStatus.OK
+
+    # Damage only the copy; original bucket prefix stays intact.
+    (copied_remote / "landing" / "lerobot_episode_0001.mcap").write_bytes(b"Episode-0")
+    damaged = verify_lerobot_import(copied_root)
+    assert damaged.status is VerificationStatus.DAMAGED
+    assert [finding.reason for finding in damaged.findings] == [REASON_CONTENT_ID_MISMATCH]
+    assert verify_lerobot_import(original_root).status is VerificationStatus.OK
+
+
+def test_cli_verify_lerobot_import_exit_codes(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    clean_root = tmp_path / "clean"
+    _write_prepared_delivery(clean_root)
+    assert main(["verify", "lerobot-import", str(clean_root)]) == 0
+    assert "ok" in capsys.readouterr().out
+
+    damaged_root = tmp_path / "damaged"
+    episode_path = _write_prepared_delivery(damaged_root)
+    episode_path.write_bytes(b"")
+    assert main(["verify", "lerobot-import", str(damaged_root)]) == 1
+    damaged_err = capsys.readouterr().err
+    assert REASON_SIZE_MISMATCH in damaged_err
+    assert REASON_CONTENT_ID_MISMATCH in damaged_err
+
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    assert main(["verify", "lerobot-import", str(empty_root)]) == 3
+    assert "unverifiable" in capsys.readouterr().err
+
+    bad_root = tmp_path / "bad"
+    bad_root.mkdir()
+    (bad_root / "prepared-manifest.json").write_text("{broken", encoding="utf-8")
+    assert main(["verify", "lerobot-import", str(bad_root)]) == 2
+    assert "not valid JSON" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add shared `VerificationReport` / `VerificationFinding` / `VerificationStatus` in `src/hflow/verification.py` for the `hflow verify` family (#432; contract with #428).
- Implement `verify_lerobot_import` and CLI `hflow verify lerobot-import` to check schema-3 prepared-manifest receipts (`uri`, `content_id`, `size_bytes`) without re-converting.
- Exit codes: `0` clean, `1` damaged, `2` unreadable, `3` unverifiable; unlisted `landing/` extras ignored.
- Docs: `import-lerobot-v3.md` names the real verify path; `FORMAT.md` documents verify exit `3`.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` / `ty check`
- [x] `uv run pytest tests/test_verification.py -q`
- [x] Full `uv run pytest -q` (1594 passed, 6 skipped)
- [x] Confirm CI green
- [x] @Sagar-024: please review — this lands `verification.py` first for #428 to import