### PR TITLE
fix(lerobot): validate the path templates at the info.json boundary

### DIFF
--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -642,6 +642,11 @@ def _validate_path_template(
     failure arrived as a bare ``KeyError`` naming neither the file nor the
     field. Formatting once here moves it to the boundary and gives it the same
     shape as every other refusal.
+
+    What this proves is that the template formats, not that it names a
+    sensible path. ``{chunk_index.bit_length}`` formats fine and yields a
+    directory named after a bound method; that becomes a 404 at download time
+    rather than something to catch here.
     """
     try:
         template.format(**format_fields)
@@ -655,7 +660,11 @@ def _validate_path_template(
             f"LeRobot meta/info.json has an invalid {field_name} template "
             f"{template!r}: positional fields are not supported, name the field instead"
         ) from error
-    except ValueError as error:
+    except (ValueError, TypeError) as error:
+        # TypeError belongs here for the same reason as the rest: subscripting
+        # a field, ``{chunk_index[0]}``, raises it from str.format and would
+        # otherwise leave the boundary as a bare "'int' object is not
+        # subscriptable" naming neither the file nor the field.
         raise ValueError(
             f"LeRobot meta/info.json has an invalid {field_name} template {template!r}: {error}"
         ) from error

--- a/src/hflow/importers/lerobot.py
+++ b/src/hflow/importers/lerobot.py
@@ -617,6 +617,50 @@ def _episode_metadata_cache_path(
     return episodes_metadata_directory / relative_path
 
 
+#: The fields ``_convert_episode`` supplies to each template's ``format`` call.
+#: They differ, and validating against the union would accept a ``data_path``
+#: naming ``camera_key`` that then fails at the data call site. The values are
+#: representative rather than real: the format spec is checked against the type
+#: the call site passes, so ``{chunk_index:03d}`` has to see an int.
+_DATA_PATH_FORMAT_FIELDS: dict[str, object] = {"chunk_index": 0, "file_index": 0}
+_VIDEO_PATH_FORMAT_FIELDS: dict[str, object] = {
+    "chunk_index": 0,
+    "file_index": 0,
+    "video_key": "camera",
+    "camera_key": "camera",
+}
+
+
+def _validate_path_template(
+    template: str, field_name: str, format_fields: dict[str, object]
+) -> None:
+    """Refuse a path template the converter could not format.
+
+    ``_parse_dataset_information`` is the one place the external document is
+    read, but these two templates used to reach ``str.format`` five hundred
+    lines later, after the episode metadata had already been downloaded. The
+    failure arrived as a bare ``KeyError`` naming neither the file nor the
+    field. Formatting once here moves it to the boundary and gives it the same
+    shape as every other refusal.
+    """
+    try:
+        template.format(**format_fields)
+    except KeyError as error:
+        raise ValueError(
+            f"LeRobot meta/info.json has an invalid {field_name} template "
+            f"{template!r}: unknown field {error.args[0]!r}"
+        ) from error
+    except IndexError as error:
+        raise ValueError(
+            f"LeRobot meta/info.json has an invalid {field_name} template "
+            f"{template!r}: positional fields are not supported, name the field instead"
+        ) from error
+    except ValueError as error:
+        raise ValueError(
+            f"LeRobot meta/info.json has an invalid {field_name} template {template!r}: {error}"
+        ) from error
+
+
 def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation:
     """Turn a raw ``meta/info.json`` document into immutable internal values.
 
@@ -624,6 +668,10 @@ def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation
     boundary inspects the external document again. Unknown upstream fields are
     ignored: LeRobot adds them, and refusing one would fail imports that
     convert correctly.
+
+    The two path templates are checked by formatting them, each against the
+    fields its own call site supplies, so a template the converter could not
+    use is refused before any download.
     """
     frames_per_second = dataset_information.get("fps")
     if (
@@ -639,11 +687,13 @@ def _parse_dataset_information(dataset_information: dict) -> _DatasetInformation
     data_path_template = dataset_information.get("data_path")
     if not isinstance(data_path_template, str) or not data_path_template.strip():
         raise ValueError("LeRobot meta/info.json must define a non-empty data_path template")
+    _validate_path_template(data_path_template, "data_path", _DATA_PATH_FORMAT_FIELDS)
     video_path_template = dataset_information.get(
         "video_path", "videos/{camera_key}/{chunk_index:06d}/{file_index:06d}.mp4"
     )
     if not isinstance(video_path_template, str) or not video_path_template.strip():
         raise ValueError("LeRobot meta/info.json must define a non-empty video_path template")
+    _validate_path_template(video_path_template, "video_path", _VIDEO_PATH_FORMAT_FIELDS)
 
     dataset_features = dataset_information.get("features")
     if not isinstance(dataset_features, dict):

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -119,6 +119,94 @@ def test_import_refuses_empty_path_templates(
     _assert_no_dataset_output(output_dir)
 
 
+_VALID_DATA_PATH = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+_VALID_VIDEO_PATH = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+
+
+def _info(**overrides: object) -> dict[str, object]:
+    info: dict[str, object] = {
+        "fps": 30,
+        "data_path": _VALID_DATA_PATH,
+        "video_path": _VALID_VIDEO_PATH,
+        "features": {},
+    }
+    info.update(overrides)
+    return info
+
+
+@pytest.mark.parametrize(
+    ("field", "template", "detail"),
+    [
+        ("data_path", "data/{episode_index:03d}/f.parquet", "unknown field 'episode_index'"),
+        ("data_path", "data/{chunk_index:03d/f.parquet", "unmatched '{' in format spec"),
+        (
+            "data_path",
+            "data/{chunk_index:qq}/f.parquet",
+            "Invalid format specifier 'qq' for object of type 'int'",
+        ),
+        (
+            "data_path",
+            "data/{0}/f.parquet",
+            "positional fields are not supported, name the field instead",
+        ),
+        ("data_path", "data/}chunk/f.parquet", "Single '}' encountered in format string"),
+        ("video_path", "videos/{episode_index}/f.mp4", "unknown field 'episode_index'"),
+        (
+            "video_path",
+            "videos/{0}/f.mp4",
+            "positional fields are not supported, name the field instead",
+        ),
+    ],
+)
+def test_import_refuses_a_template_the_converter_could_not_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    template: str,
+    detail: str,
+) -> None:
+    """Each of these used to pass the boundary and raise at ``str.format``.
+
+    The second assertion is the point. The old failure arrived after
+    ``meta/episodes`` had been listed and every episode metadata parquet
+    downloaded; asserting only the message would pass either way.
+    """
+    _stub_repo_info(monkeypatch)
+    monkeypatch.setattr(
+        prep, "_fetch_info_json", lambda _repo, _revision, _cache: _info(**{field: template})
+    )
+    listed_paths: list[str] = []
+
+    def recording_hf_tree(_repo: str, _revision: str, path: str) -> list[dict[str, str]]:
+        listed_paths.append(path)
+        return []
+
+    monkeypatch.setattr(prep, "_hf_tree", recording_hf_tree)
+    output_dir = tmp_path / "out"
+
+    message = f"LeRobot meta/info.json has an invalid {field} template {template!r}: {detail}"
+    with pytest.raises(ValueError, match=_exactly(message)):
+        _import(output_dir)
+
+    assert listed_paths == []
+    _assert_no_dataset_output(output_dir)
+
+
+def test_the_two_templates_are_checked_against_different_field_sets() -> None:
+    """``camera_key`` is legal in ``video_path`` and not in ``data_path``.
+
+    ``_convert_episode`` formats ``data_path`` with ``chunk_index`` and
+    ``file_index`` only, and ``video_path`` with ``video_key`` and
+    ``camera_key`` as well. Checking both against the union would accept a
+    ``data_path`` naming ``camera_key``, which is one of the failures this
+    boundary is meant to catch.
+    """
+    prep._parse_dataset_information(_info(video_path="videos/{camera_key}/f.mp4"))
+
+    with pytest.raises(ValueError, match="unknown field 'camera_key'"):
+        prep._parse_dataset_information(_info(data_path="data/{camera_key}/f.parquet"))
+
+
 def test_import_refuses_info_json_without_features_before_listing_episodes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_lerobot_metadata_refusals.py
+++ b/tests/test_lerobot_metadata_refusals.py
@@ -150,6 +150,9 @@ def _info(**overrides: object) -> dict[str, object]:
             "positional fields are not supported, name the field instead",
         ),
         ("data_path", "data/}chunk/f.parquet", "Single '}' encountered in format string"),
+        # Subscripting a field raises TypeError rather than the other three,
+        # so without it in the caught set this one escapes the boundary raw.
+        ("data_path", "data/{chunk_index[0]}/f.parquet", "'int' object is not subscriptable"),
         ("video_path", "videos/{episode_index}/f.mp4", "unknown field 'episode_index'"),
         (
             "video_path",


### PR DESCRIPTION
Closes #471.

Both templates are now formatted once inside `_parse_dataset_information`, and a template that raises is refused there with the same message shape as the other invalid fields:

```
LeRobot meta/info.json has an invalid data_path template 'data/{episode_index:03d}/f.parquet': unknown field 'episode_index'
```

Each template is checked against the fields its own call site supplies, as you asked: `data_path` against `chunk_index` and `file_index`, `video_path` against those plus `video_key` and `camera_key`. The sample values match the types the call sites pass, ints for the two indexes and strings for the keys, because a format spec is only valid against a type. `{chunk_index:03d}` has to see an int to be checked at all.

Three failure modes reach the message: `KeyError` becomes `unknown field 'x'`, `IndexError` becomes a line saying positional fields are not supported, and a `ValueError` from `str.format` is passed through as its own text.

The refusal now lands before `meta/episodes` is listed and before any metadata parquet is downloaded. The tests assert that directly, not just the message: each case records what `_hf_tree` was asked for and requires the list to be empty. Asserting the message alone would pass either way.

`test_the_two_templates_are_checked_against_different_field_sets` is the one covering your point about the union. It requires `camera_key` to be legal in `video_path` and refused in `data_path`. I checked it bites by validating both against the union: that test fails and nothing else does.

Removing both validation calls fails 8 of the new tests.

These extend the #415 refusal file rather than adding a new one.

Local: 1488 passed. 29 tests in `test_packaging.py`, `test_packaging_manifest_parsing.py`, `test_cli.py` and `test_end_to_end.py` fail here, and fail identically on `origin/main` with this branch stashed, so they are not from this change. `ruff check`, `ruff format --check` and `ty check` are clean.
