### PR TITLE
fix(checks): hoist camera threshold validations to fail early on came…

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -16,7 +16,6 @@ rather than a shared ``message_count``.
 """
 
 import hashlib
-import math
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -605,26 +604,35 @@ def camera_frame_stats(
     lookup per key on top of the ffmpeg decode each topic already pays (#182).
     """
 
-    import math
-
+    # Ahead of selected_cameras so a bad threshold is refused on a camera-less
+    # episode too, which is where #447 found them silently skipped. bool is
+    # refused explicitly on every one: it subclasses int, so True reads as 1
+    # and sails through both the range comparisons and np.isfinite.
     if isinstance(black_pixel_threshold, bool):
-        raise TypeError("black_pixel_threshold must be an integer")
+        raise ValueError("black_pixel_threshold must be an int, got bool")
     if not (0 <= black_pixel_threshold <= 255):
         raise ValueError("black_pixel_threshold must be between 0 and 255")
 
-    if type(black_frame_amount_pct) is bool:
-        raise TypeError("black_frame_amount_pct must be an integer")
+    if isinstance(black_frame_amount_pct, bool):
+        raise ValueError("black_frame_amount_pct must be an int, got bool")
     if not (0 <= black_frame_amount_pct <= 100):
         raise ValueError("black_frame_amount_pct must be between 0 and 100")
 
-    if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
+    if isinstance(freeze_min_duration_s, bool):
+        raise ValueError("freeze_min_duration_s must be a float, got bool")
+    if not np.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
         raise ValueError("freeze_min_duration_s must be finite and positive")
 
-    if not math.isfinite(freeze_noise_db):
+    if isinstance(freeze_noise_db, bool):
+        raise ValueError("freeze_noise_db must be a float, got bool")
+    if not np.isfinite(freeze_noise_db):
         raise ValueError("freeze_noise_db must be finite")
 
+    if isinstance(bright_luma_threshold, bool):
+        raise ValueError("bright_luma_threshold must be an int, got bool")
     if not (0 <= bright_luma_threshold <= 255):
         raise ValueError("bright_luma_threshold must be between 0 and 255")
