### PR TITLE
perf: pass channel topics down to the MCAP reader

### DIFF
--- a/src/hflow/reader.py
+++ b/src/hflow/reader.py
@@ -246,8 +246,12 @@ class PythonMcapEpisodeReader:
             try:
                 known_channels = self.channels()
             except ValueError:
-                # No summary section to derive topics from (unindexed or
-                # truncated file); fall back to the unconstrained read.
+                # No summary section to derive topics from: a legitimately
+                # unindexed file, still readable by linear scan, so fall back
+                # to the unconstrained read. A truncated file is not this
+                # case -- channels() raises mcap's RecordLengthLimitExceeded,
+                # and the same error surfaces from iter_messages below with
+                # or without this catch, so damage stays loud.
                 known_channels = {}
             derived_topics = sorted(
                 {

--- a/src/hflow/reader.py
+++ b/src/hflow/reader.py
@@ -236,6 +236,28 @@ class PythonMcapEpisodeReader:
         batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     ) -> Iterator[MessageBatch]:
         wanted_channel_ids = frozenset(channel_ids) if channel_ids is not None else None
+        if topics is None and wanted_channel_ids is not None:
+            # Constrain the underlying read to the topics the requested
+            # channels live on, so the MCAP reader can skip unrelated streams
+            # (e.g. multi-gigabyte camera topics) instead of yielding messages
+            # that would be discarded below. Topic filtering alone is not
+            # exact -- several channels may share one topic -- so the
+            # channel-id filter in the loop still applies.
+            try:
+                known_channels = self.channels()
+            except ValueError:
+                # No summary section to derive topics from (unindexed or
+                # truncated file); fall back to the unconstrained read.
+                known_channels = {}
+            derived_topics = sorted(
+                {
+                    known_channels[channel_id].topic
+                    for channel_id in wanted_channel_ids
+                    if channel_id in known_channels
+                }
+            )
+            if derived_topics:
+                topics = derived_topics
         topics_by_channel_id: dict[int, str] = {}
         pending_log_times: dict[int, list[int]] = {}
         pending_publish_times: dict[int, list[int]] = {}

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -19,7 +19,7 @@ from mcap.writer import Writer as StockWriter
 from hflow.doctor import diagnose
 from hflow.episode import Episode
 from hflow.format import METADATA_RECORD_EPISODE
-from hflow.reader import PythonMcapEpisodeReader, open_reader
+from hflow.reader import EpisodeReader, PythonMcapEpisodeReader, open_reader
 from hflow.transform import write_canonical_episode
 
 SHARED_TOPIC = "/status"
@@ -124,12 +124,45 @@ def test_episode_addresses_channels_by_id(dual_channel_source: Path) -> None:
         ]
 
 
+def _write_two_topic_mcap(
+    path: Path,
+    target_payloads: list[bytes],
+    camera_payloads: list[bytes],
+    **writer_kwargs: Any,
+) -> tuple[int, int]:
+    """Write a small ``/target`` channel and a large ``/camera`` channel.
+
+    The default small chunk size keeps the two streams in separate chunks,
+    the layout where an early topic filter can skip unrelated data. Returns
+    the two channel ids in registration order.
+    """
+    writer_kwargs.setdefault("chunk_size", 1024)
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, compression=CompressionType.NONE, **writer_kwargs)
+        writer.start(profile="", library="test")
+        target_channel_id = writer.register_channel(
+            topic="/target", message_encoding="json", schema_id=0
+        )
+        camera_channel_id = writer.register_channel(
+            topic="/camera", message_encoding="json", schema_id=0
+        )
+        for index, payload in enumerate(target_payloads):
+            writer.add_message(
+                target_channel_id, log_time=1 + index, data=payload, publish_time=1 + index
+            )
+        for index, payload in enumerate(camera_payloads):
+            writer.add_message(
+                camera_channel_id, log_time=10 + index, data=payload, publish_time=10 + index
+            )
+        writer.finish()
+    return target_channel_id, camera_channel_id
+
+
 def _trace_mcap_iter_messages(
-    episode: Episode, monkeypatch: pytest.MonkeyPatch
+    hflow_reader: EpisodeReader, monkeypatch: pytest.MonkeyPatch
 ) -> tuple[list[Any], list[str]]:
     """Record the ``topics`` argument HFlow passes to the stock mcap reader
     and the topic of every message that crosses that library boundary."""
