### PR TITLE
fix: validate camera FPS thresholds

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -1626,8 +1626,8 @@ def camera_fps_conformance(
     *,
     nominal_fps: dict[str, int] | None = None,
     cameras: Sequence[str] | None = None,
-    max_plausible_fps: int = 240,
-    downsample_tolerance_fps: int = 1,
+    max_plausible_fps: float = 240,
+    downsample_tolerance_fps: float = 1,
 ) -> CheckResult:
     """Classify each camera's timestamp-derived rate against the rate declared.
 
@@ -1655,6 +1655,17 @@ def camera_fps_conformance(
     classifies; it never rewrites the stream -- decimating an episode is a
     transform concern that would move episode identity.
     """
+
+    if isinstance(max_plausible_fps, bool):
+        raise ValueError("max_plausible_fps must be a float, got bool")
+    if not np.isfinite(max_plausible_fps) or max_plausible_fps <= 0:
+        raise ValueError("max_plausible_fps must be finite and positive")
+
+    if isinstance(downsample_tolerance_fps, bool):
+        raise ValueError("downsample_tolerance_fps must be a float, got bool")
+    if not np.isfinite(downsample_tolerance_fps) or downsample_tolerance_fps < 0:
+        raise ValueError("downsample_tolerance_fps must be finite and non-negative")
+
     selected_cameras = list(cameras) if cameras is not None else episode.cameras
     measurements: dict[str, MeasurementValue] = {}
     for topic in selected_cameras:
@@ -1693,8 +1704,8 @@ def _classify_derived_fps(
     *,
     derived_fps: int,
     declared_fps: int,
-    max_plausible_fps: int,
-    downsample_tolerance_fps: int,
+    max_plausible_fps: float,
+    downsample_tolerance_fps: float,
 ) -> str:
     """Branch order is the classification: equality first, then plausibility,
     then the 2x window. A declared rate at or above half the plausibility

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -487,6 +487,53 @@ def test_fps_conformance_classifies_matching_and_half_rate_streams(tmp_path: Pat
     assert undeclared.measurements[f"{camera_topic}/fps_resolution"] == "no-nominal-declared"
 
 
+def test_fps_conformance_rejects_invalid_thresholds(tmp_path: Path) -> None:
+    source = synthesize_episode(
+        tmp_path / "episode.mcap",
+        SyntheticEpisodeSpec(
+            cameras=(),
+            black_segment=None,
+            timestamp_offset_segment=None,
+        ),
+    )
+
+    with hflow.Episode(source) as episode:
+        with pytest.raises(ValueError, match=r"^max_plausible_fps must be a float, got bool$"):
+            camera_fps_conformance(episode, max_plausible_fps=True)
+
+        with pytest.raises(ValueError, match=r"^max_plausible_fps must be finite and positive$"):
+            camera_fps_conformance(episode, max_plausible_fps=float("nan"))
+
+        with pytest.raises(ValueError, match=r"^max_plausible_fps must be finite and positive$"):
+            camera_fps_conformance(episode, max_plausible_fps=float("inf"))
+
+        with pytest.raises(ValueError, match=r"^max_plausible_fps must be finite and positive$"):
+            camera_fps_conformance(episode, max_plausible_fps=0)
+
+        with pytest.raises(
+            ValueError, match=r"^downsample_tolerance_fps must be a float, got bool$"
+        ):
+            camera_fps_conformance(episode, downsample_tolerance_fps=True)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^downsample_tolerance_fps must be finite and non-negative$",
+        ):
+            camera_fps_conformance(episode, downsample_tolerance_fps=float("nan"))
+
+        with pytest.raises(
+            ValueError,
+            match=r"^downsample_tolerance_fps must be finite and non-negative$",
+        ):
+            camera_fps_conformance(episode, downsample_tolerance_fps=float("inf"))
+
+        with pytest.raises(
+            ValueError,
+            match=r"^downsample_tolerance_fps must be finite and non-negative$",
+        ):
+            camera_fps_conformance(episode, downsample_tolerance_fps=-1)
+
+
 def test_action_integrity_finds_the_injected_frozen_run(tmp_path: Path) -> None:
     """A stalled publisher repeats samples bit-for-bit; a still robot does not.
     The fixture holds every joint for 1 s of a 4 s stream.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -533,6 +533,16 @@ def test_fps_conformance_rejects_invalid_thresholds(tmp_path: Path) -> None:
         ):
             camera_fps_conformance(episode, downsample_tolerance_fps=-1)
 
+        # Zero tolerance is a meaningful setting, not a missing one: it asks
+        # for an exact rate match. The two parameters therefore take different
+        # bars, > 0 for the plausibility ceiling and >= 0 here. Tightening
+        # this one to > 0 went unnoticed by every other case, so it is pinned.
+        camera_fps_conformance(episode, downsample_tolerance_fps=0)
+
+        # Fractional thresholds are why these widened from int to float:
+        # 29.97 and 23.976 are real camera rates.
+        camera_fps_conformance(episode, max_plausible_fps=29.97, downsample_tolerance_fps=0.5)
+
 
 def test_action_integrity_finds_the_injected_frozen_run(tmp_path: Path) -> None:
     """A stalled publisher repeats samples bit-for-bit; a still robot does not.


### PR DESCRIPTION
## Summary

<!-- What user-visible outcome does this change produce? -->

`camera_fps_conformance` now validates both `max_plausible_fps` and `downsample_tolerance_fps` before processing an episode. Invalid boolean, non-finite, and out-of-range values now raise a clear `ValueError`.

## Why

<!-- What problem does it solve, and why is this the appropriate scope? -->

Previously, both threshold parameters accepted invalid values such as `True`, negative values, `NaN`, and infinity. This could lead to incorrect FPS classification or silently bypass validation, especially for episodes without cameras.

This change adds parameter validation at the start of `camera_fps_conformance` and adds regression coverage using a camera-less episode. No valid-argument behavior is changed.

## Validation

<!-- List the exact commands you ran and their results. -->

* `uv run pytest tests/test_checks.py -k "fps_conformance or invalid_thresholds" -q` — 2 passed
* `uv run ruff check` — passed
* `uv run ruff format --check` — passed
* `uv run ty check` — passed
* `uv run pytest tests/test_checks.py -k invalid_thresholds -q` — passed
* `uv run pytest -q` — 1691 passed, 28 failed, 11 skipped

  * The 28 failures are unrelated existing environment/platform failures in packaging tests and the ffmpeg end-to-end test.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [ ] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
