### PR TITLE
refactor(video-import): compose VideoImportConfig guards from _field_guards

### DIFF
--- a/src/hflow/importers/video.py
+++ b/src/hflow/importers/video.py
@@ -12,6 +12,7 @@ from foxglove_schemas_protobuf.CompressedImage_pb2 import CompressedImage
 from mcap.writer import Writer
 from mcap_protobuf.schema import build_file_descriptor_set
 
+from hflow._field_guards import require_finite_float, require_int_in_range, require_positive_int
 from hflow._pinned_asset import sha256_hex_of_file
 from hflow.ffmpeg import ffmpeg_path, ffmpeg_version
 from hflow.ffmpeg._process import media_input_was_rejected, run_media_command
@@ -52,10 +53,7 @@ class VideoImportConfig:
             ("source_start_s", self.source_start_s),
             ("image_hz", self.image_hz),
         ):
-            if isinstance(value, bool) or not isinstance(value, int | float):
-                raise ValueError(f"{name} must be a finite number")
-            if not math.isfinite(value):
-                raise ValueError(f"{name} must be a finite number")
+            require_finite_float(value, name)
         if self.duration_s <= 0 or self.source_start_s < 0:
             raise ValueError("duration_s must be positive and source_start_s nonnegative")
         if not 0 < self.image_hz <= NANOSECONDS_PER_SECOND:
@@ -66,14 +64,14 @@ class VideoImportConfig:
             ("image_width", self.image_width),
             ("image_height", self.image_height),
         ):
-            if isinstance(value, bool) or not isinstance(value, int) or value <= 0 or value % 2:
-                raise ValueError(f"{name} must be a positive even integer")
-        if (
-            isinstance(self.start_time_ns, bool)
-            or not isinstance(self.start_time_ns, int)
-            or not 0 <= self.start_time_ns <= _MAXIMUM_TIMESTAMP_NS
-        ):
-            raise ValueError("start_time_ns must be an unsigned 64-bit integer")
+            require_positive_int(value, name)
+            # Evenness is a domain rule (H.264 4:2:0 chroma subsampling needs
+            # even dimensions), not a shared numeric guard, so it stays here.
+            if value % 2:
+                raise ValueError(f"{name} must be even, got {value}")
+        require_int_in_range(
+            self.start_time_ns, "start_time_ns", minimum=0, maximum=_MAXIMUM_TIMESTAMP_NS
+        )
         if self.frame_count > (1 << 32):
             raise ValueError("the excerpt exceeds the MCAP sequence number range")
         final_timestamp_ns = _sample_timestamp_ns(self, self.frame_count - 1)

--- a/tests/test_video_import.py
+++ b/tests/test_video_import.py
@@ -211,23 +211,32 @@ def test_invalid_sources_and_incomplete_excerpts_publish_nothing(
 
 
 @pytest.mark.parametrize(
-    "config",
+    ("config", "refusal"),
     [
-        {"duration_s": 0},
-        {"duration_s": float("nan")},
-        {"source_start_s": -1},
-        {"image_hz": 0},
-        {"image_hz": float("inf")},
-        {"image_width": 3},
-        {"image_height": True},
-        {"start_time_ns": -1},
-        {"start_time_ns": (1 << 64) - 1},
-        {"camera_name": ""},
-        {"metadata": (("task", "one"), ("task", "two"))},
+        ({"duration_s": 0}, r"duration_s must be positive"),
+        ({"duration_s": True}, r"duration_s must be an int or float, got bool"),
+        ({"duration_s": "1"}, r"duration_s must be an int or float, got str"),
+        ({"duration_s": float("nan")}, r"duration_s must be finite, got nan"),
+        ({"source_start_s": -1}, r"source_start_s nonnegative"),
+        ({"image_hz": 0}, r"image_hz must be positive"),
+        ({"image_hz": float("inf")}, r"image_hz must be finite, got inf"),
+        ({"image_width": 0}, r"image_width must be > 0, got 0"),
+        ({"image_width": -2}, r"image_width must be > 0, got -2"),
+        ({"image_width": 3}, r"image_width must be even, got 3"),
+        ({"image_height": True}, r"image_height must be an int, got bool"),
+        ({"image_height": 359}, r"image_height must be even, got 359"),
+        ({"start_time_ns": False}, r"start_time_ns must be an int, got bool"),
+        ({"start_time_ns": -1}, r"start_time_ns must be in \[0, 18446744073709551615\], got -1"),
+        ({"start_time_ns": 1 << 64}, r"start_time_ns must be in \[0, 18446744073709551615\]"),
+        # The maximum start time is accepted by the range guard; what refuses
+        # it is the excerpt's final sample landing past the MCAP range.
+        ({"start_time_ns": (1 << 64) - 1}, r"excerpt exceeds the MCAP timestamp range"),
+        ({"camera_name": ""}, r"camera_name must be nonempty"),
+        ({"metadata": (("task", "one"), ("task", "two"))}, r"duplicate key 'task'"),
     ],
 )
-def test_invalid_import_configuration_is_rejected(config: dict[str, object]) -> None:
-    with pytest.raises(ValueError):
+def test_invalid_import_configuration_is_rejected(config: dict[str, object], refusal: str) -> None:
+    with pytest.raises(ValueError, match=refusal):
         replace(VideoImportConfig(duration_s=1), **config)
 
 


### PR DESCRIPTION
Closes #508.

## What changed

`VideoImportConfig.__post_init__` now composes its numeric guards from `_field_guards` instead of hand-rolling the bool exclusion three times, split exactly along the line the issue draws between shared rules and domain rules:

- The finite-number loop over `duration_s`, `source_start_s`, and `image_hz` is `require_finite_float(value, name)`, which distinguishes the wrong-type and non-finite cases the old single message conflated.
- `image_width` and `image_height` call `require_positive_int`, then keep the evenness check local with its own message (`image_width must be even, got 3`). A code comment records why it stays: H.264 4:2:0 chroma subsampling is a domain rule about these two fields, not a shared numeric guard. No `even=` parameter was added to `_field_guards`, per the issue.
- `start_time_ns` is `require_int_in_range(..., minimum=0, maximum=_MAXIMUM_TIMESTAMP_NS)`, whose message now names the bounds and the offending value instead of the fixed "unsigned 64-bit integer" sentence.

No `isinstance(x, bool)` remains in `video.py`, and no behavior changes for valid configurations. Message wording moves to the helpers' spelling, the trade #487 established.

## The tests

`test_invalid_import_configuration_is_rejected` kept its parametrized shape and gained an anchored `match=` per row, plus the rows the old one-message guards could not distinguish: `True`, a string, zero, negative, odd, `False`, and one past the range. Every refusal the file made before, it still makes.

One pre-existing weakness surfaced by the tightening, worth a reviewer's eye: the old `start_time_ns=(1 << 64) - 1` row looked like a range case but actually passes the range guard (the maximum is inclusive) and is refused later by the excerpt's final sample exceeding the MCAP timestamp range. Without `match=` the row proved nothing about which guard fired; it now asserts the excerpt-range message and carries a comment saying so, and a genuine one-past-the-range row (`1 << 64`) pins the range guard itself.

## Validation

Run on WSL2 Ubuntu, Python 3.12:

```
uv sync --locked
uv run ruff check          # All checks passed
uv run ruff format --check # already formatted
uv run ty check            # All checks passed
uv run pytest -q           # 1930 passed, 6 skipped
```

Mutation, per the definition of done: each guard neutered in turn (the finite-float call, the positive-int call, the evenness check on its own, and the range bounds) turns its rows red; restored, everything passes. The touched test file also passes under Python 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
