### PR TITLE
fix: log check and enrichment execution errors

### DIFF
--- a/src/hflow/app.py
+++ b/src/hflow/app.py
@@ -17,6 +17,7 @@ quality outcome.
 import hashlib
 import inspect
 import json
+import logging
 import os
 import re
 import shutil
@@ -99,6 +100,8 @@ from hflow.transform import (
     write_canonical_episode,
 )
 from hflow.workspace import RUNTIME_BUNDLE_DIRECTORY_NAME, Workspace
+
+logger = logging.getLogger(__name__)
 
 # The contract a @app.transform override implements: (source, output, config)
 # -> the stamps it wrote. See :meth:`App.transform`.
@@ -884,8 +887,21 @@ def _execute_enrichment(
                 "expected hflow.EnrichmentResult -- wrap it: return "
                 "hflow.EnrichmentResult(labels=...)"
             )
-    except Exception:
+            logger.error(
+                "Enrichment %s errored on episode %s: %s",
+                registered_enrichment.name,
+                canonical_episode.path,
+                outcome.error,
+            )
+    except Exception as error:
         outcome = Errored(traceback.format_exc(limit=8))
+        logger.error(
+            "Enrichment %s errored on episode %s: %s: %s",
+            registered_enrichment.name,
+            canonical_episode.path,
+            type(error).__name__,
+            error,
+        )
     duration_s = time.perf_counter() - started
     return EnrichmentRunReport(
         enrichment=registered_enrichment, outcome=outcome, duration_s=duration_s
@@ -2182,6 +2198,11 @@ class App:
         ``<data_root>/episodes/<stem>-<source-identity-hash>/`` unless
         ``output_dir`` is given.
 
+        Check and enrichment execution errors, including artifact publication
+        failures, are logged at ERROR level independently of ``verbose``.
+        They remain in the returned report without raising or quarantining
+        the episode. ``verbose=True`` additionally prints the full summary.
+
         ``stages`` is a run-profile name (see ``hflow.RUN_PROFILES``), an
         explicit stage set, or ``None`` for the full profile. Without
         ``sync``, the canonical file must already exist in the run dir and
@@ -2487,9 +2508,22 @@ class App:
                             "hflow.CheckResult -- wrap it: return hflow.CheckResult("
                             "measurements=...)"
                         )
-                except Exception:
+                        logger.error(
+                            "Check %s errored on episode %s: %s",
+                            registered.name,
+                            canonical_episode.path,
+                            outcome.error,
+                        )
+                except Exception as error:
                     # Infrastructure, not data: never recorded as a quality outcome.
                     outcome = Errored(traceback.format_exc(limit=8))
+                    logger.error(
+                        "Check %s errored on episode %s: %s: %s",
+                        registered.name,
+                        canonical_episode.path,
+                        type(error).__name__,
+                        error,
+                    )
                 duration_s = time.perf_counter() - started
                 run = CheckRunReport(check=registered, outcome=outcome, duration_s=duration_s)
                 report.checks.append(run)
@@ -2608,7 +2642,7 @@ class App:
                     enrichment_run.artifact_uris[artifact_name] = run_storage_root.publish(
                         artifact_path, artifact_key
                     )
-                except Exception:
+                except Exception as error:
                     # A missing or unreadable artifact file is the STEP's
                     # failure (user code declared a path it never wrote), not
                     # the run's: record it like any other step error and keep
@@ -2627,6 +2661,16 @@ class App:
                         PublishFailed(result=enrichment_result_so_far, error=combined_error)
                         if enrichment_result_so_far is not None
                         else Errored(combined_error)
+                    )
+                    logger.error(
+                        "Enrichment %s errored on episode %s: artifact %r at %s "
+                        "could not be published: %s: %s",
+                        enrichment_run.enrichment.name,
+                        canonical_path,
+                        artifact_name,
+                        artifact_path,
+                        type(error).__name__,
+                        error,
                     )
 
         # Assembled even when not recording, so the dev loop refuses a key

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,6 +1,7 @@
 """The vertical slice, end to end: one episode in, measurements out, zero
 infrastructure. Mirrors the README design-target example."""
 
