### PR TITLE
fix: make preview and pin agree on which SQL the curation gate accepts

### DIFF
--- a/packages/hflow-server/src/hflow_server/_curation.py
+++ b/packages/hflow-server/src/hflow_server/_curation.py
@@ -8,8 +8,10 @@ can read the data but can never touch the catalog's files -- hosted parity,
 and defense in depth even locally. The server wraps that SQL as a subquery
 (``SELECT ... FROM (<sql>)``) for LIMITing, counting, and SUMMARIZE, so a
 smuggled second statement is a parser error, and every DuckDB parser/binder
-error travels back as a 400 whose detail is DuckDB's own message -- the
-useful part -- never a 500.
+error about the CALLER'S SQL travels back as a 400 whose detail is DuckDB's
+own message -- the useful part -- never a 500. A parse failure of a wrapper
+this server constructed is answered with the gate's fixed refusal sentence
+instead: no 400 body ever contains SQL the caller did not send (#450).
 
 Workspace convention: pinned manifests are immutable files at
 ``<data_root>/manifests/<slug>-<utc timestamp>.parquet`` -- never the
@@ -76,6 +78,21 @@ CATALOG_TABLE_BROWSING_ORDER = (
 )
 
 _TIMESTAMPTZ_TYPE = "TIMESTAMP WITH TIME ZONE"
+
+# The one sentence every curation route answers when SQL is well-formed but
+# not the accepted shape. Pinned by tests (#448); reused verbatim so preview,
+# report, and pin can never drift apart on wording.
+_SINGLE_SELECT_REFUSAL = "sql must be exactly one read-only SELECT statement"
+
+# Statement texts the curation gate accepts: every way DuckDB spells a query
+# that is both genuinely a SELECT and legal as a subquery (preview wraps the
+# SQL in ``SELECT ... FROM (<sql>)``). DuckDB types introspection statements
+# such as ``PRAGMA database_list``, ``DESCRIBE``, ``SUMMARIZE``, and ``SHOW``
+# as StatementType.SELECT because it implements them as table functions, but
+# they are illegal as subqueries -- so preview's wrapper failed to parse while
+# pin ran them as-is, and the two routes disagreed (#450). Judging the leading
+# keyword too keeps both routes refusing them with the same sentence.
+_ACCEPTED_LEADING_SQL_KEYWORDS = frozenset({"SELECT", "WITH", "FROM", "VALUES"})
 
 # What a read-only launch refuses on this router; the sentence around it (and
 # the 403) belongs to _settings.refuse_when_read_only.
@@ -158,24 +175,70 @@ def _bad_sql_refusal(error: duckdb.Error) -> HTTPException:
     return HTTPException(status_code=400, detail=str(error))
 
 
-def _reject_non_single_select(user_sql: str) -> None:
-    """Refuse anything that is not exactly one SELECT statement.
+def _leading_sql_keyword(sql: str) -> str:
+    """The statement's first word, uppercased -- past whitespace, comments, parens.
 
-    ``hflow.reject_non_single_select`` owns the rule (exactly one statement
-    whose type is SELECT, judged by parsing with ``extract_statements``
-    WITHOUT executing anything); this route only maps its two failure modes
-    onto the two client-facing 400s: DuckDB's own diagnostic for SQL the
-    parser rejects, the fixed sentence for SQL that is well-formed but not a
-    single SELECT.
+    A tiny scan, not a SQL parser: the gate has already confirmed *sql* parses
+    as exactly one statement, so this only needs to find where that statement's
+    first keyword starts. It skips runs of whitespace, ``--`` line comments,
+    ``/* */`` block comments (nested, as DuckDB nests them following Postgres),
+    and ``(`` -- a parenthesized query like ``(SELECT 1)`` is still SELECT
+    text, and no non-query statement can appear inside parentheses and survive
+    the parse the gate already ran.
+    """
+    index = 0
+    end = len(sql)
+    while index < end:
+        character = sql[index]
+        if character.isspace() or character == "(":
+            index += 1
+        elif sql.startswith("--", index):
+            line_end = sql.find("\n", index)
+            index = end if line_end == -1 else line_end + 1
+        elif sql.startswith("/*", index):
+            comment_depth = 1
+            index += 2
+            while index < end and comment_depth > 0:
+                if sql.startswith("/*", index):
+                    comment_depth += 1
+                    index += 2
+                elif sql.startswith("*/", index):
+                    comment_depth -= 1
+                    index += 2
+                else:
+                    index += 1
+        else:
+            break
+    keyword_start = index
+    while index < end and (sql[index].isalpha() or sql[index] == "_"):
+        index += 1
+    return sql[keyword_start:index].upper()
+
+
+def _reject_non_single_select(user_sql: str) -> None:
+    """Refuse anything that is not exactly one SELECT-text statement.
+
+    ``hflow.reject_non_single_select`` owns the base rule (exactly one
+    statement whose type is SELECT, judged by parsing with
+    ``extract_statements`` WITHOUT executing anything); this route only maps
+    its two failure modes onto the two client-facing 400s: DuckDB's own
+    diagnostic for SQL the parser rejects, the fixed sentence for SQL that is
+    well-formed but not a single SELECT.
+
+    On top of that, the statement must READ as a SELECT: its leading keyword
+    has to be one of ``_ACCEPTED_LEADING_SQL_KEYWORDS``. Statement TYPE alone
+    let DuckDB's SELECT-typed introspection statements (``PRAGMA``,
+    ``DESCRIBE``, ``SUMMARIZE``, ``SHOW``) through, which pin could run but
+    preview's subquery wrapper could not even parse (#450).
     """
     try:
         reject_non_single_select(user_sql)
     except duckdb.Error as error:
         raise _bad_sql_refusal(error) from error
     except NonSingleSelectQueryError:
-        raise HTTPException(
-            status_code=400, detail="sql must be exactly one read-only SELECT statement"
-        ) from None
+        raise HTTPException(status_code=400, detail=_SINGLE_SELECT_REFUSAL) from None
+    if _leading_sql_keyword(user_sql) not in _ACCEPTED_LEADING_SQL_KEYWORDS:
+        raise HTTPException(status_code=400, detail=_SINGLE_SELECT_REFUSAL)
 
 
 def _browsable_relations(
@@ -213,7 +276,17 @@ def _browsable_relations(
 def _described_columns(
     connection: duckdb.DuckDBPyConnection, user_sql: str
 ) -> list[ColumnDescriptor]:
-    described_rows = connection.execute(f"DESCRIBE SELECT * FROM ({user_sql})").fetchall()
+    # The DESCRIBE wrapper is OUR text, not the caller's: the gate already
+    # parsed user_sql standalone, so a parse failure here means the wrapper
+    # choked on a statement shape the gate should have refused. Answer with
+    # the gate's fixed sentence -- never DuckDB's diagnostic for a rewrite the
+    # caller did not send and cannot act on (#450). Binder/catalog errors
+    # (unknown table, unknown column) still propagate to the route's handler
+    # and travel back with DuckDB's own message, which IS about their SQL.
+    try:
+        described_rows = connection.execute(f"DESCRIBE SELECT * FROM ({user_sql})").fetchall()
+    except (duckdb.ParserException, duckdb.SyntaxException) as error:
+        raise HTTPException(status_code=400, detail=_SINGLE_SELECT_REFUSAL) from error
     return [ColumnDescriptor(name=str(row[0]), type=str(row[1])) for row in described_rows]
 
 

--- a/packages/hflow-server/tests/test_server_curation_sql_gate.py
+++ b/packages/hflow-server/tests/test_server_curation_sql_gate.py
@@ -1,0 +1,73 @@
+"""Preview and pin agree on which SQL the curation gate accepts (#450).
+
+DuckDB types introspection statements (``PRAGMA``, ``DESCRIBE``,
+``SUMMARIZE``) as StatementType.SELECT, so a statement-type-only gate let
+them through: pin ran them as-is while preview's ``DESCRIBE SELECT * FROM
+(<sql>)`` wrapper failed to parse and blamed the caller for the wrapper's
+syntax error. The gate now also requires the statement to READ as a SELECT
+(leading keyword SELECT/WITH/FROM/VALUES), so both routes refuse the same
+inputs with the same sentence, and no refusal ever echoes the rewrite.
+"""
+
+import duckdb
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from hflow_server import _curation
+
+_WRAPPER_TEXT = "DESCRIBE SELECT * FROM"
+_REFUSAL_SENTENCE = "sql must be exactly one read-only SELECT statement"
+
+# The issue's measured table, plus the query spellings DuckDB supports that
+# must stay accepted: FROM-first, VALUES, WITH, and comment-prefixed SELECTs.
+AGREEMENT_TABLE = [
+    ("SELECT episode_id FROM episodes", True),
+    ("WITH ok AS (SELECT episode_id FROM episodes) SELECT * FROM ok", True),
+    ("FROM episodes", True),
+    ("VALUES (1), (2)", True),
+    ("-- keep the good runs\nSELECT episode_id FROM episodes", True),
+    ("/* leading block comment */ SELECT 1 AS n", True),
+    ("(SELECT episode_id FROM episodes)", True),
+    ("PRAGMA database_list", False),
+    ("PRAGMA show_tables", False),
+    ("PRAGMA version", False),
+    ("DESCRIBE SELECT 1", False),
+    ("SUMMARIZE SELECT 1", False),
+    ("SHOW TABLES", False),
+    ("/* SELECT in a comment fools nobody */ PRAGMA version", False),
+    ("SELECT 1; SELECT 2", False),
+]
+
+
+@pytest.mark.parametrize(("sql", "accepted"), AGREEMENT_TABLE)
+def test_preview_and_pin_agree_on_what_the_gate_accepts(
+    writable_api: TestClient, sql: str, accepted: bool
+) -> None:
+    preview = writable_api.post("/api/v1/curation/preview", json={"sql": sql})
+    pin = writable_api.post("/api/v1/curation/pin", json={"sql": sql, "name": "agreement case"})
+    if accepted:
+        assert preview.status_code == 200, preview.text
+        assert pin.status_code == 200, pin.text
+    else:
+        # Both routes refuse, with the SAME fixed sentence -- never DuckDB's
+        # diagnostic for the preview wrapper, and never the rewrite itself.
+        for response in (preview, pin):
+            assert response.status_code == 400, response.text
+            assert response.json()["detail"] == _REFUSAL_SENTENCE
+            assert _WRAPPER_TEXT not in response.text
+
+
+def test_a_wrapper_parse_failure_is_never_blamed_on_the_caller() -> None:
+    # Belt and braces behind the gate: if a statement that cannot be
+    # subqueried ever reaches the DESCRIBE wrapper again, the 400 is the
+    # gate's fixed sentence, not DuckDB's parse diagnostic for OUR rewrite
+    # (which names a ')' the caller never typed and echoes the wrapper).
+    connection = duckdb.connect()
+    try:
+        with pytest.raises(HTTPException) as raised:
+            _curation._described_columns(connection, "PRAGMA database_list")
+    finally:
+        connection.close()
+    assert raised.value.status_code == 400
+    assert raised.value.detail == _REFUSAL_SENTENCE
+    assert _WRAPPER_TEXT not in str(raised.value.detail)


### PR DESCRIPTION
Closes #450.

## Problem

`POST /curation/preview` and `POST /curation/pin` advertise the same rule, exactly one read-only SELECT, and did not accept the same SQL. DuckDB types introspection statements such as `PRAGMA database_list` as `StatementType.SELECT`, so they passed the shared gate: pin ran them (200), while preview interpolated them into its `DESCRIBE SELECT * FROM (...)` wrapper, which failed to parse and returned a 400 whose body was DuckDB's diagnostic for the rewritten query, blaming the caller for a `)` they never typed and leaking the internal rewrite.

## Direction taken

The issue's first option: narrow the shared gate so both routes refuse statements that are not actually SELECT text. After the existing single-statement and statement-type check, the statement's leading keyword, scanned past whitespace, line comments, nested block comments, and parentheses, must be `SELECT`, `WITH`, `FROM`, or `VALUES` (FROM-first and VALUES are genuine queries and subquery-legal). `PRAGMA`, `DESCRIBE`, `SUMMARIZE`, and `SHOW` are refused on both routes with the existing pinned sentence, now a shared constant so the three routes cannot drift on wording.

What a user loses: `DESCRIBE` and `SUMMARIZE` previously worked on both routes (verified on DuckDB 1.5.5, which can wrap both as subqueries; only `PRAGMA` fails to wrap). They now get 400 on both. They worked by accident of DuckDB's statement typing, nothing documents them, and preview-then-pin is the advertised flow, so consistency wins.

Defense in depth for the leak: `_described_columns` now answers a parse failure of its own wrapper with the fixed refusal sentence, so no 400 body can contain SQL the caller did not send. Binder and catalog errors about the caller's own SQL still travel back with DuckDB's message, keeping the #448 pins intact.

## Coverage

New `packages/hflow-server/tests/test_server_curation_sql_gate.py`: a 15-row parametrized table (the issue's cases plus WITH, FROM-first, VALUES, parenthesized, comment-prefixed, SHOW, a comment-disguised PRAGMA, and multi-statement) runs every row against both endpoints and asserts they agree, that refusals carry the fixed sentence, and that no body contains the wrapper text. A direct unit test pins that a wrapper parse failure is never blamed on the caller.

During validation the root-suite test `test_successful_retry_after_error_appends_repaired_outcome` failed once on a `recorded_at` ordering tie and passed 12 out of 12 repeat runs on both this branch and main, so it looks like an unrelated timing flake, noted here for transparency.

## Validation

Run on WSL2 Ubuntu, Python 3.12:

```
uv sync --locked
uv run ruff check          # All checks passed
uv run ruff format --check # already formatted
uv run ty check            # All checks passed
uv run pytest -q           # 1727 passed, 6 skipped
```

Mutation check: with `_curation.py` reverted to main, 8 of the 16 new gate tests fail (the refusal rows); restored, all 16 pass. The server test suite also passes under Python 3.11 (251 passed).
