### PR TITLE
refactor(ffmpeg): reuse contact sheet field guards

### DIFF
--- a/src/hflow/ffmpeg/_contact_sheet.py
+++ b/src/hflow/ffmpeg/_contact_sheet.py
@@ -23,6 +23,7 @@ from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from hflow._field_guards import require_positive_int
 from hflow.ffmpeg._binary import ffmpeg_path
 
 if TYPE_CHECKING:
@@ -139,21 +140,16 @@ def contact_sheet(
     tile_width: int = 320,
     max_tiles: int = 24,
 ) -> ContactSheet:
-    """Composite ``frames`` (from ``Episode.frames()``) into one JPEG grid."""
+    """Composite ``frames`` (from ``Episode.frames()``) into one JPEG grid.
+
+    ``columns``, ``tile_width`` and ``max_tiles`` must be positive integers,
+    excluding booleans. Invalid settings raise ``ValueError`` before frame work.
+    """
     if not frames:
         raise ValueError("contact_sheet needs at least one frame")
-    if not isinstance(columns, int) or isinstance(columns, bool):
-        raise ValueError(f"columns must be an int, got {columns!r}")
-    if columns < 1:
-        raise ValueError(f"columns must be >= 1, got {columns}")
-    if not isinstance(tile_width, int) or isinstance(tile_width, bool):
-        raise ValueError(f"tile_width must be an int, got {tile_width!r}")
-    if tile_width < 1:
-        raise ValueError(f"tile_width must be >= 1, got {tile_width}")
-    if not isinstance(max_tiles, int) or isinstance(max_tiles, bool):
-        raise ValueError(f"max_tiles must be an int, got {max_tiles!r}")
-    if max_tiles < 1:
-        raise ValueError(f"max_tiles must be >= 1, got {max_tiles}")
+    require_positive_int(columns, "columns")
+    require_positive_int(tile_width, "tile_width")
+    require_positive_int(max_tiles, "max_tiles")
     selected_frames = [frames[index] for index in _evenly_sampled_indices(len(frames), max_tiles)]
     rows = math.ceil(len(selected_frames) / columns)
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -975,37 +975,59 @@ def _unreadable_frame(tmp_path: Path) -> ExtractedFrame:
     return ExtractedFrame(path=tmp_path / "must-not-be-read.jpg", log_time_ns=0)
 
 
-@pytest.mark.parametrize("tile_width", [0, -320])
-def test_contact_sheet_rejects_non_positive_tile_width_before_ffmpeg(
-    tile_width: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("parameter", ["columns", "tile_width", "max_tiles"])
+@pytest.mark.parametrize("value", [0, -320])
+def test_contact_sheet_rejects_non_positive_dimensions_before_ffmpeg(
+    parameter: str, value: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
-    with pytest.raises(ValueError, match=rf"tile_width must be >= 1, got {tile_width}"):
-        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", tile_width=tile_width)
+    with pytest.raises(ValueError, match=rf"^{parameter} must be > 0, got {value}$"):
+        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", **{parameter: value})
 
 
-def test_contact_sheet_rejects_boolean_columns_before_ffmpeg(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("columns", [True, False, 1.0, "1", None])
+def test_contact_sheet_rejects_non_integer_columns_before_ffmpeg(
+    columns: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
-    with pytest.raises(ValueError, match=r"columns must be an int, got True"):
-        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", columns=True)
+    with pytest.raises(
+        ValueError, match=rf"^columns must be an int, got {type(columns).__name__}$"
+    ):
+        contact_sheet(
+            [_unreadable_frame(tmp_path)],
+            tmp_path / "never.jpg",
+            columns=columns,  # ty: ignore[invalid-argument-type]
+        )
 
 
-def test_contact_sheet_rejects_boolean_tile_width_before_ffmpeg(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("tile_width", [True, False, 1.0, "1", None])
+def test_contact_sheet_rejects_non_integer_tile_width_before_ffmpeg(
+    tile_width: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
-    with pytest.raises(ValueError, match=r"tile_width must be an int, got True"):
-        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", tile_width=True)
+    with pytest.raises(
+        ValueError, match=rf"^tile_width must be an int, got {type(tile_width).__name__}$"
+    ):
+        contact_sheet(
+            [_unreadable_frame(tmp_path)],
+            tmp_path / "never.jpg",
+            tile_width=tile_width,  # ty: ignore[invalid-argument-type]
+        )
 
 
-def test_contact_sheet_rejects_boolean_max_tiles_before_ffmpeg(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("max_tiles", [True, False, 1.0, "1", None])
+def test_contact_sheet_rejects_non_integer_max_tiles_before_ffmpeg(
+    max_tiles: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _refuse_ffmpeg_for_invalid_contact_sheet_arguments(monkeypatch)
-    with pytest.raises(ValueError, match=r"max_tiles must be an int, got True"):
-        contact_sheet([_unreadable_frame(tmp_path)], tmp_path / "never.jpg", max_tiles=True)
+    with pytest.raises(
+        ValueError, match=rf"^max_tiles must be an int, got {type(max_tiles).__name__}$"
+    ):
+        contact_sheet(
+            [_unreadable_frame(tmp_path)],
+            tmp_path / "never.jpg",
+            max_tiles=max_tiles,  # ty: ignore[invalid-argument-type]
+        )
 
 
 def test_coding_range_is_derived_from_luma_and_selects_the_exposure_gates() -> None:


### PR DESCRIPTION
## Summary

Closes #507.

Use `require_positive_int` for `columns`, `tile_width`, and `max_tiles` in `contact_sheet`. All three checks still run before frame selection. Valid arguments and rendered output are unchanged.

## Why

This removes the three duplicate guards and makes their errors consistent with the other settings: wrong types report the type name, and non-positive values report `must be > 0`.

Extended the four existing validation tests to cover both booleans, floats, strings, `None`, zero, and negative values for every parameter. The function docstring now states the validation contract.

## Validation

Tested on macOS with Python 3.14.6 and system ffmpeg/ffprobe, using the root development environment documented in CONTRIBUTING:

- `uv sync --locked --python 3.14`
- `uv run --locked ruff check --fix` — passed.
- `uv run --locked ruff format` — clean.
- `uv run --locked ty check` — passed.
- `uv run --locked pytest tests/test_ffmpeg.py -k contact_sheet -q` — 25 passed, 1 skipped.
- `.venv/bin/python -m pytest tests/test_ffmpeg.py -q -ra` — 73 passed, 6 skipped (Linux-only binary tests and unavailable drawtext).
- `uv run --locked pytest -q --tb=short` — 1,859 passed, 11 skipped, 27 failed. All 27 failures are native-overlay tests requiring CPython on Linux. Reproduced the same 27 failures in `tests/test_packaging.py` and `tests/test_packaging_manifest_parsing.py` on an untouched worktree at `48aad38`; none involve this change.

The updated validation assertions failed against the old implementation. For the requested mutation check, I temporarily bypassed each guard independently in memory and ran `pytest tests/test_ffmpeg.py -k contact_sheet_rejects -q --tb=no`: each mutation produced 7 failures for its parameter and 15 passes. No mutation is included in the patch.

## Checklist

- [x] I added or updated outcome-focused tests for changed business logic.
- [x] I updated documentation for changed behavior, flags, formats, or requirements.
- [x] I ran `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check`.
- [x] I ran the relevant pytest suite.
- [x] I did not add recordings, generated media, credentials, private URLs, or runtime artifacts.
- [x] I preserved stored-data compatibility or documented an explicit version change.
