### PR TITLE
perf: avoid repeated keyframe payload scans

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1837,10 +1837,16 @@ def _keyframe_indices(channel: ChannelData) -> tuple[int, ...]:
 
 
 def _keyframe_interval_intermediates(channel: ChannelData) -> _KeyframeIntervalPerCamera:
-    frame_count = channel.timestamps.size
+    """One camera's keyframe scan, computed once and shared by the body and
+    the key-set fact (#480).
+
+    No empty-channel shortcut: ``_keyframe_indices`` on a channel with no
+    messages already returns ``()`` without inspecting a payload, so guarding
+    it would only add a branch that reads as if it saved something.
+    """
     return _KeyframeIntervalPerCamera(
-        frame_count=frame_count,
-        keyframe_indices=_keyframe_indices(channel) if frame_count else (),
+        frame_count=channel.timestamps.size,
+        keyframe_indices=_keyframe_indices(channel),
     )
 
 
@@ -1940,11 +1946,15 @@ def keyframe_interval(episode: Episode, *, cameras: Sequence[str] | None = None)
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     timestamps_by_camera: dict[str, np.ndarray] = {}
     intermediates_by_camera: dict[str, _KeyframeIntervalPerCamera] = {}
+    # dict.fromkeys, not set: a repeated camera is loaded once but the
+    # measurement loop below still walks selected_cameras in the order the
+    # caller gave. Only the timestamps and the small keyframe struct are kept,
+    # so the channel's raw payloads are released as the loop moves on rather
+    # than all C being held at once.
     for topic in dict.fromkeys(selected_cameras):
         channel = episode.channel(topic)
         timestamps_by_camera[topic] = channel.timestamps
         intermediates_by_camera[topic] = _keyframe_interval_intermediates(channel)