+import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -535,12 +536,17 @@ def test_failed_critical_verdict_quarantines_and_skips_downstream(
     assert by_name["camera_blackout"].status == "failed"
 
 
+@pytest.mark.parametrize("dev_loop", [False, True])
 def test_crashing_check_is_infrastructure_not_data(
-    state_only_source_episode: Path, tmp_path: Path
+    state_only_source_episode: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    dev_loop: bool,
 ) -> None:
     app = hflow.App("crashy-pipeline", data_root=tmp_path)
 
-    @app.check(version="1")
+    @app.check(version="1", critical=True)
     def exploding(ep: hflow.Episode) -> hflow.CheckResult:
         raise RuntimeError("boom")
 
@@ -548,12 +554,23 @@ def test_crashing_check_is_infrastructure_not_data(
     def still_runs(ep: hflow.Episode) -> hflow.CheckResult:
         return hflow.CheckResult(measurements={"ran": True})
 
-    report = app.test(state_only_source_episode, verbose=False)
+    report = (
+        app.test(state_only_source_episode) if dev_loop else app.process(state_only_source_episode)
+    )
+    assert report.has_errors
     assert not report.quarantined
     by_name = {run.check.name: run for run in report.checks}
     assert by_name["exploding"].status == "error"
     assert by_name["exploding"].error is not None and "boom" in by_name["exploding"].error
     assert by_name["still_runs"].status == "measured"
+    (record,) = caplog.records
+    assert record.name == "hflow.app"
+    assert record.levelno == logging.ERROR
+    assert "exploding" in record.getMessage()
+    assert str(report.canonical_path) in record.getMessage()
+    assert "RuntimeError: boom" in record.getMessage()
+    assert "Traceback" not in record.getMessage()
+    assert capsys.readouterr().out == (report.summary() + "\n" if dev_loop else "")
 
 
 def test_resource_declaring_checks_run_after_plain_ones(

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -1,6 +1,7 @@
 """Enrichment step registration, execution, and catalog outcomes."""
 
 import json
+import logging
 from pathlib import Path
 from typing import cast
 
@@ -60,7 +61,9 @@ def test_quarantine_skips_enrichments(source_episode: Path, tmp_path: Path) -> N
     assert report.enrichments[0].status == hflow.CheckStatus.SKIPPED
 
 
-def test_enrichment_wrong_return_type_is_an_error(source_episode: Path, tmp_path: Path) -> None:
+def test_enrichment_wrong_return_type_is_an_error(
+    source_episode: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     app = hflow.App("enrich-boundary", data_root=tmp_path / "data")
 
     @app.enrich(version="1")
@@ -71,6 +74,46 @@ def test_enrichment_wrong_return_type_is_an_error(source_episode: Path, tmp_path
     assert report.enrichments[0].status == hflow.CheckStatus.ERROR
     assert report.enrichments[0].error is not None
     assert "expected hflow.EnrichmentResult" in report.enrichments[0].error
+    (record,) = caplog.records
+    assert record.levelno == logging.ERROR
+    assert "returns_a_string" in record.getMessage()
+    assert str(report.canonical_path) in record.getMessage()
+    assert "expected hflow.EnrichmentResult" in record.getMessage()
+
+
+def test_enrichment_crash_is_logged_and_later_steps_continue(
+    source_episode: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app = hflow.App("enrich-crash", data_root=tmp_path / "data", default_checks=())
+
+    @app.enrich(version="1")
+    def exploding(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        raise RuntimeError("labeler unavailable")
+
+    @app.enrich(version="1")
+    def still_runs(ep: hflow.Episode) -> hflow.EnrichmentResult:
+        return hflow.EnrichmentResult(labels={"caption": "robot arm"})
+
+    report = app.process(source_episode)
+    assert report.has_errors
+    assert not report.quarantined
+    failed, measured = report.enrichments
+    assert failed.status == hflow.CheckStatus.ERROR
+    assert "RuntimeError: labeler unavailable" in (failed.error or "")
+    assert "Traceback" in (failed.error or "")
+    assert measured.status == hflow.CheckStatus.MEASURED
+    assert measured.result is not None
+    assert measured.result.labels == {"caption": "robot arm"}
+    (record,) = caplog.records
+    assert record.levelno == logging.ERROR
+    assert "exploding" in record.getMessage()
+    assert str(report.canonical_path) in record.getMessage()
+    assert "RuntimeError: labeler unavailable" in record.getMessage()
+    assert "Traceback" not in record.getMessage()
+    assert capsys.readouterr().out == ""
 
 
 def test_enrichment_labels_and_artifacts_land_in_the_catalog(

--- a/tests/test_processing_regressions.py
+++ b/tests/test_processing_regressions.py
@@ -2,6 +2,9 @@
 
 import functools
 import json
+import logging
+import subprocess
+import sys
 import textwrap
 from collections.abc import Callable
 from pathlib import Path
@@ -432,7 +435,9 @@ def test_failed_sync_clears_completion_proof_and_blocks_later_stages(tmp_path: P
         app.process(source, record=False, stages={hflow.Stage.META})
 
 
-def test_check_returning_wrong_type_is_an_error_not_a_crash(tmp_path: Path) -> None:
+def test_check_returning_wrong_type_is_an_error_not_a_crash(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     source = synthesize_episode(
         tmp_path / "episode.mcap", SyntheticEpisodeSpec(duration_s=2.0, cameras=())
     )
@@ -455,6 +460,49 @@ def test_check_returning_wrong_type_is_an_error_not_a_crash(tmp_path: Path) -> N
     assert "expected hflow.CheckResult" in by_name["returns_a_dict"].error
     assert by_name["well_behaved"].status == hflow.CheckStatus.MEASURED
     assert report.has_errors
+    (record,) = caplog.records
+    assert record.levelno == logging.ERROR
+    assert "returns_a_dict" in record.getMessage()
+    assert str(report.canonical_path) in record.getMessage()
+    assert "expected hflow.CheckResult" in record.getMessage()
+
+
+def test_direct_process_loop_logs_errors_without_logging_configuration(tmp_path: Path) -> None:
+    source = _state_only_episode(tmp_path)
+    script = textwrap.dedent(
+        """\
+        import sys
+        from pathlib import Path
+        import hflow
+
+        source = Path(sys.argv[1])
+        app = hflow.App("error-loop", data_root=source.parent / "data", default_checks=())
+
+        @app.check(version="1", critical=True)
+        def exploding(ep: hflow.Episode) -> hflow.CheckResult:
+            raise RuntimeError("intentional probe failure")
+
+        completed = 0
+        for index in range(3):
+            episode = source.with_name(f"episode_{index}.mcap")
+            episode.write_bytes(source.read_bytes())
+            report = app.process(episode)
+            assert report.has_errors
+            assert not report.quarantined
+            completed += 1
+        assert completed == 3
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(source)], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr.count("RuntimeError: intentional probe failure") == 3
+    assert result.stderr.count("exploding") == 3
+    for index in range(3):
+        assert f"episode_{index}" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def _state_only_episode(tmp_path: Path) -> Path:
@@ -801,7 +849,9 @@ def test_non_sync_stages_never_fetch_the_raw_source(tmp_path: Path) -> None:
     assert report.stamps.pipeline_version
 
 
-def test_missing_artifact_is_the_steps_error_not_the_runs(tmp_path: Path) -> None:
+def test_missing_artifact_is_the_steps_error_not_the_runs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
     from hflow.testing import SyntheticEpisodeSpec, synthesize_episode
 
     episode_file = synthesize_episode(
@@ -818,6 +868,16 @@ def test_missing_artifact_is_the_steps_error_not_the_runs(tmp_path: Path) -> Non
     assert enrichment_run.status is hflow.CheckStatus.ERROR
     assert "never-written.png" in (enrichment_run.error or "")
     assert report.catalog_entry is not None and report.catalog_entry.written
+    assert report.has_errors
+    assert not report.quarantined
+    (record,) = caplog.records
+    assert record.levelno == logging.ERROR
+    assert "declares_a_ghost" in record.getMessage()
+    assert str(report.canonical_path) in record.getMessage()
+    assert "FileNotFoundError:" in record.getMessage()
+    assert "never-written.png" in record.getMessage()
+    assert "Traceback" not in record.getMessage()
+    assert capsys.readouterr().out == ""
 
 
 def test_source_identity_is_stable_across_vantage_points(


### PR DESCRIPTION
## What changed

Fixes #505.

Check and enrichment execution failures were already recorded as `ERROR` in the returned report, but direct `app.process()` usage could stay completely silent unless the caller explicitly inspected `report.has_errors` or printed the summary.

This adds ERROR-level logging for:

* check execution failures
* enrichment execution failures
* enrichment artifact publication failures

The log includes the step name, episode, and exception information, while the full traceback remains available in the existing report/summary.

## Behavior unchanged

The existing execution semantics are preserved:

* errors are still recorded in the returned report
* processing continues after a check or enrichment fails
* `has_errors` behavior is unchanged
* infrastructure errors do not quarantine the episode
* exceptions are not re-raised
* exit behavior is unchanged
* `verbose` behavior is unchanged
* no new output is written to stdout

## Tests

Added/updated coverage for:

* check failures producing ERROR logs
* enrichment failures producing ERROR logs
* artifact publication failures producing ERROR logs
* later steps continuing after a failure
* direct multi-episode `app.process()` loops still completing successfully while failures are visible on stderr
* full tracebacks not being duplicated in the log line
* no additional stdout output
