### PR TITLE
fix(doctor): report unsupported video encodings and missing schemas separately from read-failed

### DIFF
--- a/src/hflow/doctor.py
+++ b/src/hflow/doctor.py
@@ -181,6 +181,17 @@ def _check_video_payload(
         )
 
 
+class VideoEncodingUnsupported(ValueError):
+    """No decoder factory in the supported set handles this message encoding.
+
+    A subclass of ``ValueError`` because every existing caller treats
+    resolution failure as a ``ValueError``; the distinct type lets the video
+    check report the true cause, an encoding outside the supported set, a
+    fact about the file paired with the reader, instead of wrapping it in a
+    corruption assertion. #460.
+    """
+
+
 def _resolve_video_decoder(topic: str, channel: Channel, schema: Schema) -> Callable[[bytes], Any]:
     """Resolve either supported encoded-video payload representation."""
     from mcap_protobuf.decoder import DecoderFactory as ProtobufDecoderFactory
@@ -190,7 +201,7 @@ def _resolve_video_decoder(topic: str, channel: Channel, schema: Schema) -> Call
         decoder = factory.decoder_for(channel.message_encoding, schema)
         if decoder is not None:
             return decoder
-    raise ValueError(
+    raise VideoEncodingUnsupported(
         f"video topic {topic!r} has message encoding {channel.message_encoding!r} "
         "that no available decoder handles"
     )
@@ -237,6 +248,26 @@ def diagnose(path: Path | str) -> DoctorReport:
 
         metadata_records = {record.name: dict(record.metadata) for record in reader.iter_metadata()}
         provenance = metadata_records.get(METADATA_RECORD_PROVENANCE)
+
+        # Schema pre-pass (#460): a channel naming a schema id the file does
+        # not carry makes the reader raise KeyError mid-iteration, and the
+        # broad read handler would wrap that in a corruption assertion. The
+        # true defect is a missing schema record, reported here per channel;
+        # those channels are then read nowhere, so read-failed stays reserved
+        # for genuine read and CRC errors. A schema_id of 0 means schemaless
+        # and is legitimate, not a dangling reference.
+        topics_with_missing_schema = [
+            channel.topic
+            for channel in summary.channels.values()
+            if channel.schema_id != 0 and channel.schema_id not in summary.schemas
+        ]
+        for topic in topics_with_missing_schema:
+            collector.add(
+                DiagnosticLevel.ERROR,
+                "channel-schema-missing",
+                f"{topic}: channel names a schema id that has no schema record in "
+                "the file; its messages are unreadable and its checks are skipped",
+            )
 
         group_by_topic = {}
         if provenance:
@@ -344,13 +375,23 @@ def diagnose(path: Path | str) -> DoctorReport:
 
         # Full message pass: CRC validation happens as a side effect of
         # reading every chunk; per-topic time order and video constraints are
-        # checked message by message.
+        # checked message by message. Channels named in the schema pre-pass
+        # are excluded: reading them raises KeyError on the missing schema,
+        # which is a reported defect, not a corrupt chunk (#460).
         def iter_all_messages() -> Iterator[tuple[int, int, bytes]]:
-            for _schema, channel, message in reader.iter_messages(log_time_order=False):
+            readable_topics = [
+                topic
+                for topic in topics_by_channel_id.values()
+                if topic not in set(topics_with_missing_schema)
+            ]
+            for _schema, channel, message in reader.iter_messages(
+                log_time_order=False, topics=readable_topics
+            ):
                 yield channel.id, message.log_time, message.data
 
         last_log_time_by_channel: dict[int, int] = {}
         video_message_counts: dict[int, int] = {}
+        video_check_skipped_topics: set[str] = set(topics_with_missing_schema)
         try:
             video_decoders: dict[int, Callable[[bytes], Any]] = {}
 
@@ -365,17 +406,28 @@ def diagnose(path: Path | str) -> DoctorReport:
                     )
                 last_log_time_by_channel[channel_id] = log_time
                 if channel_id in video_channel_ids:
+                    if topics_by_channel_id[channel_id] in video_check_skipped_topics:
+                        # Already reported for this topic: its payloads cannot
+                        # be video-checked, but they are not damage and must
+                        # not read as such.
+                        continue
                     message_index = video_message_counts.get(channel_id, 0)
                     video_message_counts[channel_id] = message_index + 1
                     decoder = video_decoders.get(channel_id)
                     if decoder is None:
                         channel = summary.channels[channel_id]
-                        schema = summary.schemas.get(channel.schema_id)
-                        if schema is None:
-                            raise ValueError(
-                                f"video topic {channel.topic!r} has no readable schema record"
+                        schema = summary.schemas[channel.schema_id]
+                        try:
+                            decoder = _resolve_video_decoder(channel.topic, channel, schema)
+                        except VideoEncodingUnsupported as error:
+                            video_check_skipped_topics.add(topics_by_channel_id[channel_id])
+                            collector.add(
+                                DiagnosticLevel.ERROR,
+                                "video-encoding-unsupported",
+                                f"{topics_by_channel_id[channel_id]}: {error}; video checks "
+                                "cannot run on this topic (the file bytes are not implicated)",
                             )
-                        decoder = _resolve_video_decoder(channel.topic, channel, schema)
+                            continue
                         video_decoders[channel_id] = decoder
                     decoded = decoder(payload)
                     _check_video_payload(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -52,6 +52,86 @@ def test_raw_input_recording_is_not_conforming(tmp_path: Path) -> None:
     assert "missing-provenance" in codes
 
 
+def test_unsupported_video_encoding_is_reported_not_corrupt(tmp_path: Path) -> None:
+    """An encoding outside hflow's supported decoder set stops video checks
+    on that topic, but the finding says exactly that instead of asserting
+    corrupt chunk or bad CRC. Real path: json encoding, which neither the
+    ros2 nor the protobuf decoder factory handles (#460)."""
+    path = tmp_path / "unsupported_encoding.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        channel_id = writer.register_channel(
+            topic="/cam", message_encoding="json", schema_id=schema_id
+        )
+        writer.add_message(channel_id, log_time=10**9, data=b"{}", publish_time=10**9)
+        writer.finish()
+
+    report = diagnose(path)
+
+    codes = {finding.code for finding in report.findings}
+    assert "video-encoding-unsupported" in codes
+    encoding_finding = next(
+        finding for finding in report.findings if finding.code == "video-encoding-unsupported"
+    )
+    assert "/cam" in encoding_finding.message
+    assert "no available decoder handles" in encoding_finding.message
+    assert "video checks cannot run" in encoding_finding.message
+    assert not any(finding.code == "read-failed" for finding in report.findings)
+
+
+def test_video_channel_with_missing_schema_is_reported_not_corrupt(tmp_path: Path) -> None:
+    """A channel naming a schema id the file does not carry is a real defect,
+    but a missing record is not a damaged chunk: it gets its own finding, the
+    reader never KeyErrors on it, and a healthy sibling topic on the same
+    file is still fully checked (#460)."""
+    path = tmp_path / "missing_schema.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        broken_channel_id = writer.register_channel(
+            topic="/broken-cam", message_encoding="protobuf", schema_id=99
+        )
+        good_channel_id = writer.register_channel(
+            topic="/good-cam", message_encoding="protobuf", schema_id=schema_id
+        )
+        writer.add_message(broken_channel_id, log_time=10**9, data=b"payload", publish_time=10**9)
+        message = CompressedVideo()
+        message.timestamp.FromNanoseconds(10**9)
+        message.frame_id = "cam"
+        message.data = b"\x00\x00\x00\x01\x09\x10\x00\x00\x00\x01\x41\xa8"
+        message.format = "h264"
+        writer.add_message(
+            good_channel_id, log_time=10**9, data=message.SerializeToString(), publish_time=10**9
+        )
+        writer.finish()
+
+    report = diagnose(path)
+
+    codes = {finding.code for finding in report.findings}
+    assert "channel-schema-missing" in codes
+    schema_finding = next(
+        finding for finding in report.findings if finding.code == "channel-schema-missing"
+    )
+    assert "/broken-cam" in schema_finding.message
+    assert "no schema record" in schema_finding.message
+    assert not any(finding.code == "read-failed" for finding in report.findings)
+    # The healthy sibling is still video-checked: its payload is a deliberate
+    # B picture, so the video path must have run and classified it.
+    b_finding = next(finding for finding in report.findings if finding.code == "video-b-picture")
+    assert "/good-cam" in b_finding.message
+
+
 def test_nonconforming_video_is_reported(tmp_path: Path) -> None:
     path = tmp_path / "bad_video.mcap"
     with path.open("wb") as stream:


### PR DESCRIPTION
# fix(doctor): report unsupported video encodings and missing schemas separately from read-failed

Closes #460.

## What changed

Doctor's video check previously ran inside one broad `try` block. That meant two failures that weren't actually corruption problems ended up being reported as `read-failed`, along with the misleading "corrupt chunk or bad CRC?" assertion.

### Unsupported video encodings

`_resolve_video_decoder` raises when neither supported decoder factory (ROS2 or protobuf) can handle a channel's `message_encoding`.

That isn't evidence of corrupted bytes or a machine codec problem. It simply means the file uses an encoding that isn't supported by our current decoder set.

This now reports as `video-encoding-unsupported`, including the topic name and a detail message making it clear that the file bytes themselves are not implicated. The resolver now raises the typed `VideoEncodingUnsupported`, which remains a `ValueError` subclass.

### Missing schemas

The existing in-loop `schema is None` check was effectively dead code.

There are two reasons:

* A channel with a dangling schema gets an empty schema name, so it never gets classified as a video channel.
* The reader raises `KeyError` during iteration before the loop body can reach that check.

The missing-schema case is now handled in a summary pre-pass instead. Any channel that references a schema ID not present in the file reports `channel-schema-missing`.

`schema_id == 0` remains valid and means the channel is schemaless.

Channels with missing schemas are excluded from the read pass using the reader's `topics` filter, which keeps `read-failed` reserved for actual read and CRC failures.

## Severity

Both findings remain **ERROR**.

Doctor is certifying episode conformance. If a video topic uses an encoding our decoder set cannot handle, the episode can't be fully certified because downstream readers rely on that same decoder support.

Making this a WARNING would allow Doctor to certify a file whose video was never actually checked.

The distinction is reflected in the finding codes and messages, which now describe what actually happened. The severity represents "cannot certify," consistent with findings such as `no-statistics` and `no-chunk-indexes`.

## Behavior notes

* **Healthy files:** No behavioral change. When all channels are valid, the read pass remains unfiltered and follows the exact same path as before.
* **Excluded topics:** Chunks containing only excluded topics are no longer CRC-validated during the read pass. Previously, iteration would stop at the first exception anyway, so CRC coverage for later chunks in already-broken files was already incomplete. Healthy files still receive the full pass.
* **Zero-message channels:** Decoder resolution now happens during the summary pre-pass, so unsupported video channels with zero messages are reported instead of remaining silent.

## Tests

`23 passed` in `tests/test_doctor.py`, including two new real-path tests with no stubs:

* A JSON-encoded video channel reports `video-encoding-unsupported` and never `read-failed`.
* A channel with a fabricated schema ID (`99`) alongside a healthy sibling reports `channel-schema-missing` and never `read-failed`, while the sibling's video checks still run.

Mutation checks also confirmed the new coverage: removing either the pre-pass or the encoding catch makes exactly the two new tests fail. Restoring them brings everything back to green.

`ruff check`, `ruff format`, and `ty` are all clean.