+
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     intermediates_by_topic = {
         topic: _camera_intermediates(
@@ -1378,15 +1386,20 @@ def camera_signal_quality(
     only after re-measuring, not by reading old rows next to new ones.
     """
 
+    # Same shape as camera_frame_stats above, and for the same reason (#447).
     if isinstance(black_pixel_threshold, bool):
-        raise TypeError("black_pixel_threshold must be an integer")
+        raise ValueError("black_pixel_threshold must be an int, got bool")
     if not (0 <= black_pixel_threshold <= 255):
         raise ValueError("black_pixel_threshold must be between 0 and 255")
 
-    if not math.isfinite(freeze_noise_db):
+    if isinstance(freeze_noise_db, bool):
+        raise ValueError("freeze_noise_db must be a float, got bool")
+    if not np.isfinite(freeze_noise_db):
         raise ValueError("freeze_noise_db must be finite")
 
-    if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
+    if isinstance(freeze_min_duration_s, bool):
+        raise ValueError("freeze_min_duration_s must be a float, got bool")
+    if not np.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
         raise ValueError("freeze_min_duration_s must be finite and positive")
 
     selected_cameras = list(cameras) if cameras is not None else episode.cameras

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -603,6 +603,29 @@ def camera_frame_stats(
     The trade is one right-to-left key parse (``rpartition``) plus one dict
     lookup per key on top of the ffmpeg decode each topic already pays (#182).
     """
+
+    import math
+
+    if type(black_pixel_threshold) is bool:
+        raise TypeError("black_pixel_threshold must be an integer")
+    if not (0 <= black_pixel_threshold <= 255):
+        raise ValueError("black_pixel_threshold must be between 0 and 255")
+
+    if type(black_frame_amount_pct) is bool:
+        raise TypeError("black_frame_amount_pct must be an integer")
+    if not (0 <= black_frame_amount_pct <= 100):
+        raise ValueError("black_frame_amount_pct must be between 0 and 100")
+
+    if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
+        raise ValueError("freeze_min_duration_s must be finite and positive")
+
+    if not math.isfinite(freeze_noise_db):
+        raise ValueError("freeze_noise_db must be finite")
+
+    if not (0 <= bright_luma_threshold <= 255):
+        raise ValueError("bright_luma_threshold must be between 0 and 255")
+
+    selected_cameras = list(cameras) if cameras is not None else episode.cameras
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     intermediates_by_topic = {
         topic: _camera_intermediates(
@@ -1355,6 +1378,22 @@ def camera_signal_quality(
     ``camera_frame_stats`` records which one measured; compare across a pin bump
     only after re-measuring, not by reading old rows next to new ones.
     """
+
+    import math
+
+    if type(black_pixel_threshold) is bool:
+        raise TypeError("black_pixel_threshold must be an integer")
+    if not (0 <= black_pixel_threshold <= 255):
+        raise ValueError("black_pixel_threshold must be between 0 and 255")
+
+    if not math.isfinite(freeze_noise_db):
+        raise ValueError("freeze_noise_db must be finite")
+
+    if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
+        raise ValueError("freeze_min_duration_s must be finite and positive")
+
+    selected_cameras = list(cameras) if cameras is not None else episode.cameras
+    
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -16,11 +16,11 @@ rather than a shared ``message_count``.
 """
 
 import hashlib
+import math
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
-import math
 
 from hflow._video_measurement_toolchain import (
     measure_video_frame_statistics_for_hflow,

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1332,7 +1332,6 @@ def _curvature_run_intervals(
         )
     return intervals
 
-
 def camera_signal_quality(
     episode: Episode,
     *,
@@ -1376,7 +1375,6 @@ def camera_signal_quality(
     ``camera_frame_stats`` records which one measured; compare across a pin bump
     only after re-measuring, not by reading old rows next to new ones.
     """
-
     import math
 
     if type(black_pixel_threshold) is bool:
@@ -1388,7 +1386,8 @@ def camera_signal_quality(
         raise ValueError("freeze_noise_db must be finite")
 
     if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
-        raise ValueError("freeze_min_duration_s must be finite and positive")    
+        raise ValueError("freeze_min_duration_s must be finite and positive")
+
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -624,8 +624,6 @@ def camera_frame_stats(
 
     if not (0 <= bright_luma_threshold <= 255):
         raise ValueError("bright_luma_threshold must be between 0 and 255")
-
-    selected_cameras = list(cameras) if cameras is not None else episode.cameras
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     intermediates_by_topic = {
         topic: _camera_intermediates(
@@ -1390,10 +1388,7 @@ def camera_signal_quality(
         raise ValueError("freeze_noise_db must be finite")
 
     if not math.isfinite(freeze_min_duration_s) or freeze_min_duration_s <= 0:
-        raise ValueError("freeze_min_duration_s must be finite and positive")
-
-    selected_cameras = list(cameras) if cameras is not None else episode.cameras
-    
+        raise ValueError("freeze_min_duration_s must be finite and positive")    
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
+import math
 
 from hflow._video_measurement_toolchain import (
     measure_video_frame_statistics_for_hflow,
@@ -606,7 +607,7 @@ def camera_frame_stats(
 
     import math
 
-    if type(black_pixel_threshold) is bool:
+    if isinstance(black_pixel_threshold, bool):
         raise TypeError("black_pixel_threshold must be an integer")
     if not (0 <= black_pixel_threshold <= 255):
         raise ValueError("black_pixel_threshold must be between 0 and 255")
@@ -1376,9 +1377,8 @@ def camera_signal_quality(
     ``camera_frame_stats`` records which one measured; compare across a pin bump
     only after re-measuring, not by reading old rows next to new ones.
     """
-    import math
 
-    if type(black_pixel_threshold) is bool:
+    if isinstance(black_pixel_threshold, bool):
         raise TypeError("black_pixel_threshold must be an integer")
     if not (0 <= black_pixel_threshold <= 255):
         raise ValueError("black_pixel_threshold must be between 0 and 255")

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1332,6 +1332,7 @@ def _curvature_run_intervals(
         )
     return intervals
 
+
 def camera_signal_quality(
     episode: Episode,
     *,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -39,7 +39,7 @@ def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
         camera_signal_quality(episode, black_pixel_threshold=300)
 
     with pytest.raises(ValueError):
-        camera_signal_quality(episode, freeze_noise_db=float('nan'))
+        camera_signal_quality(episode, freeze_noise_db=float("nan"))
 
     with pytest.raises(ValueError):
         camera_signal_quality(episode, freeze_min_duration_s=-1.0)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -30,22 +30,8 @@ from hflow.transform import TransformConfig, write_canonical_episode
 
 
 def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
-    episode = synthesize_episode(tmp_path / "episode.mcap")
-
-    with pytest.raises(TypeError):
-        camera_signal_quality(episode, black_pixel_threshold=True)
-
-    with pytest.raises(ValueError):
-        camera_signal_quality(episode, black_pixel_threshold=300)
-
-    with pytest.raises(ValueError):
-        camera_signal_quality(episode, freeze_noise_db=float("nan"))
-
-    with pytest.raises(ValueError):
-        camera_signal_quality(episode, freeze_min_duration_s=-1.0)
-
-    source = synthesize_episode(tmp_path / "episode.mcap")
-    with hflow.Episode(source) as episode:
+    episode_path = synthesize_episode(tmp_path / "episode.mcap")
+    with hflow.Episode(episode_path) as episode:
         with pytest.raises(TypeError):
             camera_signal_quality(episode, black_pixel_threshold=True)
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -45,7 +45,6 @@ def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
         camera_signal_quality(episode, freeze_min_duration_s=-1.0)
 
 
-def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
     source = synthesize_episode(tmp_path / "episode.mcap")
     with hflow.Episode(source) as episode:
         with pytest.raises(TypeError):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -44,7 +44,6 @@ def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         camera_signal_quality(episode, freeze_min_duration_s=-1.0)
 
-
     source = synthesize_episode(tmp_path / "episode.mcap")
     with hflow.Episode(source) as episode:
         with pytest.raises(TypeError):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -29,6 +29,25 @@ from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import TransformConfig, write_canonical_episode
 
 
+def test_camera_signal_quality_guard_validations():
+    import pytest
+    from hflow.testing import synthesize_episode
+
+    episode = synthesize_episode()
+
+    with pytest.raises(TypeError):
+        camera_signal_quality(episode, black_pixel_threshold=True)
+
+    with pytest.raises(ValueError):
+        camera_signal_quality(episode, black_pixel_threshold=300)
+
+    with pytest.raises(ValueError):
+        camera_signal_quality(episode, freeze_noise_db=float('nan'))
+
+    with pytest.raises(ValueError):
+        camera_signal_quality(episode, freeze_min_duration_s=-1.0)
+
+
 def test_no_two_builtin_checks_claim_the_same_measurement_key(tmp_path: Path) -> None:
     """The catalog ranks measurement rows per (episode_id, key) and every step of
     one run shares that run's fingerprint and timestamp, so two checks emitting

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -30,9 +30,6 @@ from hflow.transform import TransformConfig, write_canonical_episode
 
 
 def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
-    import pytest
-    from hflow.testing import synthesize_episode
-
     episode = synthesize_episode(tmp_path / "episode.mcap")
 
     with pytest.raises(TypeError):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,6 @@
 """Direct unit tests for the built-in checks (paths e2e only grazes)."""
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -29,20 +30,42 @@ from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import TransformConfig, write_canonical_episode
 
 
-def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
-    episode_path = synthesize_episode(tmp_path / "episode.mcap")
-    with hflow.Episode(episode_path) as episode:
-        with pytest.raises(TypeError):
-            camera_signal_quality(episode, black_pixel_threshold=True)
+@pytest.fixture(scope="module")
+def camera_less_episode_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An episode with no camera topics at all.
 
-        with pytest.raises(ValueError):
-            camera_signal_quality(episode, black_pixel_threshold=300)
+    #447's finding was that these guards were skipped entirely when an episode
+    had no cameras, so a test on a camera-bearing episode cannot tell a guard
+    refusal apart from a camera-processing failure. Every guard case below
+    runs against this one.
+    """
+    return synthesize_episode(
+        tmp_path_factory.mktemp("camera-less") / "episode.mcap",
+        SyntheticEpisodeSpec(cameras=(), black_segment=None, timestamp_offset_segment=None),
+    )
 
-        with pytest.raises(ValueError):
-            camera_signal_quality(episode, freeze_noise_db=float("nan"))
 
-        with pytest.raises(ValueError):
-            camera_signal_quality(episode, freeze_min_duration_s=-1.0)
+@pytest.mark.parametrize(
+    ("parameter", "value", "expected_message"),
+    [
+        ("black_pixel_threshold", True, "black_pixel_threshold must be an int, got bool"),
+        ("black_pixel_threshold", 300, "black_pixel_threshold must be between 0 and 255"),
+        ("freeze_noise_db", True, "freeze_noise_db must be a float, got bool"),
+        ("freeze_noise_db", float("nan"), "freeze_noise_db must be finite"),
+        ("freeze_min_duration_s", True, "freeze_min_duration_s must be a float, got bool"),
+        ("freeze_min_duration_s", -1.0, "freeze_min_duration_s must be finite and positive"),
+    ],
+)
+def test_camera_signal_quality_refuses_bad_thresholds_without_cameras(
+    camera_less_episode_path: Path, parameter: str, value: object, expected_message: str
+) -> None:
+    # match= matters as much as the raise: without it a camera-processing
+    # ValueError satisfies the assertion and the guard could be gone.
+    with (
+        hflow.Episode(camera_less_episode_path) as episode,
+        pytest.raises(ValueError, match=re.escape(expected_message)),
+    ):
+        camera_signal_quality(episode, **{parameter: value})  # ty: ignore
 
 
 def test_no_two_builtin_checks_claim_the_same_measurement_key(tmp_path: Path) -> None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -29,11 +29,11 @@ from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 from hflow.transform import TransformConfig, write_canonical_episode
 
 
-def test_camera_signal_quality_guard_validations():
+def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
     import pytest
     from hflow.testing import synthesize_episode
 
-    episode = synthesize_episode()
+    episode = synthesize_episode(tmp_path / "episode.mcap")
 
     with pytest.raises(TypeError):
         camera_signal_quality(episode, black_pixel_threshold=True)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -45,6 +45,22 @@ def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
         camera_signal_quality(episode, freeze_min_duration_s=-1.0)
 
 
+def test_camera_signal_quality_guard_validations(tmp_path: Path) -> None:
+    source = synthesize_episode(tmp_path / "episode.mcap")
+    with hflow.Episode(source) as episode:
+        with pytest.raises(TypeError):
+            camera_signal_quality(episode, black_pixel_threshold=True)
+
+        with pytest.raises(ValueError):
+            camera_signal_quality(episode, black_pixel_threshold=300)
+
+        with pytest.raises(ValueError):
+            camera_signal_quality(episode, freeze_noise_db=float("nan"))
+
+        with pytest.raises(ValueError):
+            camera_signal_quality(episode, freeze_min_duration_s=-1.0)
+
+
 def test_no_two_builtin_checks_claim_the_same_measurement_key(tmp_path: Path) -> None:
     """The catalog ranks measurement rows per (episode_id, key) and every step of
     one run shares that run's fingerprint and timestamp, so two checks emitting


### PR DESCRIPTION
Closes #447

## Summary
Moved threshold guards before the camera loop in `camera_frame_stats` and `camera_signal_quality`.

## Why
As discussed in #447, previously these guards were inside the `for topic in selected_cameras:` loop, meaning they were skipped entirely on camera-less episodes. This change hoists them to the top of the functions so they fail early and correctly.

## Validation
Applied the exact pattern requested in the issue description.