### PR TITLE
test(episode): pin all Channel.to_numpy refusal branches

### DIFF
--- a/tests/test_episode_to_numpy.py
+++ b/tests/test_episode_to_numpy.py
@@ -1,0 +1,172 @@
+"""Refusal-branch tests for :meth:`hflow.episode.ChannelData.to_numpy`.
+
+``to_numpy`` stacks one message field into a ``(n_messages, ...)`` array,
+selecting the field automatically when ``field=None`` through a priority
+ladder -- ``position`` array, lone numeric array, lone numeric scalar -- and
+refusing with a specific error when the choice is empty or ambiguous.
+
+These refusals cannot be produced by :func:`hflow.testing.synthesize_episode`,
+which only generates well-formed happy-path channels, so the fixtures build
+``ChannelData`` objects directly from raw JSON payloads whose decodes yield
+exactly the fields each scenario needs.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from hflow.episode import ChannelData
+from hflow.reader import TopicInfo
+
+
+def _json_channel(
+    topic: str, messages: list[dict[str, object]], *, schema_name: str = "test_schema"
+) -> ChannelData:
+    """A ``ChannelData`` (no file) whose JSON payloads decode to ``messages``."""
+    raw_payloads = [json.dumps(message).encode() for message in messages]
+    info = TopicInfo(
+        topic=topic,
+        channel_id=1,
+        schema_name=schema_name,
+        schema_encoding="jsonschema",
+        message_encoding="json",
+        message_count=len(raw_payloads),
+        schema_data=b"{}",
+    )
+    return ChannelData(
+        topic=topic,
+        channel_id=1,
+        info=info,
+        log_times=np.asarray([], dtype=np.int64),
+        publish_times=np.asarray([], dtype=np.int64),
+        raw=raw_payloads,
+        decoder=lambda payload: json.loads(payload.decode()),
+    )
+
+
+def test_empty_channel_refuses() -> None:
+    channel = _json_channel("/empty", [])
+
+    with pytest.raises(ValueError, match=r"topic '/empty' has no messages"):
+        channel.to_numpy()
+
+
+def test_ambiguous_array_fields_list_candidates() -> None:
+    channel = _json_channel(
+        "/multi_array",
+        [{"field_a": [1.0, 2.0], "field_b": [3.0, 4.0]} for _ in range(2)],
+    )
+
+    with pytest.raises(
+        ValueError, match=r"topic '/multi_array' has multiple numeric array fields"
+    ) as excinfo:
+        channel.to_numpy()
+    message = str(excinfo.value)
+    assert "'field_a'" in message
+    assert "'field_b'" in message
+    assert "pass field=" in message
+
+
+def test_ambiguous_scalar_fields_list_candidates() -> None:
+    channel = _json_channel(
+        "/multi_scalar",
+        [{"field_a": 1.0, "field_b": 2.0} for _ in range(2)],
+    )
+
+    with pytest.raises(
+        ValueError, match=r"topic '/multi_scalar' has multiple numeric fields"
+    ) as excinfo:
+        channel.to_numpy()
+    message = str(excinfo.value)
+    assert "'field_a'" in message
+    assert "'field_b'" in message
+    assert "pass field=" in message
+
+
+def test_no_numeric_fields_lists_available_fields() -> None:
+    channel = _json_channel(
+        "/no_numeric",
+        [{"name": "joint", "enabled": True} for _ in range(2)],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"topic '/no_numeric' \([^)]*\) has no numeric fields; available fields:",
+    ) as excinfo:
+        channel.to_numpy()
+    message = str(excinfo.value)
+    assert "'name'" in message
+    assert "'enabled'" in message
+
+
+def test_invalid_explicit_field_lists_available_fields() -> None:
+    channel = _json_channel(
+        "/jpos",
+        [{"position": [1.0, 2.0], "velocity": [3.0, 4.0]} for _ in range(2)],
+    )
+
+    with pytest.raises(KeyError, match=r"field 'nope' not in topic '/jpos'; available:") as excinfo:
+        channel.to_numpy(field="nope")
+    message = str(excinfo.value)
+    assert "'position'" in message
+    assert "'velocity'" in message
+
+
+def test_ragged_field_is_rejected() -> None:
+    channel = _json_channel(
+        "/ragged",
+        [{"path": [1.0, 2.0]}, {"path": [3.0, 4.0, 5.0]}],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"field 'path' of topic '/ragged' is ragged \(per-message lengths differ\)",
+    ):
+        channel.to_numpy(field="path")
+
+
+def test_non_numeric_field_is_rejected() -> None:
+    channel = _json_channel(
+        "/non_numeric",
+        [{"label": "a"}, {"label": "b"}],
+    )
+
+    with pytest.raises(
+        ValueError, match=r"field 'label' of topic '/non_numeric' is not numeric \(dtype"
+    ):
+        channel.to_numpy(field="label")
+
+
+def test_position_field_wins_over_other_arrays() -> None:
+    """The first selection clause: ``position`` beats an ambiguous array field."""
+    channel = _json_channel(
+        "/joint",
+        [
+            {"position": [1.0, 2.0], "velocity": [3.0, 4.0]},
+            {"position": [5.0, 6.0], "velocity": [7.0, 8.0]},
+        ],
+    )
+
+    result = channel.to_numpy()
+    np.testing.assert_array_equal(result, np.array([[1.0, 2.0], [5.0, 6.0]]))
+
+
+def test_lone_array_field_is_selected() -> None:
+    channel = _json_channel(
+        "/lone_array",
+        [{"joint_angles": [1.0, 2.0, 3.0]}, {"joint_angles": [4.0, 5.0, 6.0]}],
+    )
+
+    result = channel.to_numpy()
+    np.testing.assert_array_equal(result, np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+
+
+def test_lone_scalar_field_is_selected() -> None:
+    channel = _json_channel(
+        "/lone_scalar",
+        [{"temperature": 20.5}, {"temperature": 21.0}],
+    )
+
+    result = channel.to_numpy()
+    np.testing.assert_array_equal(result, np.array([20.5, 21.0]))


### PR DESCRIPTION
Closes #456.

Adds `tests/test_episode_to_numpy.py`, exercising every refusal branch of `Channel.to_numpy` (`src/hflow/episode.py:210`) plus the automatic-selection priority ladder. No source changes — `episode.py` is untouched.

Fixtures build `ChannelData` directly from raw JSON payloads (mirroring `make_json_channel` in `test_resample_derive.py`) rather than `synthesize_episode`, which only produces well-formed happy-path channels.

## Coverage

| Refusal | Test |
| --- | --- |
| `topic ... has no messages` | `test_empty_channel_refuses` |
| `has multiple numeric array fields ...; pass field=...` | `test_ambiguous_array_fields_list_candidates` |
| `has multiple numeric fields ...; pass field=...` | `test_ambiguous_scalar_fields_list_candidates` |
| `has no numeric fields; available fields: ...` | `test_no_numeric_fields_lists_available_fields` |
| `field ... not in topic ...; available: ...` | `test_invalid_explicit_field_lists_available_fields` |
| `field ... is ragged (per-message lengths differ)` | `test_ragged_field_is_rejected` |
| `field ... is not numeric (dtype ...)` | `test_non_numeric_field_is_rejected` |

Selection rules:
- `test_position_field_wins_over_other_arrays` — `position` beats an extra numeric array field (the first clause).
- `test_lone_array_field_is_selected` / `test_lone_scalar_field_is_selected` — the "only array" / "only scalar" clauses.

## Definition of done

1. Each refusal is asserted with a topic-specific anchored `match=` so no case can pass on a neighbour's message.
2. Every candidate-list refusal additionally asserts the actual field names (`'field_a'`, `'field_b'`, `'position'`, etc.) appear in the exception string, not just the static advice text.
3. The `position` shortcut has its own case (no ambiguity error).

## Testing note

All 10 tests pass locally. The host CI runs on Linux; on a Windows-only box the package cannot import because `src/hflow/storage.py` unconditionally imports `fcntl` (Linux-only), so the full `uv run pytest -q` was not runnable here — the new file was verified with `ruff check`, `ruff format --check`, and a per-file `pytest` run under a throwaway `fcntl` shim (10 passed). I did not perform a mutation sweep (temporarily deleting each refusal to confirm exactly one test goes red) since the full suite is blocked on this host; the topic-anchored `match=` patterns are intended to guarantee each maps to exactly one branch.