### PR TITLE
refactor: move require_int/require_float to hflow._field_guards

### DIFF
--- a/src/hflow/_field_guards.py
+++ b/src/hflow/_field_guards.py
@@ -1,13 +1,13 @@
-"""Shared numeric-field validation for the video-measurement settings dataclasses.
+"""Shared numeric-field type guards for caller-constructed settings.
 
 Range checks alone (``0 <= x <= 100``) do not reject the wrong *type*: ``bool``
 subclasses ``int``, so ``True``/``False`` satisfy every numeric comparison and
-range test the settings below already run, and a ``str``/``None`` would raise
-a bare ``TypeError`` from the comparison itself instead of a clear message
+range test a settings dataclass runs, and a ``str``/``None`` would raise a
+bare ``TypeError`` from the comparison itself instead of a clear message
 naming the field. This closes that hole the same way ``catalog.py`` already
 does for interval bounds and measurement values.
 
-These settings are caller-constructed configuration, not measurement-pipeline
+These guards are for caller-constructed configuration, not measurement-pipeline
 output, so unlike ``catalog.py``'s NumPy-scalar coercion, no NumPy handling is
 added here: a caller building a ``np.float64`` threshold can call ``.item()``
 itself, the same way any other non-native-Python value would need to.

--- a/src/hflow/_video_measurements/_camera_motion.py
+++ b/src/hflow/_video_measurements/_camera_motion.py
@@ -7,7 +7,8 @@ from types import ModuleType
 
 import numpy as np
 
-from ._field_guards import require_float
+from hflow._field_guards import require_float
+
 from ._raw_frames import LUMA_FRAME_FILTER_GRAPH, luma_frames
 from ._toolchain import VideoMeasurementToolchain
 

--- a/src/hflow/_video_measurements/_frame_statistics.py
+++ b/src/hflow/_video_measurements/_frame_statistics.py
@@ -14,7 +14,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Protocol
 
-from ._field_guards import require_float, require_int
+from hflow._field_guards import require_float, require_int
+
 from ._toolchain import VideoMeasurementToolchain
 
 FRAME_STATISTICS_DEFINITION_VERSION = "video-frame-statistics/v1"

--- a/src/hflow/testing.py
+++ b/src/hflow/testing.py
@@ -31,9 +31,6 @@ Implementation notes:
   ``MSG: pkg/msg/Type`` headers) so any ROS 2-aware reader decodes them.
 - Everything is deterministic: fixed ``start_time_ns``, seeded noise, no
   wall-clock reads.