-    hflow_reader = episode._reader
     assert isinstance(hflow_reader, PythonMcapEpisodeReader)
     mcap_reader = hflow_reader._reader
     original_iter_messages = mcap_reader.iter_messages
@@ -155,26 +188,10 @@ def test_channel_read_is_constrained_to_the_requested_topic(
     path = tmp_path / "two_topics.mcap"
     target_payload = b"t" * 4096
     camera_payloads = [bytes([65 + index]) * 4096 for index in range(8)]
-    with path.open("wb") as stream:
-        # A small chunk size keeps the two streams in separate chunks, the
-        # layout where an early topic filter can skip unrelated data.
-        writer = StockWriter(stream, chunk_size=1024, compression=CompressionType.NONE)
-        writer.start(profile="", library="test")
-        target_channel_id = writer.register_channel(
-            topic="/target", message_encoding="json", schema_id=0
-        )
-        camera_channel_id = writer.register_channel(
-            topic="/camera", message_encoding="json", schema_id=0
-        )
-        writer.add_message(target_channel_id, log_time=1, data=target_payload, publish_time=1)
-        for index, payload in enumerate(camera_payloads):
-            writer.add_message(
-                camera_channel_id, log_time=10 + index, data=payload, publish_time=10 + index
-            )
-        writer.finish()
+    _write_two_topic_mcap(path, [target_payload], camera_payloads)
 
     with Episode(path) as episode:
-        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode, monkeypatch)
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode._reader, monkeypatch)
         channel = episode.channel("/target")
         assert channel.raw == [target_payload]
         assert channel.timestamps.tolist() == [1]
@@ -191,12 +208,71 @@ def test_shared_topic_channel_read_keeps_channel_id_selection(
     messages come back."""
     with Episode(dual_channel_source) as episode:
         by_encoding = {info.message_encoding: info for info in episode.channels.values()}
-        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode, monkeypatch)
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode._reader, monkeypatch)
         cdr_channel = episode.channel(by_encoding["cdr"].channel_id)
         assert topics_passed == [[SHARED_TOPIC]]
         assert set(topics_yielded) == {SHARED_TOPIC}
         assert cdr_channel.channel_id == by_encoding["cdr"].channel_id
         assert cdr_channel.raw == CDR_PAYLOADS
+
+
+def test_decoded_batches_by_channel_id_derive_the_topic_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Episode.channel()`` passes its topic explicitly, but
+    ``iter_decoded_batches(channel_ids=...)`` still reaches the reader with
+    ``topics=None`` -- the reader itself must derive the topic filter from
+    the channel ids so the underlying read narrows to the requested stream."""
+    path = tmp_path / "two_topics_decoded.mcap"
+    target_payloads = [json.dumps({"joint": index}).encode() for index in range(2)]
+    camera_payloads = [json.dumps({"pad": "y" * 4096}).encode() for _ in range(8)]
+    target_channel_id, _ = _write_two_topic_mcap(path, target_payloads, camera_payloads)
+
+    with Episode(path) as episode:
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode._reader, monkeypatch)
+        batches = list(episode.iter_decoded_batches(channel_ids=[target_channel_id]))
+        assert [message for batch in batches for message in batch.messages] == [
+            {"joint": 0},
+            {"joint": 1},
+        ]
+        assert topics_passed == [["/target"]]
+        assert topics_yielded == ["/target", "/target"]
+
+
+def test_channel_id_read_without_a_summary_falls_back_to_a_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file with no summary section cannot map channel ids to topics, so a
+    channel-id read falls back to the unconstrained scan instead of refusing,
+    and the channel-id filter still selects the right messages. A truncated
+    file is deliberately not this case: ``channels()`` raises mcap's
+    ``RecordLengthLimitExceeded`` rather than ``ValueError``, and any read of
+    such a file surfaces the same error, so damage stays loud."""
+    path = tmp_path / "unindexed.mcap"
+    target_payload = b'{"v": 1}'
+    target_channel_id, _ = _write_two_topic_mcap(
+        path,
+        [target_payload],
+        [b"y" * 4096 for _ in range(8)],
+        use_chunking=False,
+        use_statistics=False,
+        use_summary_offsets=False,
+        repeat_channels=False,
+        repeat_schemas=False,
+    )
+
+    reader = open_reader(path)
+    try:
+        with pytest.raises(ValueError, match="no MCAP summary section"):
+            reader.channels()
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(reader, monkeypatch)
+        batches = list(reader.iter_batches(channel_ids=[target_channel_id]))
+        assert [payload for batch in batches for payload in batch.data] == [target_payload]
+        assert [batch.topic for batch in batches] == ["/target"]
+        assert topics_passed == [None]
+        assert set(topics_yielded) == {"/target", "/camera"}
+    finally:
+        reader.close()
 
 
 def test_episode_streams_several_decoded_channels_in_bounded_batches(

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -7,17 +7,19 @@ represent both channels; only the topic-keyed convenience views refuse.
 """
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 from mcap.reader import make_reader
+from mcap.writer import CompressionType
 from mcap.writer import Writer as StockWriter
 
 from hflow.doctor import diagnose
 from hflow.episode import Episode
 from hflow.format import METADATA_RECORD_EPISODE
