### PR TITLE
refactor: centralize unusable file path checks

### DIFF
--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -61,7 +61,6 @@ extracts them to temp files):
    mass failure visible.
 """
 
-import errno
 import hashlib
 import json
 import logging
@@ -1065,15 +1064,7 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     )
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
-        if requirements_source.is_dir():
-            # FileNotFoundError, not IsADirectoryError, for the reason above.
-            raise FileNotFoundError(
-                errno.EISDIR, os.strerror(errno.EISDIR), str(requirements_source)
-            )
-        if not requirements_source.is_file():
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)
-            )
+        _refuse_unusable_file_path(requirements_source)
         shutil.copyfile(requirements_source, user_dir / "requirements.txt")
 
     hflow_source = (

--- a/src/hflow/runtime/_bundle.py
+++ b/src/hflow/runtime/_bundle.py
@@ -91,6 +91,7 @@ from hflow.storage import (
     BucketStorageRoot,
     LocalStorageRoot,
     StorageRoot,
+    _refuse_unusable_file_path,
     is_bucket_url,
     parse_storage_root,
 )
@@ -1026,19 +1027,7 @@ def render_bundle(config: RuntimeConfig, bundle_dir: Path | str) -> BundlePaths:
     """
     bundle_directory = Path(bundle_dir)
     pipeline_source = Path(config.pipeline_file)
-    if pipeline_source.is_dir():
-        # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
-        # class subclasses OSError, not FileNotFoundError, so an `except
-        # FileNotFoundError` stops catching it. Two such handlers sit in this
-        # call path, cli.py:560 for `up` and cli.py:601 for `deploy`, and both
-        # turn this into exit 2; thirteen more name it elsewhere under
-        # src/hflow/, and callers outside the repo are the real unknown.
-        # The errno carries the accurate text without moving the class. #100.
-        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
-    if not pipeline_source.is_file():
-        # Three-argument form, as storage.py does: str() then carries the errno
-        # text, so the CLI prints why the path failed and not just the path.
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))
+    _refuse_unusable_file_path(pipeline_source)
 
     dags_dir = bundle_directory / "dags"
     logs_dir = bundle_directory / "logs"

--- a/src/hflow/runtime/_deploy.py
+++ b/src/hflow/runtime/_deploy.py
@@ -29,8 +29,6 @@ spool-through-mirror boundary; workers therefore keep the processing core on
 local files without pretending bucket keys have ``pathlib.Path`` semantics.
 """
 
-import errno
-import os
 import shlex
 import shutil
 from dataclasses import dataclass
@@ -188,15 +186,7 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     requirements_copied = False
     if config.requirements_file is not None:
         requirements_source = Path(config.requirements_file)
-        if requirements_source.is_dir():
-            # FileNotFoundError, not IsADirectoryError, for the reason above.
-            raise FileNotFoundError(
-                errno.EISDIR, os.strerror(errno.EISDIR), str(requirements_source)
-            )
-        if not requirements_source.is_file():
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), str(requirements_source)
-            )
+        _refuse_unusable_file_path(requirements_source)
         shutil.copyfile(requirements_source, user_dir / "requirements.txt")
         requirements_copied = True
 

--- a/src/hflow/runtime/_deploy.py
+++ b/src/hflow/runtime/_deploy.py
@@ -53,7 +53,7 @@ from hflow.runtime._templates import (
 )
 from hflow.stage_execution import USER_DIRECTORY_DEFAULT
 from hflow.steps import RUN_PROFILES, Stage
-from hflow.storage import is_bucket_url, parse_storage_root
+from hflow.storage import _refuse_unusable_file_path, is_bucket_url, parse_storage_root
 
 # The interpreter of the user venv on the deployment's workers. Matches the
 # Compose runtime's convention so a venv built from these instructions is
@@ -169,17 +169,7 @@ def render_deploy_bundle(config: DeployConfig, output_dir: Path | str) -> Deploy
     """
     output_directory = Path(output_dir)
     pipeline_source = Path(config.pipeline_file)
-    if pipeline_source.is_dir():
-        # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
-        # class subclasses OSError, not FileNotFoundError, so an `except
-        # FileNotFoundError` stops catching it. Two such handlers sit in this
-        # call path, cli.py:560 for `up` and cli.py:601 for `deploy`, and both
-        # turn this into exit 2; thirteen more name it elsewhere under
-        # src/hflow/, and callers outside the repo are the real unknown.
-        # The errno carries the accurate text without moving the class. #100.
-        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(pipeline_source))
-    if not pipeline_source.is_file():
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(pipeline_source))
+    _refuse_unusable_file_path(pipeline_source)
 
     dags_dir = output_directory / "dags"
     user_dir = output_directory / "user"

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -96,6 +96,17 @@ def _load_obstore() -> Any:
     return obstore
 
 