-- ``_require_int`` / ``_require_float`` are copied here rather than imported
-  from ``hflow._video_measurements`` so that incubating package can stay
-  dependency-free and extractable (see ``src/hflow/_video_measurements/__init__.py``).
 """
 
 import errno
@@ -49,23 +46,13 @@ from pathlib import Path
 
 from mcap.writer import Writer
 
+from hflow._field_guards import require_float, require_int
 from hflow.ffmpeg import ffmpeg_path
 from hflow.format import (
     EPISODE_KEY_ROBOT_SOFTWARE_VERSION,
     METADATA_RECORD_EPISODE,
     NANOSECONDS_PER_SECOND,
 )
-
-
-def _require_int(value: object, name: str) -> None:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(f"{name} must be an int, got {type(value).__name__}")
-
-
-def _require_float(value: object, name: str) -> None:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise ValueError(f"{name} must be an int or float, got {type(value).__name__}")
-
 
 JOINT_STATES_TOPIC = "/joint_states"
 JOINT_STATE_SCHEMA_NAME = "sensor_msgs/msg/JointState"
@@ -361,9 +348,9 @@ def _validate_numeric_spec_fields(
 ) -> None:
     """Require the declared numeric field types and finite real-valued fields."""
     for field_name, value in float_fields:
-        _require_float(value, field_name)
+        require_float(value, field_name)
     for field_name, value in int_fields:
-        _require_int(value, field_name)
+        require_int(value, field_name)
     for field_name, value in float_fields:
         if not math.isfinite(float(value)):
             raise ValueError(f"{field_name} must be finite, got {value!r}")
@@ -396,7 +383,7 @@ def _validate_video_episode_spec(spec: VideoEpisodeSpec) -> None:
         )
     if not spec.camera_name.strip():
         raise ValueError(f"camera_name must not be empty, got {spec.camera_name!r}")
-    _require_int(spec.shake_amplitude_px, "shake_amplitude_px")
+    require_int(spec.shake_amplitude_px, "shake_amplitude_px")
     if spec.shake_amplitude_px <= 0:
         raise ValueError(f"shake_amplitude_px must be > 0, got {spec.shake_amplitude_px}")
     fault_segments = (

--- a/tests/test_module_boundaries.py
+++ b/tests/test_module_boundaries.py
@@ -29,21 +29,22 @@ _DOCUMENTED_HFLOW_IMPORT_BOUNDARIES = (
     _ImportBoundary(
         source_paths=tuple(sorted(Path(video_measurements.__file__).parent.rglob("*.py"))),
         restricted_module_prefix="hflow",
-        allowed_modules=frozenset(),
+        allowed_modules=frozenset({"hflow._field_guards"}),
         scope=_ImportScope.ALL,
         rule=(
-            "the video-measurements package must not import hflow or any hflow.* "
-            "module because it is designed to be extracted into a standalone package"
+            "the video-measurements package must not import hflow or any hflow.* module "
+            "other than the dependency-free hflow._field_guards type guards, because it is "
+            "designed to be extracted into a standalone package"
         ),
     ),
     _ImportBoundary(
         source_paths=(_HFLOW_PACKAGE_DIRECTORY / "testing.py",),
         restricted_module_prefix="hflow",
-        allowed_modules=frozenset({"hflow.ffmpeg", "hflow.format"}),
+        allowed_modules=frozenset({"hflow._field_guards", "hflow.ffmpeg", "hflow.format"}),
         scope=_ImportScope.ALL,
         rule=(
-            "hflow.testing may import only hflow.ffmpeg and hflow.format; the fixture "
-            "must not depend on the canonical writer or other HFlow domain modules"
+            "hflow.testing may import only hflow._field_guards, hflow.ffmpeg and hflow.format; "
+            "the fixture must not depend on the canonical writer or other HFlow domain modules"
         ),
     ),
     _ImportBoundary(


### PR DESCRIPTION
## Summary

`require_int` / `require_float` now have one definition, `src/hflow/_field_guards.py`, imported by `_frame_statistics.py`, `_camera_motion.py` and `testing.py`. The byte-identical private copy in `testing.py` is gone. Same exception types, same message strings, same public names. No behavior change; the other ~50 inline `isinstance` sites are untouched, per the issue.

Fixes #463

## Why

The move is what the issue asks for. One thing did not go as the issue's definition of done predicted, and it is worth being explicit about:

**One test edit was required.** `tests/test_module_boundaries.py` enforces two import contracts that any single-definition layout has to cross:

- `_video_measurements/*` may import nothing from `hflow.*` (empty allowlist), and
- `hflow.testing` may import only `hflow.ffmpeg` and `hflow.format`.

With the layout from the issue and no test change, the guard fails with exactly the three imports this PR adds:

```
hflow/_video_measurements/_camera_motion.py:10: from hflow._field_guards import require_float -- the video-measurements package must not import hflow or any hflow.* module because it is designed to be extracted into a standalone package
hflow/_video_measurements/_frame_statistics.py:17: from hflow._field_guards import require_float, require_int -- ...
hflow/testing.py:49: from hflow._field_guards import require_float, require_int -- hflow.testing may import only hflow.ffmpeg and hflow.format; ...
```

The AST guard skips relative imports, so `from .._field_guards import ...` inside `_video_measurements` would have passed it silently. I did not do that: it is the same dependency, just hidden from the test. Instead both boundaries allowlist `hflow._field_guards` by name, with the rule text updated to say so. `_field_guards` has no imports of its own, so extracting `_video_measurements` later means vendoring 14 lines. I mutation-checked that a `from hflow.storage import ...` inside `_camera_motion.py` is still red under the new rule.

If you would rather keep the `_video_measurements` allowlist empty, the alternative is to leave `_field_guards.py` where it was and have `testing.py` import it from there (only the `hflow.testing` allowlist changes). Happy to flip; it is a one-line direction change.

Also removed the `testing.py` module-docstring bullet that explained why the copy existed, since it no longer does.

## Validation

```
uv sync --locked
uv run ruff check                 # All checks passed!
uv run ruff format --check        # 227 files already formatted
uv run ty check                   # All checks passed!
uv run pytest -q                  # 1609 passed, 9 skipped, 27 failed (see note)
```

Ran on macOS (CI is Linux-only). The 27 failures are all `tests/test_packaging*.py` raising `CythonOverlayBuildError: native overlay builds currently require CPython on Linux; found cpython on darwin`; the identical 27 fail on pristine `upstream/main` (7df224a) in the same environment, so they are platform-only and CI covers them.

Additional checks:

- `uv run pytest -q tests/test_module_boundaries.py` with the source change and the *unmodified* test: 1 failed with the three violations quoted above, then 2 passed with the allowlist.
- Mutation: appended `from hflow.storage import _load_obstore` to `_camera_motion.py`, guard went red naming that line; restored, green.
- `tests/test_testing.py`, `tests/test_video_measurement_settings_types.py`, `tests/test_video_measurement_settings_ranges.py`: 103 passed, unmodified. These already pin every `must be an int[, got ...]` / `must be an int or float, got ...` message through the public constructors, which is why no new test is added for a pure move.
- `git diff --check` clean.

## Checklist

- [ ] I added or updated outcome-focused tests for changed business logic. -- no business logic changed; existing outcome tests cover both consumers and pass unmodified. The only test edit is the boundary allowlist described above.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements. -- no user-facing behavior changed; docs do not reference `_field_guards`.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
