### PR TITLE
fix(verification): type finding reasons as an enum

### DIFF
--- a/src/hflow/__init__.py
+++ b/src/hflow/__init__.py
@@ -122,6 +122,7 @@ from hflow.storage import (
 from hflow.transform import EpisodeStamps, TransformConfig, write_canonical_episode
 from hflow.verification import (
     VerificationFinding,
+    VerificationReason,
     VerificationReport,
     VerificationStatus,
 )
@@ -206,6 +207,7 @@ __all__ = [
     "TopicInfo",
     "TransformConfig",
     "VerificationFinding",
+    "VerificationReason",
     "VerificationReport",
     "VerificationStatus",
     "VideoImportConfig",

--- a/src/hflow/verification.py
+++ b/src/hflow/verification.py
@@ -9,7 +9,8 @@ dataset snapshot verifier (:func:`hflow.snapshot.verify_dataset_snapshot`,
 #428) both return this shape, so one CLI and one exit-code mapping cover
 every delivered artifact.
 
-Reasons are fixed strings so callers can branch on them.
+Reasons use a closed string enum so callers can branch on a documented set of
+values.
 ``exit_code_for`` maps a report to the verify-family exit codes: 0 clean,
 1 damaged, 3 unverifiable. Exit 2 (unreadable input) is raised as an
 exception before a report exists.
@@ -20,11 +21,23 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
-REASON_MISSING = "missing"
-REASON_SIZE_MISMATCH = "size-mismatch"
-REASON_CONTENT_ID_MISMATCH = "content-id-mismatch"
-# #428: a readable snapshot format.json that carries no integrity receipt.
-REASON_NO_RECEIPT = "no-receipt"
+
+class VerificationReason(StrEnum):
+    """Machine-readable reason for a verification finding."""
+
+    MISSING = "missing"
+    SIZE_MISMATCH = "size-mismatch"
+    CONTENT_ID_MISMATCH = "content-id-mismatch"
+    # #428: a readable snapshot format.json that carries no integrity receipt.
+    NO_RECEIPT = "no-receipt"
+
+
+# Keep the original names as public aliases for callers that already import
+# the reason constants.
+REASON_MISSING = VerificationReason.MISSING
+REASON_SIZE_MISMATCH = VerificationReason.SIZE_MISMATCH
+REASON_CONTENT_ID_MISMATCH = VerificationReason.CONTENT_ID_MISMATCH
+REASON_NO_RECEIPT = VerificationReason.NO_RECEIPT
 
 
 class VerificationStatus(StrEnum):
@@ -40,7 +53,7 @@ class VerificationFinding:
     """One claimed object that does not match its receipt."""
 
     uri: str
-    reason: str
+    reason: VerificationReason
     detail: str
 
 

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -15,7 +15,10 @@ from hflow.storage import BucketStorageRoot
 from hflow.verification import (
     REASON_CONTENT_ID_MISMATCH,
     REASON_MISSING,
+    REASON_NO_RECEIPT,
     REASON_SIZE_MISMATCH,
+    VerificationFinding,
+    VerificationReason,
     VerificationStatus,
     exit_code_for,
 )
@@ -42,6 +45,21 @@ def _write_prepared_delivery(root: Path, *, payload: bytes = b"episode-0") -> Pa
     }
     (root / "prepared-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     return episode_path
+
+
+def test_verification_reason_constants_are_enum_members() -> None:
+    assert REASON_MISSING is VerificationReason.MISSING
+    assert REASON_SIZE_MISMATCH is VerificationReason.SIZE_MISMATCH
+    assert REASON_CONTENT_ID_MISMATCH is VerificationReason.CONTENT_ID_MISMATCH
+    assert REASON_NO_RECEIPT is VerificationReason.NO_RECEIPT
+    assert VerificationReason.NO_RECEIPT == "no-receipt"
+
+    finding = VerificationFinding(
+        uri="landing/episode.mcap",
+        reason=VerificationReason.NO_RECEIPT,
+        detail="receipt is missing",
+    )
+    assert finding.reason is VerificationReason.NO_RECEIPT
 
 
 def test_verify_lerobot_import_accepts_an_unchanged_delivery(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add `VerificationReason` as the closed `StrEnum` for verification findings.
- Preserve the existing `REASON_*` names as aliases to the enum members.
- Export `VerificationReason` from the package root and cover the enum aliases with a focused test.

## Why

`VerificationFinding.reason` had a plain `str` type even though every valid value was already a fixed set. The enum makes that contract explicit without changing the string values or existing constant imports.

## Validation

- `uv run ruff check --fix` passed.
- `uv run ruff format` passed.
- `uv run ty check` passed.
- `uv run pytest tests/test_verification.py -q` passed: 13 tests.
- `uv run pytest -q` completed with 1741 passed, 6 skipped, and 3 pre-existing failures. The failures are in unrelated ffmpeg tests because this host has ffmpeg 4.4.2, which does not support `-fps_mode`; the same failures occur on the unchanged base branch.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements. No user-facing documentation changed because this is a type/API contract clarification.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility; no behavior version change is needed.

Closes #488
