### PR TITLE
refactor(transform): use _field_guards helpers for TransformConfig numeric settings

### DIFF
--- a/src/hflow/transform.py
+++ b/src/hflow/transform.py
@@ -56,7 +56,6 @@ v1 behavior:
 import hashlib
 import json
 import logging
-import math
 from collections.abc import Callable, Mapping, Sequence
 from copy import copy
 from dataclasses import dataclass, field
@@ -64,6 +63,11 @@ from pathlib import Path
 from typing import Any, Literal
 
 from hflow import video as video_module
+from hflow._field_guards import (
+    require_int_in_range,
+    require_positive_float,
+    require_positive_int,
+)
 from hflow._grouped_mcap_writer import (
     NO_SCHEMA_ID,
     ChannelId,
@@ -156,28 +160,13 @@ class TransformConfig:
 
     def __post_init__(self) -> None:
         """Reject invalid settings before they become a pipeline identity."""
-        if isinstance(self.crf, bool) or not isinstance(self.crf, int):
-            raise ValueError(f"crf must be an int, got {type(self.crf).__name__}")
-        if not 0 <= self.crf <= 51:
-            raise ValueError(f"crf must be between 0 and 51, got {self.crf}")
+        require_int_in_range(self.crf, "crf", minimum=0, maximum=51)
 
         if self.gop_seconds is not None:
-            if isinstance(self.gop_seconds, bool) or not isinstance(self.gop_seconds, int | float):
-                raise ValueError(
-                    f"gop_seconds must be an int or float, got {type(self.gop_seconds).__name__}"
-                )
-            if not math.isfinite(self.gop_seconds) or self.gop_seconds <= 0:
-                raise ValueError(f"gop_seconds must be positive and finite, got {self.gop_seconds}")
+            require_positive_float(self.gop_seconds, "gop_seconds")
 
         if self.chunk_size_bytes is not None:
-            if isinstance(self.chunk_size_bytes, bool) or not isinstance(
-                self.chunk_size_bytes, int
-            ):
-                raise ValueError(
-                    f"chunk_size_bytes must be an int, got {type(self.chunk_size_bytes).__name__}"
-                )
-            if self.chunk_size_bytes <= 0:
-                raise ValueError(f"chunk_size_bytes must be positive, got {self.chunk_size_bytes}")
+            require_positive_int(self.chunk_size_bytes, "chunk_size_bytes")
 
 
 @dataclass(frozen=True)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -49,24 +49,36 @@ def test_pipeline_version_is_a_content_hash() -> None:
 
 
 @pytest.mark.parametrize(
-    ("construct", "field"),
+    ("construct", "message"),
     [
-        (lambda: TransformConfig(crf=True), "crf"),
-        (lambda: TransformConfig(crf=-1), "crf"),
-        (lambda: TransformConfig(crf=52), "crf"),
-        (lambda: TransformConfig(gop_seconds=True), "gop_seconds"),
-        (lambda: TransformConfig(gop_seconds=0), "gop_seconds"),
-        (lambda: TransformConfig(gop_seconds=float("nan")), "gop_seconds"),
-        (lambda: TransformConfig(gop_seconds=float("inf")), "gop_seconds"),
-        (lambda: TransformConfig(chunk_size_bytes=True), "chunk_size_bytes"),
-        (lambda: TransformConfig(chunk_size_bytes=0), "chunk_size_bytes"),
-        (lambda: TransformConfig(chunk_size_bytes=-1), "chunk_size_bytes"),
+        (lambda: TransformConfig(crf=True), r"^crf must be an int, got bool$"),
+        (lambda: TransformConfig(crf=-1), r"^crf must be in \[0, 51\], got -1$"),
+        (lambda: TransformConfig(crf=52), r"^crf must be in \[0, 51\], got 52$"),
+        (
+            lambda: TransformConfig(gop_seconds=True),
+            r"^gop_seconds must be an int or float, got bool$",
+        ),
+        (lambda: TransformConfig(gop_seconds=0), r"^gop_seconds must be > 0, got 0$"),
+        (
+            lambda: TransformConfig(gop_seconds=float("nan")),
+            r"^gop_seconds must be finite, got nan$",
+        ),
+        (
+            lambda: TransformConfig(gop_seconds=float("inf")),
+            r"^gop_seconds must be finite, got inf$",
+        ),
+        (
+            lambda: TransformConfig(chunk_size_bytes=True),
+            r"^chunk_size_bytes must be an int, got bool$",
+        ),
+        (lambda: TransformConfig(chunk_size_bytes=0), r"^chunk_size_bytes must be > 0, got 0$"),
+        (lambda: TransformConfig(chunk_size_bytes=-1), r"^chunk_size_bytes must be > 0, got -1$"),
     ],
 )
 def test_transform_config_rejects_invalid_numeric_settings(
-    construct: Callable[[], TransformConfig], field: str
+    construct: Callable[[], TransformConfig], message: str
 ) -> None:
-    with pytest.raises(ValueError, match=field):
+    with pytest.raises(ValueError, match=message):
         construct()
 
 


### PR DESCRIPTION
Follow-on from #487, closes #510.

`TransformConfig.__post_init__` hand-rolled three numeric guards. Each maps straight onto an existing `_field_guards` helper:

| parameter | before | helper |
| --- | --- | --- |
| `crf` | bool exclusion + `0 <= crf <= 51` | `require_int_in_range(..., minimum=0, maximum=51)` |
| `gop_seconds` | bool exclusion + finite + `> 0` | `require_positive_float` |
| `chunk_size_bytes` | bool exclusion + `> 0` | `require_positive_int` |

`gop_seconds` and `chunk_size_bytes` keep their `is not None` wrappers so `None` (the default) stays legal.

## Message changes

Accepted trade from #487: the messages now use `_field_guards`'s spelling, which names the offending value.

- `crf` range: `"between 0 and 51"` → `"in [0, 51]"` (plus `"got 52"` etc.)
- `gop_seconds`: `"positive and finite"` → split into `must be > 0` / `must be finite` (and the type message now spells `int or float`)
- `chunk_size_bytes`: `"positive"` → `"must be > 0"`

## Test tightening

The existing parametrized test asserted `match=field`, so `crf=True` and `crf=52` were indistinguishable. Each of the ten rows now asserts its own message with anchored regexes (e.g. `r"^crf must be in \[0, 51\], got 52$"`), so a type refusal and a range refusal cannot pass on each other's message.

## Definition of done

1. No `isinstance(..., bool)` left in `src/hflow/transform.py` — the three sites are gone (`rg` confirms zero).
2. `None` still accepted for `gop_seconds` and `chunk_size_bytes` (guards stay inside the `is not None` wrappers).
3. Ten rows each assert their own anchored message rather than the field name.
4. Each guard maps one-to-one onto a helper; neutering any one would turn exactly one case red (no overlaps between the three parameters' messages).
5. No behaviour change for valid configs — valid values pass through unchanged, so `compute_pipeline_version`'s content hash is unaffected.

Note: I could not run `pytest` locally (this Windows box fails importing `fcntl` in `storage.py`), so I verified the helper messages and valid-value passthrough against `_field_guards` directly, and ruff check + format pass. CI should cover the full suite.