-from hflow.reader import open_reader
+from hflow.reader import PythonMcapEpisodeReader, open_reader
 from hflow.transform import write_canonical_episode
 
 SHARED_TOPIC = "/status"
@@ -120,6 +122,81 @@ def test_episode_addresses_channels_by_id(dual_channel_source: Path) -> None:
         assert [message.data for message in cdr_channel.messages] == [
             bool(payload[-1]) for payload in CDR_PAYLOADS
         ]
+
+
+def _trace_mcap_iter_messages(
+    episode: Episode, monkeypatch: pytest.MonkeyPatch
+) -> tuple[list[Any], list[str]]:
+    """Record the ``topics`` argument HFlow passes to the stock mcap reader
+    and the topic of every message that crosses that library boundary."""
+    hflow_reader = episode._reader
+    assert isinstance(hflow_reader, PythonMcapEpisodeReader)
+    mcap_reader = hflow_reader._reader
+    original_iter_messages = mcap_reader.iter_messages
+    topics_passed: list[Any] = []
+    topics_yielded: list[str] = []
+
+    def traced_iter_messages(*args: Any, **kwargs: Any) -> Iterator[Any]:
+        topics_passed.append(kwargs.get("topics", args[0] if args else None))
+        for schema, channel, message in original_iter_messages(*args, **kwargs):
+            topics_yielded.append(channel.topic)
+            yield schema, channel, message
+
+    monkeypatch.setattr(mcap_reader, "iter_messages", traced_iter_messages)
+    return topics_passed, topics_yielded
+
+
+def test_channel_read_is_constrained_to_the_requested_topic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reading one small channel must not pull a large unrelated stream
+    through the underlying MCAP reader: the channel's topic is passed down,
+    so only that topic's messages cross the library boundary."""
+    path = tmp_path / "two_topics.mcap"
+    target_payload = b"t" * 4096
+    camera_payloads = [bytes([65 + index]) * 4096 for index in range(8)]
+    with path.open("wb") as stream:
+        # A small chunk size keeps the two streams in separate chunks, the
+        # layout where an early topic filter can skip unrelated data.
+        writer = StockWriter(stream, chunk_size=1024, compression=CompressionType.NONE)
+        writer.start(profile="", library="test")
+        target_channel_id = writer.register_channel(
+            topic="/target", message_encoding="json", schema_id=0
+        )
+        camera_channel_id = writer.register_channel(
+            topic="/camera", message_encoding="json", schema_id=0
+        )
+        writer.add_message(target_channel_id, log_time=1, data=target_payload, publish_time=1)
+        for index, payload in enumerate(camera_payloads):
+            writer.add_message(
+                camera_channel_id, log_time=10 + index, data=payload, publish_time=10 + index
+            )
+        writer.finish()
+
+    with Episode(path) as episode:
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode, monkeypatch)
+        channel = episode.channel("/target")
+        assert channel.raw == [target_payload]
+        assert channel.timestamps.tolist() == [1]
+        assert topics_passed == [["/target"]]
+        assert topics_yielded == ["/target"]
+
+
+def test_shared_topic_channel_read_keeps_channel_id_selection(
+    dual_channel_source: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The topic constraint narrows the read but never replaces channel-id
+    selection: with two channels on one topic, the MCAP reader receives the
+    shared topic, yields both channels, and exactly the requested channel's
+    messages come back."""
+    with Episode(dual_channel_source) as episode:
+        by_encoding = {info.message_encoding: info for info in episode.channels.values()}
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode, monkeypatch)
+        cdr_channel = episode.channel(by_encoding["cdr"].channel_id)
+        assert topics_passed == [[SHARED_TOPIC]]
+        assert set(topics_yielded) == {SHARED_TOPIC}
+        assert cdr_channel.channel_id == by_encoding["cdr"].channel_id
+        assert cdr_channel.raw == CDR_PAYLOADS
 
 
 def test_episode_streams_several_decoded_channels_in_bounded_batches(

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -239,6 +239,34 @@ def test_decoded_batches_by_channel_id_derive_the_topic_filter(
         assert topics_yielded == ["/target", "/target"]
 
 
+def test_an_explicit_topic_filter_is_never_replaced_by_the_derived_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The derivation fires only when the caller left ``topics`` unset.
+
+    ``Episode.channel()`` passes both a topic and a channel id (#475), so if
+    the ``topics is None`` condition were dropped, the caller's explicit
+    filter would be silently replaced by one derived from the channel ids.
+    For that caller the two agree, which is why deleting the condition left
+    the whole suite green. Asking for one topic while naming a channel on a
+    different one is what separates them: the reader must receive what the
+    caller asked for, and yield nothing, rather than quietly reading the
+    other stream instead.
+    """
+    path = tmp_path / "two_topics_explicit.mcap"
+    _, camera_channel_id = _write_two_topic_mcap(path, [b"t" * 16], [b"c" * 16])
+
+    with Episode(path) as episode:
+        topics_passed, topics_yielded = _trace_mcap_iter_messages(episode._reader, monkeypatch)
+        batches = list(
+            episode._reader.iter_batches(topics=["/target"], channel_ids=[camera_channel_id])
+        )
+
+    assert topics_passed == [["/target"]]
+    assert topics_yielded == ["/target"]
+    assert batches == []
+
+
 def test_channel_id_read_without_a_summary_falls_back_to_a_full_scan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #470.

## Problem

`Episode.channel()` selects a channel by `channel_id`, but that never became a topic filter for the underlying MCAP reader, so `iter_messages(topics=None)` yielded every stream in the file and HFlow discarded the unrelated ones in Python. Reading a small state or action channel could decompress gigabytes of camera data for nothing.

## Fix

I took Option 2 from the issue: `PythonMcapEpisodeReader.iter_batches()` now derives the topics for the requested `channel_ids` from the file summary and passes them to `iter_messages()`, so the seeking reader can skip unrelated chunks. This covers every `channel_ids` caller, including `Episode.iter_decoded_batches()`, not just `Episode.channel()`.

Correctness cases from the issue are preserved:

- The channel-id filter is unchanged. Several channels can share one topic, and topic filtering only narrows the read, it never selects.
- Caller-supplied `topics` are never overridden.
- A file with no summary section, or all-unknown channel ids, falls back to the unconstrained read, preserving current behavior.

## Coverage

Two tests added to `tests/test_multichannel.py`, tracing at the mcap library boundary:

- Two topics in separate chunks: requesting `/target` passes `topics=["/target"]` down and only `/target` messages cross the boundary, with identical returned data.
- Two channels sharing one topic (the file's existing fixture): the shared topic is passed down, both channels are yielded by mcap, and exactly the requested channel's payloads come back, pinning that channel-id selection still wins.

## Validation

Run on WSL2 Ubuntu, Python 3.12:

```
uv sync --locked
uv run ruff check          # All checks passed
uv run ruff format --check # already formatted
uv run ty check            # All checks passed
uv run pytest -q           # 1713 passed, 6 skipped
```

Mutation check: with `src/hflow/reader.py` reverted to main, both new tests fail; restored, they pass. The touched test file also passes under Python 3.11.
