### PR TITLE
fix: validate LeRobot path templates at the info.json boundary

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -617,6 +617,46 @@ def _episode_metadata_cache_path(
     return episodes_metadata_directory / relative_path
 
 
+# Exactly the fields _convert_single_episode supplies to each template's
+# str.format call: data_path gets integer chunk/file indexes; video_path
+# additionally gets the camera name under both of its historical spellings.
+# Values mirror the runtime types so format specs are checked honestly
+# ({chunk_index:06d} needs an int, {camera_key} a str).
+_DATA_PATH_TEMPLATE_TEST_FIELDS: dict[str, int | str] = {"chunk_index": 0, "file_index": 0}
+_VIDEO_PATH_TEMPLATE_TEST_FIELDS: dict[str, int | str] = {
+    "chunk_index": 0,
+    "file_index": 0,
+    "video_key": "camera",
+    "camera_key": "camera",
+}
+
+
+def _validate_path_template(
+    template: str, field_name: str, converter_supplied_fields: dict[str, int | str]
+) -> None:
+    """Refuse a path template that ``str.format`` would reject during conversion.
+
+    Episode conversion formats these templates with a fixed set of fields.
+    Test-formatting once here, with exactly those fields and value types,
+    keeps a malformed or wrong-placeholder template at this boundary instead
+    of surfacing as a bare ``KeyError``/``ValueError``/``IndexError`` after
+    every episode metadata shard has already been downloaded (#471).
+    """
+    try:
+        template.format(**converter_supplied_fields)
+    except (KeyError, IndexError, ValueError) as format_error:
+        match format_error:
+            case KeyError():
+                reason = f"unknown field {format_error.args[0]!r}"
+            case IndexError():
+                reason = "positional fields are not supported"
+            case _:
+                reason = str(format_error)
+        raise ValueError(
+            f"LeRobot meta/info.json has an invalid {field_name} template {template!r}: {reason}"
+        ) from format_error
+
+
 def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation:
     """Turn a raw ``meta/info.json`` document into immutable internal values.
 
@@ -639,11 +679,15 @@ def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation
     data_path_template = dataset_information.get("data_path")
     if not isinstance(data_path_template, str) or not data_path_template.strip():
         raise ValueError("LeRobot meta/info.json must define a non-empty data_path template")
+    _validate_path_template(data_path_template, "data_path", _DATA_PATH_TEMPLATE_TEST_FIELDS)
     video_path_template = dataset_information.get(
         "video_path", "videos/{camera_key}/{chunk_index:06d}/{file_index:06d}.mp4"
     )
     if not isinstance(video_path_template, str) or not video_path_template.strip():
         raise ValueError("LeRobot meta/info.json must define a non-empty video_path template")
+    # Validated after the default is applied: the parsed value, default
+    # included, is exactly what episode conversion will format.
+    _validate_path_template(video_path_template, "video_path", _VIDEO_PATH_TEMPLATE_TEST_FIELDS)
 
     dataset_features = dataset_information.get("features")
     if not isinstance(dataset_features, dict):

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -119,6 +119,149 @@ def test_import_refuses_empty_path_templates(
     _assert_no_dataset_output(output_dir)
 
 
+@pytest.mark.parametrize(
+    ("field", "template", "match_pattern"),
+    [
+        # Unknown field: the plausible accident, a template indexing episodes.
+        (
+            "data_path",
+            "data/{episode_index:03d}/f.parquet",
+            _exactly(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/{episode_index:03d}/f.parquet': unknown field 'episode_index'"
+            ),
+        ),
+        # A video-template field is unknown to data_path: proves each template
+        # is checked against its own field set, not a shared union.
+        (
+            "data_path",
+            "data/{video_key}/f.parquet",
+            _exactly(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/{video_key}/f.parquet': unknown field 'video_key'"
+            ),
+        ),
+        (
+            "data_path",
+            "data/{chunk_index:03d/f.parquet",
+            _exactly(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/{chunk_index:03d/f.parquet': unmatched '{' in format spec"
+            ),
+        ),
+        # The format-spec detail differs across Python versions (3.11 omits
+        # the specifier and type), so this one pins the stable prefix only.
+        (
+            "data_path",
+            "data/{chunk_index:qq}/f.parquet",
+            r"^"
+            + re.escape(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/{chunk_index:qq}/f.parquet': Invalid format specifier"
+            ),
+        ),
+        (
+            "data_path",
+            "data/{0}/f.parquet",
+            _exactly(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/{0}/f.parquet': positional fields are not supported"
+            ),
+        ),
+        (
+            "data_path",
+            "data/}chunk/f.parquet",
+            _exactly(
+                "LeRobot meta/info.json has an invalid data_path template "
+                "'data/}chunk/f.parquet': Single '}' encountered in format string"
+            ),
+        ),
+        (
+            "video_path",
+            "videos/{episode_index}/f.mp4",
+            _exactly(
+                "LeRobot meta/info.json has an invalid video_path template "
+                "'videos/{episode_index}/f.mp4': unknown field 'episode_index'"
+            ),
+        ),
+        (
+            "video_path",
+            "videos/{0}/f.mp4",
+            _exactly(
+                "LeRobot meta/info.json has an invalid video_path template "
+                "'videos/{0}/f.mp4': positional fields are not supported"
+            ),
+        ),
+    ],
+)
+def test_import_refuses_invalid_path_templates_before_listing_episodes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    template: str,
+    match_pattern: str,
+) -> None:
+    """A template ``str.format`` would reject is refused at the parse boundary.
+
+    #471: these previously passed the boundary and raised a bare
+    ``KeyError``/``ValueError``/``IndexError`` out of episode conversion,
+    after every episode metadata shard had been downloaded. The second
+    assertion pins the "before" part: an invalid template must not cost a
+    listing of ``meta/episodes``.
+    """
+    _stub_repo_info(monkeypatch)
+    info = {
+        "fps": 30,
+        "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+        "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        "features": {},
+    }
+    info[field] = template
+    monkeypatch.setattr(prep, "_fetch_info_json", lambda _repo, _revision, _cache: info)
+    listed_paths: list[str] = []
+
+    def recording_hf_tree(_repo: str, _revision: str, path: str) -> list[dict[str, str]]:
+        listed_paths.append(path)
+        return []
+
+    monkeypatch.setattr(prep, "_hf_tree", recording_hf_tree)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(ValueError, match=match_pattern):
+        _import(output_dir)
+
+    assert listed_paths == []
+    _assert_no_dataset_output(output_dir)
+
+
+def test_import_accepts_default_video_path_template_when_field_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Omitting ``video_path`` falls back to the default, which passes the boundary.
+
+    The boundary validates the template that conversion will actually format,
+    default included, so the import proceeds past ``info.json`` parsing and
+    fails only at the (empty) episode listing.
+    """
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(
+        prep,
+        "_fetch_info_json",
+        lambda _repo, _revision, _cache: {
+            "fps": 30,
+            "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
+            "features": {},
+        },
+    )
+    monkeypatch.setattr(prep, "_hf_tree", lambda _repo, _revision, _path: [])
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(RuntimeError, match=_exactly("no meta/episodes parquet files found")):
+        _import(output_dir)
+
+    _assert_no_dataset_output(output_dir)
+
+
 def test_import_refuses_info_json_without_features_before_listing_episodes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #471.

Note: I saw @chiruu12 offered to take this on the issue. There is no assignee, and per the maintainer's stated rule an assignee is the only thing that reserves an issue, but I am happy to defer if you would rather assign it there.

## Problem

`_parse_dataset_information` documents itself as the one place `meta/info.json` is inspected, but `data_path` and `video_path` were only checked for being non-empty strings. A template naming an unknown field, or one that is not a well-formed format string, passed the boundary and blew up about five hundred lines later inside episode conversion as a bare `KeyError`, `ValueError`, or `IndexError` that named neither the file nor the field, and only after every episode metadata shard had been downloaded.

## Fix

A `_validate_path_template` helper test-formats each template once at the boundary with exactly the fields episode conversion supplies, typed like the runtime values so format specs are checked honestly: integer `chunk_index` and `file_index` for both templates, plus string `video_key` and `camera_key` for `video_path`. Failures are refused in the same message shape as the neighboring validations:

```
LeRobot meta/info.json has an invalid data_path template 'data/{episode_index:03d}/f.parquet': unknown field 'episode_index'
```

All five failure shapes from the issue's table are covered. On the open question in the issue thread, the video template is validated after its default is applied, so the checked value is exactly the one conversion will format, and the default itself is covered as cheap insurance.

## Coverage

Extends the refusal tests from #415 in `tests/test_lerobot_metadata_refusals.py`: eight parametrized invalid-template cases (all five shapes for `data_path`, a `data_path` using `video_key` to prove the field sets are per-template, and `video_path` unknown-field and positional cases), each asserting the exact message and that no episode listing happened, so the refusal is pinned to land before any download. A ninth case proves the default `video_path` still passes the boundary. The bad-format-spec case anchors through the text both Python 3.11 and 3.14 produce.

## Validation

Run on WSL2 Ubuntu, Python 3.12:

```
uv sync --locked
uv run ruff check          # All checks passed
uv run ruff format --check # already formatted
uv run ty check            # All checks passed
uv run pytest -q           # 1720 passed, 6 skipped
```

Mutation check: with `importers/lerobot.py` reverted to main, the 8 invalid-template cases fail; restored, all 18 tests in the file pass. The file also passes under Python 3.11.
