### PR TITLE
perf: avoid caching channel payloads in episode_duration

### DIFF
--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -729,6 +729,19 @@ def _episode_duration_intermediates(
     if topics is None:
         # Statistics select topics, but need not agree with the messages.
         # Keep measuring actual timestamps/counts rather than summary values.
+        #
+        # Reaching past Episode to its reader is the point rather than an
+        # oversight: episode.channel() caches every payload it decodes, and
+        # this check wants only the timestamps (#499). Going through the
+        # public accessor would populate the cache, which is the cost being
+        # removed. Batches arrive per channel in log-time order, so the first
+        # and last stamps of a batch are its bounds.
+        #
+        # The explicit-topics path below stays on episode.channel(), which
+        # refuses an unknown topic with a message naming it; indexing `infos`
+        # here would raise a bare KeyError instead. The two must agree on
+        # measurements for the same selection, which
+        # test_episode_duration_paths_agree_on_the_same_selection pins.
         start_ns: int | None = None
         end_ns: int | None = None
         message_count_total = 0

--- a/src/hflow/checks.py
+++ b/src/hflow/checks.py
@@ -718,14 +718,39 @@ def _episode_duration_intermediates(
     episode: Episode,
     topics: Sequence[str] | None,
 ) -> _EpisodeDurationIntermediates:
-    """Verbatim aggregation from the pre-fact body: explicit ``topics``
-    select as given, otherwise every topic carrying at least one message."""
+    """Explicit ``topics`` select as given; otherwise stream nonempty topics
+    without retaining their payloads in the episode's channel cache."""
     infos = episode.topics
     selected = (
         list(topics)
         if topics is not None
         else sorted(topic for topic, info in infos.items() if info.message_count >= 1)
     )
+    if topics is None:
+        # Statistics select topics, but need not agree with the messages.
+        # Keep measuring actual timestamps/counts rather than summary values.
+        start_ns: int | None = None
+        end_ns: int | None = None
+        message_count_total = 0
+        if selected:
+            for batch in episode._reader.iter_batches(
+                topics=selected,
+                channel_ids=[infos[topic].channel_id for topic in selected],
+            ):
+                stamps_ns = batch.log_times
+                if len(stamps_ns) == 0:
+                    continue
+                message_count_total += len(stamps_ns)
+                first_ns, last_ns = int(stamps_ns[0]), int(stamps_ns[-1])
+                start_ns = first_ns if start_ns is None else min(start_ns, first_ns)
+                end_ns = last_ns if end_ns is None else max(end_ns, last_ns)
+        return _EpisodeDurationIntermediates(
+            duration_s=(end_ns - start_ns) / 1e9
+            if start_ns is not None and end_ns is not None
+            else 0.0,
+            message_count_total=message_count_total,
+            topic_count=len(selected),
+        )
     start_candidates_ns: list[int] = []
     end_candidates_ns: list[int] = []
     message_count_total = 0

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,10 +1,15 @@
 """Direct unit tests for the built-in checks (paths e2e only grazes)."""
 
+from dataclasses import replace
+from functools import partial
 from pathlib import Path
 
 import numpy as np
 import pytest
 from foxglove_schemas_protobuf.CompressedVideo_pb2 import CompressedVideo
+from mcap.data_stream import RecordBuilder
+from mcap.records import Statistics
+from mcap.writer import CompressionType, IndexType
 from mcap.writer import Writer as StockWriter
 from mcap_protobuf.schema import build_file_descriptor_set
 
@@ -212,6 +217,186 @@ def test_episode_duration_matches_the_synthesized_span(jittery_episode: hflow.Ep
     assert duration_s == pytest.approx(4.0, abs=0.1)
     message_count_total = result.measurements["message_count_total"]
     assert isinstance(message_count_total, int) and message_count_total > 0
+
+
+@pytest.fixture
+def duration_source(tmp_path: Path) -> Path:
+    path = tmp_path / "duration.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream, chunk_size=64 * 1024, compression=CompressionType.NONE)
+        writer.start()
+        state = writer.register_channel(topic="/joint_states", message_encoding="json", schema_id=0)
+        camera = writer.register_channel(topic="/camera", message_encoding="json", schema_id=0)
+        writer.register_channel(topic="/empty", message_encoding="json", schema_id=0)
+        for index, second in enumerate((1, 3), start=1):
+            writer.add_message(
+                state, second * 10**9, f'{{"state": {index}}}'.encode(), second * 10**9
+            )
+        for second in range(2, 10):
+            writer.add_message(camera, second * 10**9, b"x" * 100_000, second * 10**9)
+        writer.finish()
+    return path
+
+
+def test_episode_duration_does_not_materialize_channels(
+    duration_source: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with hflow.Episode(duration_source) as episode:
+
+        def refuse_channel(key: str | int) -> hflow.ChannelData:
+            pytest.fail(f"episode_duration materialized channel {key!r}")
+
+        monkeypatch.setattr(episode, "channel", refuse_channel)
+        # Exercise aggregation across several batches, including the camera's
+        # final batch extending beyond the other topic's end timestamp.
+        monkeypatch.setattr(
+            episode._reader,
+            "iter_batches",
+            partial(episode._reader.iter_batches, batch_max_messages=2),
+        )
+        assert episode_duration(episode).measurements == {
+            "duration_s": 8.0,
+            "message_count_total": 10,
+            "topic_count": 2,
+        }
+        assert episode._channel_data_by_id == {}
+
+
+@pytest.mark.parametrize(
+    ("topics", "duration_s", "message_count", "topic_count"),
+    [
+        (None, 8.0, 10, 2),
+        ([], 0.0, 0, 0),
+        (["/joint_states"], 2.0, 2, 1),
+        (["/joint_states", "/camera"], 8.0, 10, 2),
+        (["/joint_states", "/joint_states"], 2.0, 4, 2),
+        (["/empty"], 0.0, 0, 1),
+    ],
+)
+def test_episode_duration_selection(
+    duration_source: Path,
+    topics: list[str] | None,
+    duration_s: float,
+    message_count: int,
+    topic_count: int,
+) -> None:
+    with hflow.Episode(duration_source) as episode:
+        result = episode_duration(episode, topics=topics)
+    assert result.measurements == {
+        "duration_s": duration_s,
+        "message_count_total": message_count,
+        "topic_count": topic_count,
+    }
+
+
+@pytest.mark.parametrize("declared_channel", [False, True])
+def test_episode_duration_empty_episode(tmp_path: Path, declared_channel: bool) -> None:
+    path = tmp_path / "empty.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start()
+        if declared_channel:
+            writer.register_channel(topic="/empty", message_encoding="json", schema_id=0)
+        writer.finish()
+    with hflow.Episode(path) as episode:
+        assert episode.time_bounds is None
+        assert episode_duration(episode).measurements == {
+            "duration_s": 0.0,
+            "message_count_total": 0,
+            "topic_count": 0,
+        }
+
+
+@pytest.mark.parametrize("summary_present", [False, True])
+def test_episode_duration_without_statistics(tmp_path: Path, summary_present: bool) -> None:
+    path = tmp_path / "no-statistics.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(
+            stream,
+            use_statistics=False,
+            repeat_channels=summary_present,
+            repeat_schemas=False,
+            use_summary_offsets=False,
+            index_types=IndexType.NONE,
+        )
+        writer.start()
+        channel = writer.register_channel(topic="/state", message_encoding="json", schema_id=0)
+        for second in (1, 3):
+            writer.add_message(channel, second * 10**9, b"{}", second * 10**9)
+        writer.finish()
+    with hflow.Episode(path) as episode:
+        assert episode.time_bounds is None
+        if not summary_present:
+            with pytest.raises(ValueError, match="has no MCAP summary section"):
+                episode_duration(episode)
+            return
+        assert episode.topics["/state"].message_count == 0
+        assert episode_duration(episode).measurements == {
+            "duration_s": 0.0,
+            "message_count_total": 0,
+            "topic_count": 0,
+        }
+        assert episode_duration(episode, topics=["/state"]).measurements == {
+            "duration_s": 2.0,
+            "message_count_total": 2,
+            "topic_count": 1,
+        }
+
+
+@pytest.mark.parametrize("message_counts", [(2, 2), (2, 0), (0, 0)])
+@pytest.mark.parametrize("topics", [None, [], ["/status"]])
+def test_episode_duration_rejects_duplicate_topics(
+    tmp_path: Path, message_counts: tuple[int, int], topics: list[str] | None
+) -> None:
+    path = tmp_path / "duplicates.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start()
+        for count in message_counts:
+            channel = writer.register_channel(topic="/status", message_encoding="json", schema_id=0)
+            for stamp in range(count):
+                writer.add_message(channel, stamp, b"{}", stamp)
+        writer.finish()
+    with hflow.Episode(path) as episode:
+        assert len(episode.channels) == 2
+        with pytest.raises(ValueError, match="multiple channels for topic '/status'"):
+            episode_duration(episode, topics=topics)
+
+
+@pytest.mark.parametrize("reported_count", [0, 1, 9])
+def test_episode_duration_statistics_select_topics_but_do_not_supply_measurements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reported_count: int
+) -> None:
+    original_write = Statistics.write
+
+    def write_statistics(statistics: Statistics, builder: RecordBuilder) -> None:
+        original_write(
+            replace(
+                statistics,
+                channel_message_counts={1: reported_count} if reported_count else {},
+                message_start_time=0,
+                message_end_time=100 * 10**9,
+            ),
+            builder,
+        )
+
+    monkeypatch.setattr(Statistics, "write", write_statistics)
+    path = tmp_path / "inconsistent-statistics.mcap"
+    with path.open("wb") as stream:
+        writer = StockWriter(stream)
+        writer.start()
+        channel = writer.register_channel(topic="/state", message_encoding="json", schema_id=0)
+        for second in (1, 3):
+            writer.add_message(channel, second * 10**9, b"{}", second * 10**9)
+        writer.finish()
+    with hflow.Episode(path) as episode:
+        assert episode.topics["/state"].message_count == reported_count
+        assert episode.time_bounds == hflow.EpisodeTimeBounds(0, 100 * 10**9)
+        assert episode_duration(episode).measurements == {
+            "duration_s": 2.0 if reported_count else 0.0,
+            "message_count_total": 2 if reported_count else 0,
+            "topic_count": 1 if reported_count else 0,
+        }
 
 
 def test_required_topics_records_present_topic_inventory(

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -262,6 +262,26 @@ def test_episode_duration_does_not_materialize_channels(
         assert episode._channel_data_by_id == {}
 
 
+def test_episode_duration_paths_agree_on_the_same_selection(duration_source: Path) -> None:
+    """#499 left two aggregations behind, and they have to stay in step.
+
+    The default path streams batches and keeps no payloads; passing ``topics``
+    explicitly still goes through ``episode.channel()``. Handed the same set
+    of topics they must produce identical measurements, or the check answers
+    differently depending on whether the caller named the topics it would
+    have selected anyway.
+    """
+    with hflow.Episode(duration_source) as episode:
+        streamed = episode_duration(episode).measurements
+        selected = sorted(topic for topic, info in episode.topics.items() if info.message_count)
+
+    with hflow.Episode(duration_source) as fresh_episode:
+        through_channels = episode_duration(fresh_episode, topics=selected).measurements
+
+    assert streamed == through_channels
+    assert streamed["topic_count"] == len(selected)
+
+
 @pytest.mark.parametrize(
     ("topics", "duration_s", "message_count", "topic_count"),
     [


### PR DESCRIPTION
Fixes #499.

`episode_duration()` only needs timestamps and message counts, but the default path was going through `Episode.channel()` for every selected topic. That materialized and cached complete channel payloads, including camera/video data the check never uses.

This changes the default `topics=None` path to aggregate the same measurements through bounded raw batches instead.

On the reproduction fixture:

```text
                            before      after
Episode.channel() calls         2          0
cached payload bytes       800024          0
duration_s                    8.0        8.0
message_count_total            10         10
topic_count                      2          2
```

Payload bytes still pass through the reader, so this does not eliminate payload I/O. It avoids retaining complete channel payloads in the episode cache.

I also checked using MCAP summary statistics directly, but that would change existing behavior when summary statistics disagree with the actual messages. The streaming path keeps the current semantics: summary counts select the default topics, while actual messages still supply duration and message-count measurements.

The regression tests pin the performance property directly by refusing `Episode.channel()` calls and checking that `_channel_data_by_id` stays empty. They also cover multiple batches, explicit and repeated topic selections, empty channels/episodes, duplicate topics, missing statistics, and inconsistent summary statistics.

Validation:

```text
episode_duration tests: 24 passed
affected focused tests: 112 passed
ruff check: passed
ruff format --check: passed
ty check: passed
full suite: 1856 passed, 7 skipped
git diff --check: passed
```