+def _refuse_unusable_file_path(path: Path) -> None:
+    """Raise the errno-carrying FileNotFoundError for a directory or missing file."""
+    # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
+    # class subclasses OSError, not FileNotFoundError, so an `except
+    # FileNotFoundError` stops catching it. The errno carries the accurate
+    # text without changing the exception class. Same decision as #100 and #144.
+    if path.is_dir():
+        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(path))
+    if not path.is_file():
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(path))
+
 def is_bucket_url(value: str) -> bool:
     """Whether ``value`` is an object-store URL (``gs://bucket/...`` etc.)."""
     scheme, separator, _rest = value.partition("://")
@@ -361,18 +372,7 @@ class LocalStorageRoot:
     def fetch(self, relative: str) -> Path:
         """The local file at ``relative`` (it already lives here)."""
         local_file = self.path / _validated_relative_key(relative)
-        if local_file.is_dir():
-            # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
-            # class subclasses OSError, not FileNotFoundError, so an `except
-            # FileNotFoundError` stops catching it. `_command_doctor` is one such
-            # handler, reached through fetch_uri below, and it turns this into a
-            # finding rather than a traceback; sixteen more name the class
-            # elsewhere under src/hflow/, and callers outside the repo are the real
-            # unknown. The errno carries the accurate text without moving the class.
-            # Same decision as the four sites #102 covered. #144.
-            raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(local_file))
-        if not local_file.is_file():
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
+        _refuse_unusable_file_path(local_file)
         return local_file
 
     def uri_for(self, relative: str) -> str:
@@ -696,9 +696,5 @@ def fetch_uri(uri: "str | Path") -> Path:
         parent_url, _, name = uri.rpartition("/")
         return BucketStorageRoot(parent_url).fetch(name)
     local_file = Path(uri)
-    if local_file.is_dir():
-        # FileNotFoundError, not IsADirectoryError, for the reason above.
-        raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(local_file))
-    if not local_file.is_file():
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(local_file))
+    _refuse_unusable_file_path(local_file)
     return local_file

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -107,6 +107,7 @@ def _refuse_unusable_file_path(path: Path) -> None:
     if not path.is_file():
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(path))
 
+
 def is_bucket_url(value: str) -> bool:
     """Whether ``value`` is an object-store URL (``gs://bucket/...`` etc.)."""
     scheme, separator, _rest = value.partition("://")

--- a/src/hflow/storage.py
+++ b/src/hflow/storage.py
@@ -101,7 +101,10 @@ def _refuse_unusable_file_path(path: Path) -> None:
     # Deliberately FileNotFoundError and not IsADirectoryError: the accurate
     # class subclasses OSError, not FileNotFoundError, so an `except
     # FileNotFoundError` stops catching it. The errno carries the accurate
-    # text without changing the exception class. Same decision as #100 and #144.
+    # text without changing the exception class. Same decision as #100, #120
+    # and #144. The three-argument form is load-bearing too: str(path) as the
+    # filename lets errno supply the text, so a CLI prints why the path failed
+    # and not just which path it was.
     if path.is_dir():
         raise FileNotFoundError(errno.EISDIR, os.strerror(errno.EISDIR), str(path))
     if not path.is_file():


### PR DESCRIPTION
## Summary

Centralizes the repeated unusable-file-path validation used across storage and runtime code.

The new private `_refuse_unusable_file_path()` helper lives in `storage.py`, since that module already owns local path handling and both runtime modules already depend on it.

## Changes

* Added `_refuse_unusable_file_path(path: Path)` in `src/hflow/storage.py`
* Replaced the duplicated directory / missing-file checks in:

  * `LocalStorageRoot.fetch()`
  * `fetch_uri()`
  * `render_deploy_bundle()`
  * `render_bundle()`
* Preserved the existing behavior:

  * directories raise `FileNotFoundError` with `errno.EISDIR`
  * missing files raise `FileNotFoundError` with `errno.ENOENT`
  * the path is still passed as the third argument so `filename` and OS error text remain unchanged
* Kept the reasoning for using `FileNotFoundError` instead of `IsADirectoryError` in one place on the helper

## Validation

Ran:

```bash
uv sync --locked --all-extras
uv run ruff check
uv run ruff format --check
uv run ty check
uv run pytest -q
```

Result:

```text
1638 passed, 7 skipped
```

Also confirmed the four existing storage regression tests pass with the helper in place.

As requested in the issue, I temporarily replaced the helper body with `pass` and confirmed all four regression tests fail because `FileNotFoundError` is no longer raised.

I also checked the current test suite for the four call sites. On the current `main`, both runtime sites now have missing-file and directory-path coverage, so the issue note that at least one site is untested appears to be outdated.

Closes #467
