### PR TITLE
test(episode): pin frames_at_indices refusal and ordering guards

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -467,21 +467,71 @@ def test_canonical_episode_extracts_exact_source_frame_indices(
 
 
 @pytest.mark.parametrize(
-    "invalid_frame_indices",
-    [[True], [np.bool_(True)], [3.0], [np.float64(3.0)]],
+    ("invalid_frame_indices", "message"),
+    [
+        # ``bool`` subclasses ``int``, so the boolean guard must run first and
+        # its message must stay distinguishable from the plain integer one.
+        ([True], r"^frame indices must be integers, not booleans$"),
+        ([np.bool_(True)], r"^frame indices must be integers, not booleans$"),
+        ([3.0], r"^frame indices must be integers$"),
+        ([np.float64(3.0)], r"^frame indices must be integers$"),
+    ],
 )
 def test_canonical_episode_rejects_non_integer_frame_indices(
     report_and_app: tuple[hflow.TestReport, hflow.App],
     invalid_frame_indices: list[Any],
+    message: str,
 ) -> None:
     report, _app = report_and_app
     with hflow.Episode(report.canonical_path) as episode:
         camera_topic = next(topic for topic in episode.cameras if "overhead_cam" in topic)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=message):
             episode.frames_at_indices(
                 camera_topic,
                 frame_indices=invalid_frame_indices,
             )
+
+
+@pytest.mark.parametrize(
+    "frame_indices",
+    [
+        [0, 0],  # a duplicate index
+        [5, 3],  # a descending pair
+    ],
+)
+def test_canonical_episode_rejects_non_ascending_frame_indices(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+    frame_indices: list[int],
+) -> None:
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        camera_topic = next(topic for topic in episode.cameras if "overhead_cam" in topic)
+        with pytest.raises(ValueError, match=r"^frame indices must be unique and ascending$"):
+            episode.frames_at_indices(camera_topic, frame_indices=frame_indices)
+
+
+def test_canonical_episode_rejects_negative_frame_indices(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+) -> None:
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        camera_topic = next(topic for topic in episode.cameras if "overhead_cam" in topic)
+        with pytest.raises(ValueError, match=r"^frame indices must be nonnegative$"):
+            episode.frames_at_indices(camera_topic, frame_indices=[-1])
+
+
+def test_frame_index_guards_run_ascending_before_nonnegative(
+    report_and_app: tuple[hflow.TestReport, hflow.App],
+) -> None:
+    """The nonnegative guard reads only the first index, so it is correct only
+    after ascending order is established. ``[-1, -2]`` violates both guards and
+    must be reported as not-ascending; if the two guards were swapped it would
+    instead be reported as "nonnegative"."""
+    report, _app = report_and_app
+    with hflow.Episode(report.canonical_path) as episode:
+        camera_topic = next(topic for topic in episode.cameras if "overhead_cam" in topic)
+        with pytest.raises(ValueError, match=r"^frame indices must be unique and ascending$"):
+            episode.frames_at_indices(camera_topic, frame_indices=[-1, -2])
 
 
 def test_arrow_export(report_and_app: tuple[hflow.TestReport, hflow.App]) -> None:


### PR DESCRIPTION
Closes #455.

Tightens the existing `test_canonical_episode_rejects_non_integer_frame_indices` in `tests/test_end_to_end.py` so each guard's exact message is asserted with an anchored `match=`, and adds the two guards that had no coverage at all — unique-and-ascending and nonnegative — plus a case that pins the ordering between them. No source changes; `episode.py` is untouched.

The anchoring is load-bearing: `^frame indices must be integers$` versus `^frame indices must be integers, not booleans$`. The trailing `$` on the former is what stops an integer case from passing on the boolean guard's (prefix) message.

## Coverage

| Guard | Message | Test case |
| --- | --- | --- |
| bool | `frame indices must be integers, not booleans` | `[True]`, `[np.bool_(True)]` |
| int | `frame indices must be integers` | `[3.0]`, `[np.float64(3.0)]` |
| unique + ascending | `frame indices must be unique and ascending` | `[0, 0]` (duplicate), `[5, 3]` (descending) |
| nonnegative | `frame indices must be nonnegative` | `[-1]` |
| ordering pin | ascending must fire before nonnegative | `[-1, -2]` |

The `np.bool_` / `np.float64` inputs are kept from the existing parametrization: they exercise the `np.generic` -> Python-scalar conversion (`episode.py:645-648`) feeding into the correct guard.

## Definition of done

1. Each of the four messages is asserted by an anchored `match=`, so no case can pass on a neighbouring guard.
2. The two previously-uncovered guards get cases: a duplicate, a descending pair, and a negative index.
3. Mutation sweep — neutered each guard in turn and re-ran (against a camera-less synthetic episode, since every guard runs before camera resolution):

   | Mutation | Cases that go red |
   | --- | --- |
   | remove bool guard | `[True]` and `[np.bool_(True)]` (overlap — both reduce to `True`) |
   | remove int guard | `[3.0]` and `[np.float64(3.0)]` (overlap) |
   | remove ascending guard | `[0,0]`, `[5,3]`, and `[-1,-2]` (the last falls through to nonnegative) |
   | remove nonnegative guard | `[-1]` only |
   | swap ascending/nonnegative | `[-1,-2]` reports "nonnegative" instead of "unique and ascending" |

4. The overlaps above are intentional: each `np.*` input shares its guard with the Python-scalar twin and exists to pin the numpy conversion, not a distinct branch.
5. The existing test's four parametrized inputs are preserved; only the assertion was tightened.

## Testing note

This host is Windows, where the package cannot import (`src/hflow/storage.py` unconditionally imports Linux-only `fcntl`, and the suite needs `ffmpeg`). I verified the guard behaviour against a camera-less synthetic episode under a throwaway `fcntl` shim, which reproduces the exact four messages and the ordering, and ran `ruff check`, `ruff format --check`, `ty check`, and a `pytest --collect-only` (all green). The tests use the same `report_and_app` plumbing as the pre-existing passing test, so they will run through on the Linux CI.