-        del channel
     keys = sorted(
         _keyframe_interval_keys(
             episode,

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -16,7 +16,7 @@ rather than a shared ``message_count``.
 """
 
 import hashlib
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -1828,21 +1828,28 @@ class _KeyframeIntervalPerCamera:
 
 def _keyframe_indices(channel: ChannelData) -> tuple[int, ...]:
     """Shared payload-scan helper for ``keyframe_interval``: which message
-    indices in ``channel.raw`` are keyframes. The fact and the body call
-    this; the cost is one Annex B scan per camera per call, which is the
-    irreducible price the default pays to know its own key set. Caching
-    the result on the channel would let the pre-decode supersession
-    consult the fact without a second scan, but no caller needs that
-    today -- the body is the only reader, and the fact is only consulted
-    when the default will run anyway. Revisit if a future change makes
-    the pre-decode check the hot path for this default.
+    indices in ``channel.raw`` are keyframes. The body shares the result
+    with the key-set fact so each camera's payloads are scanned once.
     """
     return tuple(
         index for index, payload in enumerate(channel.raw) if _payload_starts_a_keyframe(payload)
     )
 
 
-def _keyframe_interval_keys(episode: Episode, *, cameras: Sequence[str] | None = None) -> set[str]:
+def _keyframe_interval_intermediates(channel: ChannelData) -> _KeyframeIntervalPerCamera:
+    frame_count = channel.timestamps.size
+    return _KeyframeIntervalPerCamera(
+        frame_count=frame_count,
+        keyframe_indices=_keyframe_indices(channel) if frame_count else (),
+    )
+
+
+def _keyframe_interval_keys(
+    episode: Episode,
+    *,
+    cameras: Sequence[str] | None = None,
+    intermediates_by_camera: Mapping[str, _KeyframeIntervalPerCamera] | None = None,
+) -> set[str]:
     """The one statement of ``keyframe_interval``'s measurement key set.
 
     Per selected camera: ``scanned_frame_count`` and ``keyframe_count``
@@ -1851,23 +1858,26 @@ def _keyframe_interval_keys(episode: Episode, *, cameras: Sequence[str] | None =
     found; ``median_keyframe_interval_s`` only when at least two
     keyframes are found. ``App``'s pre-decode supersession reads this
     through the routing map, which only ever sees the automatic bare
-    registration.
+    registration. The body supplies its already-computed intermediates;
+    standalone callers compute them here.
     """
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     keys: set[str] = set()
     for topic in selected_cameras:
-        channel = episode.channel(topic)
-        frame_count = channel.timestamps.size
+        inter = (
+            _keyframe_interval_intermediates(episode.channel(topic))
+            if intermediates_by_camera is None
+            else intermediates_by_camera[topic]
+        )
         keys.add(f"{topic}/scanned_frame_count")
-        if frame_count == 0:
+        if inter.frame_count == 0:
             continue
-        keyframe_indices = _keyframe_indices(channel)
         keys.add(f"{topic}/keyframe_count")
         keys.add(f"{topic}/first_frame_is_keyframe")
-        if not keyframe_indices:
+        if not inter.keyframe_indices:
             continue
         keys.add(f"{topic}/max_keyframe_gap_s")
-        if len(keyframe_indices) >= 2:
+        if len(inter.keyframe_indices) >= 2:
             keys.add(f"{topic}/median_keyframe_interval_s")
     return keys
 
@@ -1928,18 +1938,25 @@ def keyframe_interval(episode: Episode, *, cameras: Sequence[str] | None = None)
     them as perfect.
     """
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
+    timestamps_by_camera: dict[str, np.ndarray] = {}
+    intermediates_by_camera: dict[str, _KeyframeIntervalPerCamera] = {}
+    for topic in dict.fromkeys(selected_cameras):
+        channel = episode.channel(topic)
+        timestamps_by_camera[topic] = channel.timestamps
+        intermediates_by_camera[topic] = _keyframe_interval_intermediates(channel)
+        del channel
+    keys = sorted(
+        _keyframe_interval_keys(
+            episode,
+            cameras=selected_cameras,
+            intermediates_by_camera=intermediates_by_camera,
+        )
+    )
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:
-        channel = episode.channel(topic)
-        stamps_ns = channel.timestamps
-        if stamps_ns.size == 0:
-            measurements[f"{topic}/scanned_frame_count"] = 0
-            continue
-        inter = _KeyframeIntervalPerCamera(
-            frame_count=stamps_ns.size,
-            keyframe_indices=_keyframe_indices(channel),
-        )
-        for key in sorted(_keyframe_interval_keys(episode, cameras=selected_cameras)):
+        stamps_ns = timestamps_by_camera[topic]
+        inter = intermediates_by_camera[topic]
+        for key in keys:
             if not key.startswith(f"{topic}/"):
                 continue
             name = key[len(topic) + 1 :]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
 from mcap.writer import Writer as StockWriter
+from mcap_protobuf.schema import build_file_descriptor_set
 
 import hflow
 from hflow.checks import (
@@ -463,6 +465,111 @@ def test_keyframe_interval_reports_the_encoders_gop(tmp_path: Path) -> None:
     # encoder applies when converting seconds to a frame count.
     assert 0.5 < max_gap_s < 1.6
     assert result.verdict is None
+
+
+@pytest.mark.parametrize(
+    ("cameras", "expected_payload_checks"),
+    [
+        pytest.param(None, 15, id="all-cameras"),
+        pytest.param([], 0, id="no-cameras"),
+        pytest.param(["/empty/compressed"], 0, id="empty-camera"),
+        pytest.param(["/multiple/compressed"], 5, id="one-camera"),
+        pytest.param(["/single/compressed", "/empty/compressed"], 5, id="nonempty-and-empty"),
+        pytest.param(["/multiple/compressed", "/multiple/compressed"], 5, id="repeated-selection"),
+    ],
+)
+def test_keyframe_interval_preserves_measurements_with_one_scan_per_camera(
+    cameras: list[str] | None,
+    expected_payload_checks: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Load each camera once and check its payloads once (#480).
+
+    Pin every measurement for zero, one, and multiple keyframes, including
+    irregular timestamps, a keyframe at the tail, and an empty channel.
+    """
+    source = tmp_path / "keyframes.mcap"
+    aud = b"\x00\x00\x00\x01\x09\xf0"
+    keyframe = aud + b"\x00\x00\x00\x01\x65\xb0"
+    non_keyframe = aud + b"\x00\x00\x00\x01\x41\xc0"
+    with source.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="protobuf",
+            data=build_file_descriptor_set(CompressedVideo).SerializeToString(),
+        )
+        for camera, keyframes in (("none", ()), ("single", (4,)), ("multiple", (0, 2, 3))):
+            channel_id = writer.register_channel(
+                topic=f"/{camera}/compressed", message_encoding="protobuf", schema_id=schema_id
+            )
+            for index, timestamp_s in enumerate((1, 2, 4, 7, 8)):
+                timestamp_ns = timestamp_s * 1_000_000_000
+                message = CompressedVideo(
+                    frame_id=camera,
+                    format="h264",
+                    data=keyframe if index in keyframes else non_keyframe,
+                )
+                message.timestamp.FromNanoseconds(timestamp_ns)
+                writer.add_message(
+                    channel_id,
+                    log_time=timestamp_ns,
+                    publish_time=timestamp_ns,
+                    data=message.SerializeToString(),
+                )
+        writer.register_channel(
+            topic="/empty/compressed", message_encoding="protobuf", schema_id=schema_id
+        )
+        writer.finish()
+
+    expected = {
+        "/empty/compressed/scanned_frame_count": 0,
+        "/none/compressed/scanned_frame_count": 5,
+        "/none/compressed/keyframe_count": 0,
+        "/none/compressed/first_frame_is_keyframe": 0,
+        "/single/compressed/scanned_frame_count": 5,
+        "/single/compressed/keyframe_count": 1,
+        "/single/compressed/first_frame_is_keyframe": 0,
+        "/single/compressed/max_keyframe_gap_s": 0.0,
+        "/multiple/compressed/scanned_frame_count": 5,
+        "/multiple/compressed/keyframe_count": 3,
+        "/multiple/compressed/first_frame_is_keyframe": 1,
+        "/multiple/compressed/max_keyframe_gap_s": 3.0,
+        "/multiple/compressed/median_keyframe_interval_s": 3.0,
+    }
+    if cameras is not None:
+        expected = {
+            key: value for key, value in expected.items() if key.rsplit("/", 1)[0] in cameras
+        }
+
+    payload_checks = 0
+    real_payload_check = hflow.checks._payload_starts_a_keyframe
+
+    def count_payload_check(payload: bytes) -> bool:
+        nonlocal payload_checks
+        payload_checks += 1
+        return real_payload_check(payload)
+
+    with hflow.Episode(source) as episode:
+        channel_calls: list[str | int] = []
+        real_channel = episode.channel
+
+        def count_channel_call(key: str | int) -> hflow.ChannelData:
+            channel_calls.append(key)
+            return real_channel(key)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(hflow.checks, "_payload_starts_a_keyframe", count_payload_check)
+            patch.setattr(episode, "channel", count_channel_call)
+            result = keyframe_interval(episode, cameras=cameras)
+        assert result.measurements == expected
+        assert result.verdict is None
+        assert payload_checks == expected_payload_checks
+        assert channel_calls == list(dict.fromkeys(episode.cameras if cameras is None else cameras))
+        # App's supersession path asks for keys without precomputed records.
+        assert hflow.checks._keyframe_interval_keys(episode, cameras=cameras) == set(expected)
 
 
 def test_fps_conformance_classifies_matching_and_half_rate_streams(tmp_path: Path) -> None:

--- a/tests/test_default_checks.py
+++ b/tests/test_default_checks.py
@@ -1118,6 +1118,42 @@ def test_keyframe_interval_emits_exactly_the_documented_measurements(
     _assert_measurements_match_pinned(dict(run.result.measurements), expected_subset)
 
 
+@pytest.mark.parametrize(
+    ("measurement_name", "superseded"),
+    [("max_keyframe_gap_s", True), ("median_keyframe_interval_s", False)],
+)
+def test_keyframe_supersession_uses_only_keys_the_camera_would_emit(
+    measurement_name: str, superseded: bool, camera_source: Path, tmp_path: Path
+) -> None:
+    # This one-GOP camera has a maximum gap but no median keyframe interval.
+    app = hflow.App(
+        "keyframe-overlap",
+        data_root=tmp_path / "data",
+        default_checks=(hflow.checks.keyframe_interval,),
+    )
+    key = f"/wrist_cam/compressed/{measurement_name}"
+
+    @app.check(version="1")
+    def pipeline_cadence(episode: hflow.Episode) -> hflow.CheckResult:
+        return hflow.CheckResult(measurements={key: 42.0})
+
+    report = app.test(camera_source, verbose=False)
+    pipeline_result = report.check("pipeline_cadence").result
+    assert pipeline_result is not None
+    assert pipeline_result.measurements == {key: 42.0}
+    default = report.check("keyframe_interval")
+    if superseded:
+        assert default.status is hflow.CheckStatus.SUPERSEDED
+        assert default.result is None
+        assert default.duration_s == 0.0
+        assert isinstance(default.not_run, hflow.SupersededByPipeline)
+        assert default.not_run.superseded_keys == (key,)
+    else:
+        assert default.result is not None
+        assert key not in default.result.measurements
+        assert default.result.measurements["/wrist_cam/compressed/keyframe_count"] == 1
+
+
 # content_digest: the single key ``content_digest`` carries a 64-char hex
 # SHA-256. The exact value is runner- and codec-build dependent, so the
 # fixture pins only its type and length.


### PR DESCRIPTION
Fixes #480.

`keyframe_interval()` was rescanning camera payloads multiple times while determining both per-camera measurements and the overall measurement key set.

With `C` selected cameras, the old path performed roughly:

```text
C + C²
```

full keyframe scans.

This change computes the per-camera keyframe intermediates once and reuses them, reducing the expensive payload parsing to roughly:

```text
C
```

while keeping `_keyframe_interval_keys()` as the single source of truth for the measurement key set.

## What changed

* Added a helper to compute `_KeyframeIntervalPerCamera` once per camera.
* `keyframe_interval()` now:

  * loads each unique selected camera once
  * stores only the timestamps and small keyframe intermediate
  * reuses those intermediates when determining measurement keys
* `_keyframe_interval_keys()` can consume precomputed intermediates from `keyframe_interval()`.
* Standalone callers of `_keyframe_interval_keys()` keep the existing behavior and compute the information themselves.
* Preserved the empty-camera behavior and App pre-decode supersession behavior.

## Performance regression test

Added a test that counts calls to `_payload_starts_a_keyframe()` and `Episode.channel()`.

For 3 cameras with 5 payloads each:

```text
Before:
60 payload checks

After:
15 payload checks
```

So each payload is inspected once instead of repeatedly rescanning all selected cameras.

The test also covers:

* all cameras
* no cameras
* empty camera
* one camera
* non-empty + empty cameras
* repeated camera selection

## Behavior

The emitted measurements remain unchanged, including the empty-camera case where only `scanned_frame_count` is emitted.

The App supersession path is also covered to ensure `_keyframe_interval_keys()` still produces the same key set.

## Validation

```text
uv run ruff check
uv run ruff format --check
uv run ty check
uv run pytest -q
```

Result:

```text
1720 passed, 7 skipped
```
